### PR TITLE
Add a `partial` helper method for rendering partials

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -1,4 +1,5 @@
 require 'deas/runner'
+require 'deas/template'
 
 module Deas
 
@@ -32,11 +33,10 @@ module Deas
       @sinatra_call.halt(*args)
     end
 
-    # TODO expand this
-    def render(template_name, options = nil)
+    def render(name, options = nil)
       options ||= {}
       options[:locals] = { :view => @handler }.merge(options[:locals] || {})
-      @sinatra_call.erb(template_name.to_sym, options)
+      Deas::Template.new(@sinatra_call, name, options).render
     end
 
     # TODO implement these

--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -1,0 +1,43 @@
+module Deas
+
+  class Template
+    attr_reader :name, :options
+
+    def initialize(sinatra_call, name, options = nil)
+      @options = options || {}
+      @options[:scope] = RenderScope.new(sinatra_call)
+
+      @sinatra_call = sinatra_call
+      @name         = name.to_sym
+    end
+
+    def render
+      @sinatra_call.erb(@name, @options)
+    end
+
+    class RenderScope
+      def initialize(sinatra_call)
+        @sinatra_call = sinatra_call
+      end
+
+      def partial(name, locals = nil)
+        Deas::Partial.new(@sinatra_call, name, locals || {}).render
+      end
+    end
+
+  end
+
+  class Partial < Template
+
+    def initialize(sinatra_call, name, locals = nil)
+      options = { :locals => (locals || {}) }
+      name = begin
+        basename = File.basename(name.to_s)
+        name.to_s.sub(/#{basename}\Z/, "_#{basename}")
+      end
+      super sinatra_call, name, options
+    end
+
+  end
+
+end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -31,7 +31,7 @@ module Deas
     end
 
     def render(*args)
-      "test runner render: #{args.inspect}"
+      "test runner render"
     end
 
   end

--- a/test/support/fake_app.rb
+++ b/test/support/fake_app.rb
@@ -21,8 +21,8 @@ class FakeApp
     throw :halt, *args
   end
 
-  def erb(template_name, *args)
-    "#{template_name} view"
+  def erb(*args)
+    args
   end
 
 end

--- a/test/support/views/_info.erb
+++ b/test/support/views/_info.erb
@@ -1,0 +1,1 @@
+Stuff: <%= info %>

--- a/test/support/views/show.erb
+++ b/test/support/views/show.erb
@@ -1,1 +1,2 @@
 show page: <%= view.message %>
+<%= partial "info", :info => 'Show Info' %>

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -12,8 +12,10 @@ class MakingRequestsTests < Assert::Context
   should "return a 200 response with a GET to '/show'" do
     get '/show', 'message' => 'this is a test'
 
-    assert_equal 200,                           last_response.status
-    assert_equal "show page: this is a test\n", last_response.body
+    expected_body = "show page: this is a test\n" \
+                    "Stuff: Show Info\n"
+    assert_equal 200,           last_response.status
+    assert_equal expected_body, last_response.body
   end
 
   should "allow halting with a custom response" do

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -1,5 +1,7 @@
 require 'assert'
 require 'deas/sinatra_runner'
+require 'deas/template'
+require 'test/support/fake_app'
 require 'test/support/view_handlers'
 
 class Deas::SinatraRunner
@@ -37,8 +39,15 @@ class Deas::SinatraRunner
     end
 
     should "call the sinatra_call's erb method with #render" do
-      return_value = subject.render(:index)
-      assert_equal 'index view', return_value
+      return_value = subject.render('index')
+
+      assert_equal :index, return_value[0]
+
+      expected_options = return_value[1]
+      assert_instance_of Deas::Template::RenderScope, expected_options[:scope]
+
+      expected_locals = { :view => subject.instance_variable_get("@handler") }
+      assert_equal(expected_locals, expected_options[:locals])
     end
 
   end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -1,0 +1,84 @@
+require 'assert'
+require 'deas/template'
+require 'test/support/fake_app'
+
+class Deas::Template
+
+  class BaseTests < Assert::Context
+    desc "Deas::Template"
+    setup do
+      @fake_sinatra_call = FakeApp.new
+      @template = Deas::Template.new(@fake_sinatra_call, 'users/index')
+    end
+    subject{ @template }
+
+    should have_instance_methods :name, :options, :render
+
+    should "symbolize it's name" do
+      assert_equal :"users/index", subject.name
+    end
+
+    should "set it's scope option to a empty Module" do
+      assert_instance_of Deas::Template::RenderScope, subject.options[:scope]
+    end
+
+    should "call the sinatra_call's `erb` method with #render" do
+      return_value = subject.render
+
+      assert_equal subject.name,    return_value[0]
+      assert_equal subject.options, return_value[1]
+    end
+
+  end
+
+  class RenderScopeTests < Assert::Context
+    desc "Deas::Template::RenderScope"
+    setup do
+      @fake_sinatra_call = FakeApp.new
+      @render_scope = Deas::Template::RenderScope.new(@fake_sinatra_call)
+    end
+    subject{ @render_scope }
+
+    should "call the sinatra_call's erb method with #partial" do
+      return_value = subject.partial('part', :something => true)
+
+      assert_equal :_part, return_value[0]
+
+      expected_options = return_value[1]
+      assert_instance_of Deas::Template::RenderScope, expected_options[:scope]
+
+      expected_locals = { :something => true }
+      assert_equal(expected_locals, expected_options[:locals])
+    end
+
+  end
+
+end
+
+class Deas::Partial
+
+  class BaseTests < Assert::Context
+    desc "Deas::Partial"
+    setup do
+      @fake_sinatra_call = FakeApp.new
+      @partial = Deas::Partial.new(@fake_sinatra_call, 'users/index/listing', {
+        :user => 'Joe Test'
+      })
+    end
+    subject{ @partial }
+
+    should "be a kind of Deas::Template" do
+      assert_kind_of Deas::Template, subject
+    end
+
+    should "add an underscore to it's template's basename" do
+      assert_equal :"users/index/_listing", subject.name
+    end
+
+    should "set it's locals option" do
+      assert_equal({ :user => 'Joe Test' }, subject.options[:locals])
+    end
+
+  end
+
+end

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -15,7 +15,8 @@ module Deas::ViewHandler
     subject{ @handler }
 
     should have_instance_methods :init, :init!, :run, :run!
-    should have_class_methods :before, :before_callbacks, :after, :after_callbacks
+    should have_class_methods :before, :before_callbacks, :after,
+      :after_callbacks
 
     should "raise a NotImplementedError if run! is not overwritten" do
       assert_raises(NotImplementedError){ subject.run! }


### PR DESCRIPTION
This adds a `partial` helper method for rendering partials
using view handlers. This, just like the `render` method,
leverages Sinatra's template rendering. This allows rendering
templates within other templates.

This organizes the rendering functionality in to a `Template` and
`Partial` class. The `Partial` is a specialized kind of
`Template`. In particular, it expects the files to be named with
a leading underscore and only accepts `locals`, instead of any
Sinatra rendering options.

Closes #9
