### PR TITLE
Add escaping helpers to template's render scope

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("ns-options", ["~> 1.0"])
+  gem.add_dependency("rack",       ["~> 1.5"])
   gem.add_dependency("sinatra",    ["~> 1.4"])
 
   gem.add_development_dependency("assert",       ["~> 2.0"])

--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -1,3 +1,5 @@
+require 'rack'
+
 module Deas
 
   class Template
@@ -38,6 +40,17 @@ module Deas
       def partial(name, locals = nil)
         Deas::Partial.new(@sinatra_call, name, locals || {}).render
       end
+
+      def escape_html(html)
+        Rack::Utils.escape_html(html)
+      end
+      alias :h :escape_html
+
+      def escape_url(path)
+        Rack::Utils.escape_path(path)
+      end
+      alias :u :escape_url
+
     end
 
   end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -60,6 +60,8 @@ class Deas::Template
     end
     subject{ @render_scope }
 
+    should have_instance_methods :partial, :escape_html, :h, :escape_url, :u
+
     should "call the sinatra_call's erb method with #partial" do
       return_value = subject.partial('part', :something => true)
 
@@ -70,6 +72,22 @@ class Deas::Template
 
       expected_locals = { :something => true }
       assert_equal(expected_locals, expected_options[:locals])
+    end
+
+    should "escape html with #h or #escape_html" do
+      return_value = subject.escape_html("<strong></strong>")
+      assert_equal "&lt;strong&gt;&lt;&#x2F;strong&gt;", return_value
+
+      return_value = subject.h("<strong></strong>")
+      assert_equal "&lt;strong&gt;&lt;&#x2F;strong&gt;", return_value
+    end
+
+    should "escape urls with #u or #escape_url" do
+      return_value = subject.escape_url("/path/to/somewhere")
+      assert_equal "%2Fpath%2Fto%2Fsomewhere", return_value
+
+      return_value = subject.u("/path/to/somewhere")
+      assert_equal "%2Fpath%2Fto%2Fsomewhere", return_value
     end
 
   end


### PR DESCRIPTION
This adds escaping helpers to the template's render scope. This
allows escaping HTML or URLs when needed in a template. This is
to prevent XSS attacks. These methods use the common ruby
community naming conventions of `h` for html escaping and `u`
for url escaping.

Closes #4
