### PR TITLE
Add ability to configure most of Sinatra's settings

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -1,4 +1,6 @@
 require 'ns-options'
+require 'ns-options/boolean'
+require 'pathname'
 require 'singleton'
 
 module Deas
@@ -9,7 +11,29 @@ module Deas
     class Configuration
       include NsOptions::Proxy
 
-      option :init_proc, Proc, :default => proc{ }
+      option :env,  String,   :default => 'development'
+      option :root, Pathname, :default => proc{ File.dirname(Deas.config.routes_file) }
+
+      option :app_file,      Pathname, :default => proc{ Deas.config.routes_file }
+      option :public_folder, Pathname
+      option :views_folder,  Pathname
+
+      option :dump_errors,     NsOptions::Boolean, :default => false
+      option :method_override, NsOptions::Boolean, :default => true
+      option :sessions,        NsOptions::Boolean, :default => true
+      option :static_files,    NsOptions::Boolean, :default => true
+
+      option :init_proc, Proc,   :default => proc{ }
+
+      def initialize
+        super
+        # these are defaulted here because we want to use the Configuration
+        # instance `root`. If we define a proc above, we will be using the
+        # Configuration class `root`, which will not update these options as
+        # expected.
+        self.public_folder = proc{ self.root.join('public') }
+        self.views_folder  = proc{ self.root.join('views') }
+      end
 
     end
 
@@ -17,6 +41,38 @@ module Deas
 
     def initialize
       @configuration = Configuration.new
+    end
+
+    def env(*args)
+      self.configuration.env *args
+    end
+
+    def root(*args)
+      self.configuration.root *args
+    end
+
+    def public_folder(*args)
+      self.configuration.root *args
+    end
+
+    def views_folder(*args)
+      self.configuration.root *args
+    end
+
+    def dump_errors(*args)
+      self.configuration.dump_errors *args
+    end
+
+    def method_override(*args)
+      self.configuration.method_override *args
+    end
+
+    def sessions(*args)
+      self.configuration.sessions *args
+    end
+
+    def static_files(*args)
+      self.configuration.static_files *args
     end
 
     def init(&block)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -7,7 +7,22 @@ module Deas
     def self.new(server_config)
       server_config.init_proc.call
 
-      Class.new(Sinatra::Base)
+      Class.new(Sinatra::Base).tap do |app|
+
+        app.set :environment, server_config.env
+        app.set :root,        server_config.root
+
+        app.set :app_file,      server_config.app_file
+        app.set :public_folder, server_config.public_folder
+        app.set :views,         server_config.views_folder
+
+        app.set :dump_errors,     server_config.dump_errors
+        app.set :logging,         false
+        app.set :method_override, server_config.method_override
+        app.set :sessions,        server_config.sessions
+        app.set :static,          server_config.static_files
+
+      end
     end
 
   end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -5,6 +5,14 @@ class Deas::Server
 
   class BaseTests < Assert::Context
     desc "Deas::Server"
+    setup do
+      @old_configuration = Deas::Server.configuration.dup
+      new_configuration = Deas::Server::Configuration.new
+      Deas::Server.instance_variable_set("@configuration", new_configuration)
+    end
+    teardown do
+      Deas::Server.instance_variable_set("@configuration", @old_configuration)
+    end
     subject{ Deas::Server }
 
     should have_instance_methods :configuration, :init
@@ -14,6 +22,9 @@ class Deas::Server
     end
 
     should "allow setting it's configuration options" do
+      subject.env 'staging'
+      assert_equal 'staging', subject.configuration.env
+
       init_proc = proc{ }
       subject.init(&init_proc)
       assert_equal init_proc, subject.configuration.init_proc
@@ -28,7 +39,41 @@ class Deas::Server
     end
     subject{ @configuration }
 
-    should have_instance_methods :init_proc
+    should have_instance_methods :env, :root, :app_file, :public_folder,
+      :views_folder, :dump_errors, :method_override, :sessions, :static_files,
+      :init_proc
+
+    should "default the env to 'development'" do
+      assert_equal 'development', subject.env
+    end
+
+    should "default the root to the routes file's folder" do
+      expected_root = File.expand_path('..', Deas.config.routes_file)
+      assert_equal expected_root, subject.root.to_s
+    end
+
+    should "default the app file to the routes file" do
+      assert_equal Deas.config.routes_file.to_s, subject.app_file.to_s
+    end
+
+    should "default the public folder based on the root" do
+      expected_root = File.expand_path('..', Deas.config.routes_file)
+      expected_public_folder = File.join(expected_root, 'public')
+      assert_equal expected_public_folder, subject.public_folder.to_s
+    end
+
+    should "default the views folder based on the root" do
+      expected_root = File.expand_path('..', Deas.config.routes_file)
+      expected_views_folder = File.join(expected_root, 'views')
+      assert_equal expected_views_folder, subject.views_folder.to_s
+    end
+
+    should "default the Sinatra flags" do
+      assert_equal false, subject.dump_errors
+      assert_equal true,  subject.method_override
+      assert_equal true,  subject.sessions
+      assert_equal true,  subject.static_files
+    end
 
   end
 

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -24,6 +24,21 @@ module Deas::SinatraApp
       assert_equal true, initialized
     end
 
+    should "have it's configuration set based on the server configuration" do
+      subject.settings do |settings|
+        assert_equal @configuration.env,             settings.env
+        assert_equal @configuration.root,            settings.root
+        assert_equal @configuration.app_file,        settings.app_file
+        assert_equal @configuration.public_folder,   settings.public_folder
+        assert_equal @configuration.views_folder,    settings.views
+        assert_equal @configuration.dump_errors,     settings.dump_errors
+        assert_equal @configuration.logging,         false
+        assert_equal @configuration.method_override, settings.method_override
+        assert_equal @configuration.sessions,        settings.sessions
+        assert_equal @configuration.static,          settings.static_files
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This add's the ability to set most of Sinatra's settings through
Deas. This allows some customization of the Sinatra app but only
through Deas API. The main intent is to allow customization of
things like serving static files, supporting sessions and
changing paths to the public or views folder.
