### PR TITLE
Add a `logger` option to `Deas::Server`

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -11,6 +11,7 @@ module Deas
     class Configuration
       include NsOptions::Proxy
 
+      # Sinatra based options
       option :env,  String,   :default => 'development'
       option :root, Pathname, :default => proc{ File.dirname(Deas.config.routes_file) }
 
@@ -23,7 +24,9 @@ module Deas
       option :sessions,        NsOptions::Boolean, :default => true
       option :static_files,    NsOptions::Boolean, :default => true
 
+      # Deas specific options
       option :init_proc, Proc,   :default => proc{ }
+      option :logger,            :default => proc{ Deas::NullLogger.new }
 
       def initialize
         super
@@ -79,12 +82,25 @@ module Deas
       self.configuration.init_proc = block
     end
 
+    def logger(*args)
+      self.configuration.logger *args
+    end
+
     def self.method_missing(method, *args, &block)
       self.instance.send(method, *args, &block)
     end
 
     def self.respond_to?(*args)
       super || self.instance.respond_to?(*args)
+    end
+
+  end
+
+  class NullLogger
+    require 'logger'
+
+    ::Logger::Severity.constants.each do |name|
+      define_method(name.downcase){|*args| } # no-op
     end
 
   end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -9,6 +9,7 @@ module Deas
 
       Class.new(Sinatra::Base).tap do |app|
 
+        # built-in settings
         app.set :environment, server_config.env
         app.set :root,        server_config.root
 
@@ -21,6 +22,9 @@ module Deas
         app.set :method_override, server_config.method_override
         app.set :sessions,        server_config.sessions
         app.set :static,          server_config.static_files
+
+        # custom settings
+        app.set :deas_logger, server_config.logger
 
       end
     end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -26,12 +26,39 @@ class Deas::Server
     end
 
     should "allow setting it's configuration options" do
+      config = subject.configuration
+
       subject.env 'staging'
-      assert_equal 'staging', subject.configuration.env
+      assert_equal 'staging', config.env
+
+      subject.root '/path/to/root'
+      assert_equal '/path/to/root', config.root.to_s
+
+      subject.public_folder '/path/to/public'
+      assert_equal '/path/to/public', config.public_folder.to_s
+
+      subject.views_folder '/path/to/views'
+      assert_equal '/path/to/views', config.views_folder.to_s
+
+      subject.dump_errors true
+      assert_equal true, config.dump_errors
+
+      subject.method_override false
+      assert_equal false, config.method_override
+
+      subject.sessions false
+      assert_equal false, config.sessions
+
+      subject.static_files false
+      assert_equal false, config.static_files
+
+      stdout_logger = Logger.new(STDOUT)
+      subject.logger stdout_logger
+      assert_equal stdout_logger, config.logger
 
       init_proc = proc{ }
       subject.init(&init_proc)
-      assert_equal init_proc, subject.configuration.init_proc
+      assert_equal init_proc, config.init_proc
     end
 
   end
@@ -45,7 +72,7 @@ class Deas::Server
 
     should have_instance_methods :env, :root, :app_file, :public_folder,
       :views_folder, :dump_errors, :method_override, :sessions, :static_files,
-      :init_proc
+      :init_proc, :logger
 
     should "default the env to 'development'" do
       assert_equal 'development', subject.env
@@ -77,6 +104,10 @@ class Deas::Server
       assert_equal true,  subject.method_override
       assert_equal true,  subject.sessions
       assert_equal true,  subject.static_files
+    end
+
+    should "default the logger to a NullLogger" do
+      assert_instance_of Deas::NullLogger, subject.logger
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -43,6 +43,7 @@ module Deas::SinatraApp
         assert_equal false,                      settings.method_override
         assert_equal false,                      settings.sessions
         assert_equal true,                       settings.static_files
+        assert_equal @configuration.logger,      settings.deas_logger
       end
     end
 


### PR DESCRIPTION
This adds a `logger` option to the `Deas::Server` and will set
it on the Sinatra app. This is not a build-in Sinatra option,
so it will have no effect with Sinatra. This is setting a custom
option on the Sinatra app that will store the settings and be
able to hand them off to view handlers when route handle is
implemented.

I started implementing the view handler logic and saw that the
logger is used throughout (based on Sanford's implementation).
Thus, I wanted to add this to go ahead and have it available.
