### PR TITLE
Add ability to define routes using `Deas::Server`

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency("sinatra",    ["~> 1.4"])
 
   gem.add_development_dependency("assert", ["~> 2.0"])
+  gem.add_development_dependency("assert-mocha",  ["~>1.0"])
 
 end

--- a/lib/deas/logger.rb
+++ b/lib/deas/logger.rb
@@ -1,0 +1,12 @@
+module Deas
+
+  class NullLogger
+    require 'logger'
+
+    ::Logger::Severity.constants.each do |name|
+      define_method(name.downcase){|*args| } # no-op
+    end
+
+  end
+
+end

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -1,0 +1,45 @@
+require 'deas/runner'
+
+module Deas
+
+  class Route
+    attr_reader :method, :path, :handler_class_name, :handler_class
+
+    def initialize(method, path, handler_class_name)
+      @method = method
+      @path   = path
+      @handler_class_name = handler_class_name
+      @handler_class      = nil
+    end
+
+    def constantize!
+      @handler_class ||= constantize_name(handler_class_name)
+      raise(NoHandlerClassError.new(handler_class_name)) if !@handler_class
+    end
+
+    def run(sinatra_call)
+      Deas::Runner.run(@handler_class, sinatra_call)
+    end
+
+    private
+
+    def constantize_name(class_name)
+      names = class_name.to_s.split('::').reject{|name| name.empty? }
+      klass = names.inject(Object) do |constant, name|
+        constant.const_get(name)
+      end
+      klass == Object ? false : klass
+    rescue NameError
+      false
+    end
+
+  end
+
+  class NoHandlerClassError < RuntimeError
+    def initialize(handler_class_name)
+      super "Deas couldn't find the view handler '#{handler_class_name}'. " \
+        "It doesn't exist or hasn't been required in yet."
+    end
+  end
+
+end

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -1,0 +1,6 @@
+module Deas
+
+  class Runner
+  end
+
+end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -6,6 +6,7 @@ module Deas
 
     def self.new(server_config)
       server_config.init_proc.call
+      server_config.routes.each(&:constantize!)
 
       Class.new(Sinatra::Base).tap do |app|
 
@@ -25,6 +26,13 @@ module Deas
 
         # custom settings
         app.set :deas_logger, server_config.logger
+
+        # routes
+        server_config.routes.each do |route|
+          # defines Sinatra routes like:
+          #   get('/'){ ... }
+          app.send(route.method, route.path){ route.run(self) }
+        end
 
       end
     end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -1,0 +1,6 @@
+module Deas
+
+  module ViewHandler
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,7 @@ $LOAD_PATH.unshift(ROOT)
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+require 'assert-mocha' if defined?(Assert)
 
 require 'deas'
 Deas.configure do |config|

--- a/test/support/fake_app.rb
+++ b/test/support/fake_app.rb
@@ -1,0 +1,14 @@
+require 'ostruct'
+
+class FakeApp
+
+  # Mimic's the context that is accessible in a Sinatra' route. Should provide
+  # any methods needed to replace using an actual Sinatra app.
+
+  attr_accessor :request, :response, :params, :halt, :settings
+
+  def initialize
+    @settings = OpenStruct.new({})
+  end
+
+end

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -1,0 +1,6 @@
+require 'deas/view_handler'
+
+class TestViewHandler
+  include Deas::ViewHandler
+
+end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -1,0 +1,57 @@
+require 'assert'
+require 'deas/route'
+require 'test/support/fake_app'
+require 'test/support/view_handlers'
+
+class Deas::Route
+
+  class BaseTests < Assert::Context
+    desc "Deas::Route"
+    setup do
+      @route = Deas::Route.new(:get, '/test', 'TestViewHandler')
+    end
+    subject{ @route }
+
+    should have_instance_methods :method, :path, :handler_class_name,
+      :handler_class, :run
+
+    should "constantize the handler class with #constantize!" do
+      assert_nil subject.handler_class
+
+      assert_nothing_raised{ subject.constantize! }
+
+      assert_equal TestViewHandler, subject.handler_class
+    end
+
+    should "raise a custom exception if the handler class name " \
+           "can't be constantized" do
+      route = Deas::Route.new(:get, '/', 'SomethingNotDefined')
+
+      assert_raises(Deas::NoHandlerClassError) do
+        route.constantize!
+      end
+    end
+
+  end
+
+  class RunTests < BaseTests
+    desc "run"
+    setup do
+      @route.constantize!
+
+      @fake_app = FakeApp.new
+      Deas::Runner.stubs(:run).with(TestViewHandler, @fake_app).returns('test')
+    end
+    teardown do
+      Deas::Runner.unstub(:run)
+    end
+
+    should "run the view handler and set a status code, headers and body" do
+      return_value = subject.run(@fake_app)
+
+      assert_equal 'test', return_value
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds the ability to define routes using `Deas::Server`.
These will be used to build Sinatra routes that run a Deas
view handler. This will allow users to define what HTTP requests
the app will serve. This only contains the ability to define
these routes, but they will not run at this point. The logic
for defining and running view handlers will be added in a future
commit.
