### PR TITLE
Symbolize template names with `render`

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -36,7 +36,7 @@ module Deas
     def render(template_name, options = nil)
       options ||= {}
       options[:locals] = { :view => @handler }.merge(options[:locals] || {})
-      @sinatra_call.erb(template_name, options)
+      @sinatra_call.erb(template_name.to_sym, options)
     end
 
     # TODO implement these

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -20,7 +20,7 @@ class ShowTest
   end
 
   def run!
-    render :show
+    render 'show'
   end
 
 end


### PR DESCRIPTION
The helper method `render` should automatically symbolize
template names. This is a Sinatra feature where if a symbol
is passed to an engine method (like `erb`) then it assumes there
is a template. If it's a string, then Sinatra assumes it is an
inline template. The problem is templates are typically something
like: `"users/index"` and having to manually convert this to a
symbol is annoying. Deas doesn't support inline templates, so we
can always change this to a symbol.
