### PR TITLE
Implement `Deas.init`, require routes file and build sinatra app

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency("ns-options", ["~> 1.0"])
+  gem.add_dependency("sinatra",    ["~> 1.4"])
+
   gem.add_development_dependency("assert", ["~> 2.0"])
 
 end

--- a/lib/deas.rb
+++ b/lib/deas.rb
@@ -1,3 +1,35 @@
-require "deas/version"
+require 'ns-options'
+require 'pathname'
 
-module Deas; end
+require 'deas/server'
+require 'deas/sinatra_app'
+require 'deas/version'
+
+ENV['DEAS_ROUTES_FILE'] ||= 'config/routes'
+
+module Deas
+
+  def self.app
+    @app
+  end
+
+  def self.config
+    Deas::Config
+  end
+
+  def self.configure(&block)
+    self.config.define(&block)
+    self.config
+  end
+
+  def self.init
+    require self.config.routes_file
+    @app = Deas::SinatraApp.new(Deas::Server)
+  end
+
+  module Config
+    include NsOptions::Proxy
+    option :routes_file,  Pathname, :default => ENV['DEAS_ROUTES_FILE']
+  end
+
+end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -1,0 +1,15 @@
+require 'ns-options'
+require 'singleton'
+
+module Deas
+
+  class Server
+    include Singleton
+
+    class Configuration
+      include NsOptions::Proxy
+    end
+
+  end
+
+end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -1,0 +1,13 @@
+require 'sinatra/base'
+
+module Deas
+
+  module SinatraApp
+
+    def self.new(server)
+      Class.new(Sinatra::Base)
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,14 @@
 # put any test helpers here
 
 # add the root dir to the load path
-$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
+ROOT = File.expand_path('../..', __FILE__)
+$LOAD_PATH.unshift(ROOT)
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+
+require 'deas'
+Deas.configure do |config|
+  config.routes_file = File.join(ROOT, 'test/support/routes')
+end
+Deas.init

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -1,0 +1,5 @@
+require 'deas'
+
+class Deas::Server
+
+end

--- a/test/unit/deas_tests.rb
+++ b/test/unit/deas_tests.rb
@@ -1,0 +1,21 @@
+require 'assert'
+require 'deas'
+
+module Deas
+
+  class BaseTests < Assert::Context
+    desc "Deas"
+    subject{ Deas }
+
+    should have_instance_methods :config, :configure, :init, :app
+
+  end
+
+  class ConfigTests < BaseTests
+    desc "Deas::Config"
+    subject{ Deas::Config }
+
+    should have_instance_methods :routes_file
+  end
+
+end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -1,0 +1,16 @@
+require 'assert'
+require 'deas/server'
+
+class Deas::Server
+
+  class BaseTests < Assert::Context
+    desc "Deas::Server"
+    subject{ Deas::Server }
+
+    should "be a singleton" do
+      assert_includes Singleton, subject.included_modules
+    end
+
+  end
+
+end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -1,0 +1,19 @@
+require 'assert'
+require 'deas/sinatra_app'
+
+module Deas::SinatraApp
+
+  class BaseTests < Assert::Context
+    desc "Deas::SinatraApp"
+    setup do
+      @sinatra_app = Deas::SinatraApp.new(Deas::Server)
+    end
+    subject{ @sinatra_app }
+
+    should "be a kind of Sinatra::Base" do
+      assert_equal Sinatra::Base, subject.superclass
+    end
+
+  end
+
+end


### PR DESCRIPTION
This implements `Deas.init`. This method requires in the
configured routes file (defaults to `config/routes`) and then
will build a Sinatra modular app, using the `Server` singleton.
The intent is that the app should be defined using the `Server`
singleton and then Deas will handle building the Sinatra app.
`Deas.init` is intended to be called from a `config.ru` before
running `Deas.app`.
