### PR TITLE
Add `init` proc to `Deas::Server`

### DIFF
--- a/lib/deas.rb
+++ b/lib/deas.rb
@@ -1,9 +1,9 @@
 require 'ns-options'
 require 'pathname'
 
+require 'deas/version'
 require 'deas/server'
 require 'deas/sinatra_app'
-require 'deas/version'
 
 ENV['DEAS_ROUTES_FILE'] ||= 'config/routes'
 
@@ -24,7 +24,7 @@ module Deas
 
   def self.init
     require self.config.routes_file
-    @app = Deas::SinatraApp.new(Deas::Server)
+    @app = Deas::SinatraApp.new(Deas::Server.configuration)
   end
 
   module Config

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -8,6 +8,27 @@ module Deas
 
     class Configuration
       include NsOptions::Proxy
+
+      option :init_proc, Proc, :default => proc{ }
+
+    end
+
+    attr_reader :configuration
+
+    def initialize
+      @configuration = Configuration.new
+    end
+
+    def init(&block)
+      self.configuration.init_proc = block
+    end
+
+    def self.method_missing(method, *args, &block)
+      self.instance.send(method, *args, &block)
+    end
+
+    def self.respond_to?(*args)
+      super || self.instance.respond_to?(*args)
     end
 
   end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -4,7 +4,9 @@ module Deas
 
   module SinatraApp
 
-    def self.new(server)
+    def self.new(server_config)
+      server_config.init_proc.call
+
       Class.new(Sinatra::Base)
     end
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -7,9 +7,28 @@ class Deas::Server
     desc "Deas::Server"
     subject{ Deas::Server }
 
+    should have_instance_methods :configuration, :init
+
     should "be a singleton" do
       assert_includes Singleton, subject.included_modules
     end
+
+    should "allow setting it's configuration options" do
+      init_proc = proc{ }
+      subject.init(&init_proc)
+      assert_equal init_proc, subject.configuration.init_proc
+    end
+
+  end
+
+  class ConfigurationTests < BaseTests
+    desc "Configuration"
+    setup do
+      @configuration = Deas::Server.configuration
+    end
+    subject{ @configuration }
+
+    should have_instance_methods :init_proc
 
   end
 

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -1,4 +1,5 @@
 require 'assert'
+require 'deas/server'
 require 'deas/sinatra_app'
 
 module Deas::SinatraApp
@@ -6,12 +7,21 @@ module Deas::SinatraApp
   class BaseTests < Assert::Context
     desc "Deas::SinatraApp"
     setup do
-      @sinatra_app = Deas::SinatraApp.new(Deas::Server)
+      @configuration = Deas::Server::Configuration.new
+      @sinatra_app = Deas::SinatraApp.new(@configuration)
     end
     subject{ @sinatra_app }
 
     should "be a kind of Sinatra::Base" do
       assert_equal Sinatra::Base, subject.superclass
+    end
+
+    should "call init procs when initialized" do
+      initialized = false
+      @configuration.init_proc = proc{ initialized = true }
+      @sinatra_app = Deas::SinatraApp.new(@configuration)
+
+      assert_equal true, initialized
     end
 
   end


### PR DESCRIPTION
This adds the ability configure an `init` proc on `Deas::Server`.
This proc is then called before the sinatra app is built. This
allows users to define initialization logic for their server.
