### PR TITLE
Add nested layouts support to Deas

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -33,10 +33,11 @@ module Deas
       @sinatra_call.halt(*args)
     end
 
-    def render(name, options = nil)
+    def render(name, options = nil, &block)
       options ||= {}
       options[:locals] = { :view => @handler }.merge(options[:locals] || {})
-      Deas::Template.new(@sinatra_call, name, options).render
+      options[:layout] ||= @handler_class.layouts
+      Deas::Template.new(@sinatra_call, name, options).render(&block)
     end
 
     # TODO implement these

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -48,8 +48,8 @@ module Deas
 
     # Helpers
 
-    def halt(*args);   @deas_runner.halt(*args);   end
-    def render(*args); @deas_runner.render(*args); end
+    def halt(*args);           @deas_runner.halt(*args);           end
+    def render(*args, &block); @deas_runner.render(*args, &block); end
 
     def logger;   @deas_runner.logger;   end
     def request;  @deas_runner.request;  end
@@ -77,6 +77,12 @@ module Deas
       def after_callbacks
         @after_callbacks ||= []
       end
+
+      def layout(*args)
+        @layouts = args unless args.empty?
+        @layouts
+      end
+      alias :layouts :layout
 
     end
 

--- a/test/support/fake_app.rb
+++ b/test/support/fake_app.rb
@@ -21,8 +21,12 @@ class FakeApp
     throw :halt, *args
   end
 
-  def erb(*args)
-    args
+  def erb(*args, &block)
+    if block
+      [ args, block.call ].flatten
+    else
+      args
+    end
   end
 
 end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -4,9 +4,11 @@ class Deas::Server
 
   root File.expand_path("..", __FILE__)
 
-  get '/show',  'ShowTest'
-  get '/halt',  'HaltTest'
-  get '/error', 'ErrorTest'
+  get '/show',            'ShowTest'
+  get '/halt',            'HaltTest'
+  get '/error',           'ErrorTest'
+  get '/with_layout',     'WithLayoutTest'
+  get '/alt_with_layout', 'AlternateWithLayoutTest'
 
 end
 
@@ -39,6 +41,31 @@ class ErrorTest
 
   def run!
     raise 'test'
+  end
+
+end
+
+class WithLayoutTest
+  include Deas::ViewHandler
+  layouts 'layout1', 'layout2', 'layout3'
+
+  def run!
+    render 'with_layout'
+  end
+
+end
+
+class AlternateWithLayoutTest
+  include Deas::ViewHandler
+
+  def run!
+    render 'layout1' do
+      render 'layout2' do
+        render 'layout3' do
+          render 'with_layout'
+        end
+      end
+    end
   end
 
 end

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -9,6 +9,7 @@ class FlagViewHandler
   include Deas::ViewHandler
   before{ @before_hook_called = true }
   after{  @after_hook_called  = true }
+  layout 'web'
 
   attr_reader :before_init_called, :init_bang_called, :after_init_called,
     :before_run_called, :run_bang_called, :after_run_called,

--- a/test/support/views/layout1.erb
+++ b/test/support/views/layout1.erb
@@ -1,0 +1,2 @@
+Layout 1
+<%= yield %>

--- a/test/support/views/layout2.erb
+++ b/test/support/views/layout2.erb
@@ -1,0 +1,2 @@
+Layout 2
+<%= yield %>

--- a/test/support/views/layout3.erb
+++ b/test/support/views/layout3.erb
@@ -1,0 +1,2 @@
+Layout 3
+<%= yield %>

--- a/test/support/views/with_layout.erb
+++ b/test/support/views/with_layout.erb
@@ -1,0 +1,1 @@
+With Layout

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -36,6 +36,19 @@ class MakingRequestsTests < Assert::Context
     assert_equal 500, last_response.status
   end
 
+  should "work" do
+    get '/with_layout'
+
+    expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layout\n"
+    assert_equal 200,           last_response.status
+    assert_equal expected_body, last_response.body
+
+    get '/alt_with_layout'
+
+    assert_equal 200,           last_response.status
+    assert_equal expected_body, last_response.body
+  end
+
   def app
     @app
   end

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -41,13 +41,14 @@ class Deas::SinatraRunner
     should "call the sinatra_call's erb method with #render" do
       return_value = subject.render('index')
 
-      assert_equal :index, return_value[0]
+      assert_equal :web,   return_value[0]
+      assert_equal :index, return_value[2]
 
-      expected_options = return_value[1]
-      assert_instance_of Deas::Template::RenderScope, expected_options[:scope]
+      options = return_value[3]
+      assert_instance_of Deas::Template::RenderScope, options[:scope]
 
       expected_locals = { :view => subject.instance_variable_get("@handler") }
-      assert_equal(expected_locals, expected_options[:locals])
+      assert_equal(expected_locals, options[:locals])
     end
 
   end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -31,6 +31,27 @@ class Deas::Template
 
   end
 
+  class WithLayoutsTests < BaseTests
+    desc "with layouts"
+    setup do
+      @template = Deas::Template.new(@fake_sinatra_call, 'users/index', {
+        :layout => [ 'layouts/web', 'layouts/search' ]
+      })
+    end
+
+    should "call the engine's `erb` method for each layout, " \
+           "in the `layout` option" do
+      return_value = subject.render
+
+      # the return_value is a one-dimensional array of all the render args
+      # used in order. Thus the, 0, 2, 4 nature of the indexes.
+      assert_equal :"layouts/web",    return_value[0]
+      assert_equal :"layouts/search", return_value[2]
+      assert_equal :"users/index",    return_value[4]
+    end
+
+  end
+
   class RenderScopeTests < Assert::Context
     desc "Deas::Template::RenderScope"
     setup do

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -16,7 +16,7 @@ module Deas::ViewHandler
 
     should have_instance_methods :init, :init!, :run, :run!
     should have_class_methods :before, :before_callbacks, :after,
-      :after_callbacks
+      :after_callbacks, :layout, :layouts
 
     should "raise a NotImplementedError if run! is not overwritten" do
       assert_raises(NotImplementedError){ subject.run! }
@@ -34,6 +34,16 @@ module Deas::ViewHandler
       TestViewHandler.after(&after_proc)
 
       assert_includes after_proc, TestViewHandler.after_callbacks
+    end
+
+    should "allow specifying the layouts using #layout or #layouts" do
+      handler_class = Class.new{ include Deas::ViewHandler }
+
+      handler_class.layout 'layouts/app'
+      assert_equal [ 'layouts/app' ], handler_class.layouts
+
+      handler_class.layouts 'layouts/web', 'layouts/search'
+      assert_equal [ 'layouts/web', 'layouts/search' ], handler_class.layouts
     end
 
   end


### PR DESCRIPTION
This adds nested layout support to Deas. Through Sinatra, Deas
supported a single layout, but now it will use Sinatra's
interface for nested layouts. This can be done by passing a
`:layout` or `:layouts` option to the render method. These
are then rendered left-to-right, so the left-most layout is
the outermost layout. Additionally, Sinatra's block style for
nested layouts can be used with the `render` helper. This will
allow view handlers to render their templates in a variety of
ways and also support rendering them within many layouts.
