### PR TITLE
Add system tests that use `rack-test`

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency("ns-options", ["~> 1.0"])
   gem.add_dependency("sinatra",    ["~> 1.4"])
 
-  gem.add_development_dependency("assert", ["~> 2.0"])
-  gem.add_development_dependency("assert-mocha",  ["~>1.0"])
+  gem.add_development_dependency("assert",       ["~> 2.0"])
+  gem.add_development_dependency("assert-mocha", ["~> 1.0"])
+  gem.add_development_dependency("rack-test",    ["~> 0.6"])
 
 end

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -33,8 +33,10 @@ module Deas
     end
 
     # TODO expand this
-    def render(*args)
-      @sinatra_call.erb(*args)
+    def render(template_name, options = nil)
+      options ||= {}
+      options[:locals] = { :view => @handler }.merge(options[:locals] || {})
+      @sinatra_call.erb(template_name, options)
     end
 
     # TODO implement these

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -2,4 +2,43 @@ require 'deas'
 
 class Deas::Server
 
+  root File.expand_path("..", __FILE__)
+
+  get '/show',  'ShowTest'
+  get '/halt',  'HaltTest'
+  get '/error', 'ErrorTest'
+
+end
+
+class ShowTest
+  include Deas::ViewHandler
+
+  attr_reader :message
+
+  def init!
+    @message = params['message']
+  end
+
+  def run!
+    render :show
+  end
+
+end
+
+class HaltTest
+  include Deas::ViewHandler
+
+  def init!
+    halt params['with'].to_i
+  end
+
+end
+
+class ErrorTest
+  include Deas::ViewHandler
+
+  def run!
+    raise 'test'
+  end
+
 end

--- a/test/support/views/show.erb
+++ b/test/support/views/show.erb
@@ -1,0 +1,1 @@
+show page: <%= view.message %>

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -1,0 +1,41 @@
+require 'assert'
+require 'rack/test'
+
+class MakingRequestsTests < Assert::Context
+  include Rack::Test::Methods
+
+  desc "Making requests using rack test"
+  setup do
+    @app = Deas.app.new
+  end
+
+  should "return a 200 response with a GET to '/show'" do
+    get '/show', 'message' => 'this is a test'
+
+    assert_equal 200,                           last_response.status
+    assert_equal "show page: this is a test\n", last_response.body
+  end
+
+  should "allow halting with a custom response" do
+    get '/halt', 'with' => 234
+
+    assert_equal 234, last_response.status
+  end
+
+  should "return a 404 response with an undefined route" do
+    get '/not_defined'
+
+    assert_equal 404, last_response.status
+  end
+
+  should "return a 500 response with an error route" do
+    get '/error'
+
+    assert_equal 500, last_response.status
+  end
+
+  def app
+    @app
+  end
+
+end


### PR DESCRIPTION
This adds system tests that use `rack-test` to test the entire
stack. This ensures that the Sinatra app will correclty call the
view handler (via the route and runner) and return the response
as expected.
