### PR TITLE
Define `Runner` and `ViewHandler` for running routes

### DIFF
--- a/lib/deas.rb
+++ b/lib/deas.rb
@@ -4,6 +4,7 @@ require 'pathname'
 require 'deas/version'
 require 'deas/server'
 require 'deas/sinatra_app'
+require 'deas/view_handler'
 
 ENV['DEAS_ROUTES_FILE'] ||= 'config/routes'
 

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -1,4 +1,4 @@
-require 'deas/runner'
+require 'deas/sinatra_runner'
 
 module Deas
 
@@ -18,7 +18,7 @@ module Deas
     end
 
     def run(sinatra_call)
-      Deas::Runner.run(@handler_class, sinatra_call)
+      Deas::SinatraRunner.run(@handler_class, sinatra_call)
     end
 
     private

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -1,6 +1,22 @@
 module Deas
 
   class Runner
+
+    attr_accessor :request, :response, :params, :logger
+
+    def initialize(handler_class)
+      @handler_class = handler_class
+      @handler = @handler_class.new(self)
+    end
+
+    def halt(*args)
+      raise NotImplementedError
+    end
+
+    def render(*args)
+      raise NotImplementedError
+    end
+
   end
 
 end

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -1,0 +1,53 @@
+require 'deas/runner'
+
+module Deas
+
+  class SinatraRunner < Runner
+
+    def self.run(*args)
+      self.new(*args).run
+    end
+
+    def initialize(handler_class, sinatra_call)
+      @sinatra_call = sinatra_call
+      @logger       = @sinatra_call.settings.deas_logger
+      @params       = @sinatra_call.params
+      @request      = @sinatra_call.request
+      @response     = @sinatra_call.response
+
+      super(handler_class)
+    end
+
+    def run
+      run_callbacks @handler_class.before_callbacks
+      @handler.init
+      response_data = @handler.run
+      run_callbacks @handler_class.after_callbacks
+      response_data
+    end
+
+    # Helpers
+
+    def halt(*args)
+      @sinatra_call.halt(*args)
+    end
+
+    # TODO expand this
+    def render(*args)
+      @sinatra_call.erb(*args)
+    end
+
+    # TODO implement these
+    # redirect
+    # redirect_to
+    # session
+
+    private
+
+    def run_callbacks(callbacks)
+      callbacks.each{|proc| @handler.instance_eval(&proc) }
+    end
+
+  end
+
+end

--- a/lib/deas/test_helpers.rb
+++ b/lib/deas/test_helpers.rb
@@ -1,0 +1,15 @@
+require 'deas/test_runner'
+
+module Deas
+
+  module TestHelpers
+
+    module_function
+
+    def test_runner(handler_class, args = nil)
+      TestRunner.new(handler_class, args)
+    end
+
+  end
+
+end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -1,0 +1,39 @@
+require 'deas/logger'
+require 'deas/runner'
+
+module Deas
+
+  class TestRunner < Runner
+
+    attr_reader :handler, :return_value
+
+    def initialize(handler_class, args = nil)
+      args ||= {}
+      @logger   = args.delete(:logger) || Deas::NullLogger.new
+      @params   = args.delete(:params) || {}
+      @request  = args.delete(:request)
+      @response = args.delete(:response)
+
+      super(handler_class)
+      args.each{|key, value| @handler.send("#{key}=", value) }
+
+      @return_value = catch(:halt){ @handler.init; nil }
+    end
+
+    def run
+      @return_value ||= catch(:halt){ @handler.run }
+    end
+
+    # Helpers
+
+    def halt(*args)
+      throw(:halt, args)
+    end
+
+    def render(*args)
+      "test runner render: #{args.inspect}"
+    end
+
+  end
+
+end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -1,6 +1,85 @@
+require 'deas/runner'
+
 module Deas
 
   module ViewHandler
+
+    def self.included(klass)
+      klass.class_eval do
+        extend ClassMethods
+      end
+    end
+
+    def initialize(runner)
+      @deas_runner = runner
+    end
+
+    def init
+      self.run_callback 'before_init'
+      self.init!
+      self.run_callback 'after_init'
+    end
+
+    def init!
+    end
+
+    def run
+      self.run_callback 'before_run'
+      data = self.run!
+      self.run_callback 'after_run'
+      data
+    end
+
+    def run!
+      raise NotImplementedError
+    end
+
+    def inspect
+      reference = '0x0%x' % (self.object_id << 1)
+      "#<#{self.class}:#{reference} @request=#{self.request.inspect}>"
+    end
+
+    protected
+
+    def before_init; end
+    def after_init;  end
+    def before_run;  end
+    def after_run;   end
+
+    # Helpers
+
+    def halt(*args);   @deas_runner.halt(*args);   end
+    def render(*args); @deas_runner.render(*args); end
+
+    def logger;   @deas_runner.logger;   end
+    def request;  @deas_runner.request;  end
+    def response; @deas_runner.response; end
+    def params;   @deas_runner.params;   end
+
+    def run_callback(callback)
+      self.send(callback.to_s)
+    end
+
+    module ClassMethods
+
+      def before(&block)
+        self.before_callbacks << block
+      end
+
+      def before_callbacks
+        @before_callbacks ||= []
+      end
+
+      def after(&block)
+        self.after_callbacks << block
+      end
+
+      def after_callbacks
+        @after_callbacks ||= []
+      end
+
+    end
+
   end
 
 end

--- a/test/support/fake_app.rb
+++ b/test/support/fake_app.rb
@@ -1,3 +1,4 @@
+require 'deas/logger'
 require 'ostruct'
 
 class FakeApp
@@ -8,7 +9,23 @@ class FakeApp
   attr_accessor :request, :response, :params, :halt, :settings
 
   def initialize
-    @settings = OpenStruct.new({})
+    @request  = FakeRequest.new({})
+    @params   = @request.params
+    @response = FakeResponse.new
+    @settings = OpenStruct.new({
+      :deas_logger => Deas::NullLogger.new
+    })
+  end
+
+  def halt(*args)
+    throw :halt, *args
+  end
+
+  def erb(template_name, *args)
+    "#{template_name} view"
   end
 
 end
+
+FakeRequest  = Struct.new(:params)
+FakeResponse = Struct.new(:code, :headers, :body)

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -4,3 +4,48 @@ class TestViewHandler
   include Deas::ViewHandler
 
 end
+
+class FlagViewHandler
+  include Deas::ViewHandler
+  before{ @before_hook_called = true }
+  after{  @after_hook_called  = true }
+
+  attr_reader :before_init_called, :init_bang_called, :after_init_called,
+    :before_run_called, :run_bang_called, :after_run_called,
+    :before_hook_called, :after_hook_called
+
+  def before_init
+    @before_init_called = true
+  end
+
+  def init!
+    @init_bang_called = true
+  end
+
+  def after_init
+    @after_init_called = true
+  end
+
+  def before_run
+    @before_run_called = true
+  end
+
+  def run!
+    @run_bang_called = true
+  end
+
+  def after_run
+    @after_run_called = true
+  end
+
+end
+
+class HaltViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    halt_args = [ params['code'], params['headers'], params['body'] ].compact
+    halt(*halt_args)
+  end
+
+end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -1,5 +1,6 @@
 require 'assert'
 require 'deas/route'
+require 'deas/sinatra_runner'
 require 'test/support/fake_app'
 require 'test/support/view_handlers'
 
@@ -40,10 +41,10 @@ class Deas::Route
       @route.constantize!
 
       @fake_app = FakeApp.new
-      Deas::Runner.stubs(:run).with(TestViewHandler, @fake_app).returns('test')
+      Deas::SinatraRunner.stubs(:run).with(TestViewHandler, @fake_app).returns('test')
     end
     teardown do
-      Deas::Runner.unstub(:run)
+      Deas::SinatraRunner.unstub(:run)
     end
 
     should "run the view handler and set a status code, headers and body" do

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,0 +1,26 @@
+require 'assert'
+require 'deas/runner'
+require 'test/support/view_handlers'
+
+class Deas::Runner
+
+  class BaseTests < Assert::Context
+    desc "Deas::Runner"
+    setup do
+      @runner = Deas::Runner.new(TestViewHandler)
+    end
+    subject{ @runner }
+
+    should have_instance_methods :request, :response, :params, :logger
+
+    should "raise NotImplementedError with #halt" do
+      assert_raises(NotImplementedError){ subject.halt }
+    end
+
+    should "raise NotImplementedError with #render" do
+      assert_raises(NotImplementedError){ subject.render }
+    end
+
+  end
+
+end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -1,5 +1,8 @@
 require 'assert'
+require 'deas/logger'
+require 'deas/route'
 require 'deas/server'
+require 'logger'
 
 class Deas::Server
 

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'deas/route'
 require 'deas/server'
 require 'deas/sinatra_app'
+require 'sinatra/base'
 require 'test/support/view_handlers'
 
 module Deas::SinatraApp

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -1,0 +1,70 @@
+require 'assert'
+require 'deas/sinatra_runner'
+require 'test/support/view_handlers'
+
+class Deas::SinatraRunner
+
+  class BaseTests < Assert::Context
+    desc "Deas::SinatraRunner"
+    setup do
+      @fake_sinatra_call = FakeApp.new
+      @runner = Deas::SinatraRunner.new(FlagViewHandler, @fake_sinatra_call)
+    end
+    subject{ @runner }
+
+    should have_instance_methods :run, :request, :response, :params, :logger,
+      :halt, :render
+
+    should "return the sinatra_call's request with #request" do
+      assert_equal @fake_sinatra_call.request, subject.request
+    end
+
+    should "return the sinatra_call's response with #response" do
+      assert_equal @fake_sinatra_call.response, subject.response
+    end
+
+    should "return the sinatra_call's params with #params" do
+      assert_equal @fake_sinatra_call.params, subject.params
+    end
+
+    should "return the sinatra_call's settings logger with #logger" do
+      assert_equal @fake_sinatra_call.settings.deas_logger, subject.logger
+    end
+
+    should "call the sinatra_call's halt with #halt" do
+      return_value = catch(:halt){ subject.halt('test') }
+      assert_equal 'test', return_value
+    end
+
+    should "call the sinatra_call's erb method with #render" do
+      return_value = subject.render(:index)
+      assert_equal 'index view', return_value
+    end
+
+  end
+
+  class RunTests < BaseTests
+    desc "run"
+    setup do
+      @return_value = @runner.run
+      @handler = @runner.instance_variable_get("@handler")
+    end
+    subject{ @handler }
+
+    should "run the before and after hooks" do
+      assert_equal true, subject.before_hook_called
+      assert_equal true, subject.after_hook_called
+    end
+
+    should "run the handler's init and run" do
+      assert_equal true, subject.init_bang_called
+      assert_equal true, subject.run_bang_called
+    end
+
+    should "return the handler's run! return value" do
+      assert_equal true, @return_value
+    end
+
+  end
+
+end

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -1,0 +1,85 @@
+require 'assert'
+require 'deas/test_helpers'
+require 'deas/view_handler'
+require 'test/support/view_handlers'
+
+module Deas::ViewHandler
+
+  class BaseTests < Assert::Context
+    include Deas::TestHelpers
+
+    desc "Deas::ViewHandler"
+    setup do
+      @handler = test_runner(TestViewHandler).handler
+    end
+    subject{ @handler }
+
+    should have_instance_methods :init, :init!, :run, :run!
+    should have_class_methods :before, :before_callbacks, :after, :after_callbacks
+
+    should "raise a NotImplementedError if run! is not overwritten" do
+      assert_raises(NotImplementedError){ subject.run! }
+    end
+
+    should "store procs in #before_callbacks with #before" do
+      before_proc = proc{ }
+      TestViewHandler.before(&before_proc)
+
+      assert_includes before_proc, TestViewHandler.before_callbacks
+    end
+
+    should "store procs in #after_callbacks with #after" do
+      after_proc = proc{ }
+      TestViewHandler.after(&after_proc)
+
+      assert_includes after_proc, TestViewHandler.after_callbacks
+    end
+
+  end
+
+  class WithMethodFlagsTests < BaseTests
+    setup do
+      @handler = test_runner(FlagViewHandler).handler
+    end
+
+    should "have called `init!` and it's callbacks" do
+      assert_equal true, subject.before_init_called
+      assert_equal true, subject.init_bang_called
+      assert_equal true, subject.after_init_called
+    end
+
+    should "not have called `run!` or it's callbacks when initialized" do
+      assert_nil subject.before_run_called
+      assert_nil subject.run_bang_called
+      assert_nil subject.after_run_called
+    end
+
+    should "call `run!` and it's callbacks when it's `run`" do
+      subject.run
+
+      assert_equal true, subject.before_run_called
+      assert_equal true, subject.run_bang_called
+      assert_equal true, subject.after_run_called
+    end
+
+  end
+
+  class HaltTests < BaseTests
+    desc "halt"
+
+    should "return a response with the status code and the passed data" do
+      runner = test_runner(HaltViewHandler, :params => {
+        'code'    => 200,
+        'headers' => { 'Content-Type' => 'text/plain' },
+        'body'    => 'test halting'
+      })
+      runner.run
+
+      assert_equal 200,                                runner.return_value[0]
+      assert_equal({ 'Content-Type' => 'text/plain' }, runner.return_value[1])
+      assert_equal 'test halting',                     runner.return_value[2]
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `Runner` and `ViewHandler` for running routes. These
are called when a route is run by the Sinatra app. This enables
defining views via the `ViewHandler` mixin and using many of
Sinatra's helpers. View handlers are run using a runner, either
the default `Runner` or the `TestRunner` when testing view
handlers. This provides the ability to both define views and have
them generate valid responses and also unit test them.
