### PR TITLE
Allow setting Sinatra's `show_exceptions` option

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -25,6 +25,7 @@ module Deas
       option :dump_errors,     NsOptions::Boolean, :default => false
       option :method_override, NsOptions::Boolean, :default => true
       option :sessions,        NsOptions::Boolean, :default => true
+      option :show_exceptions, NsOptions::Boolean, :default => false
       option :static_files,    NsOptions::Boolean, :default => true
 
       # Deas specific options
@@ -79,6 +80,10 @@ module Deas
 
     def sessions(*args)
       self.configuration.sessions *args
+    end
+
+    def show_exceptions(*args)
+      self.configuration.show_exceptions *args
     end
 
     def static_files(*args)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -22,6 +22,7 @@ module Deas
         app.set :logging,         false
         app.set :method_override, server_config.method_override
         app.set :sessions,        server_config.sessions
+        app.set :show_exceptions, server_config.show_exceptions
         app.set :static,          server_config.static_files
 
         # custom settings

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -53,6 +53,9 @@ class Deas::Server
       subject.sessions false
       assert_equal false, config.sessions
 
+      subject.show_exceptions true
+      assert_equal true, config.show_exceptions
+
       subject.static_files false
       assert_equal false, config.static_files
 
@@ -152,7 +155,7 @@ class Deas::Server
 
     should have_instance_methods :env, :root, :app_file, :public_folder,
       :views_folder, :dump_errors, :method_override, :sessions, :static_files,
-      :init_proc, :logger, :routes, :view_handler_ns
+      :init_proc, :logger, :routes, :view_handler_ns, :show_exceptions
 
     should "default the env to 'development'" do
       assert_equal 'development', subject.env
@@ -182,6 +185,7 @@ class Deas::Server
     should "default the Sinatra flags" do
       assert_equal false, subject.dump_errors
       assert_equal true,  subject.method_override
+      assert_equal false, subject.show_exceptions
       assert_equal true,  subject.sessions
       assert_equal true,  subject.static_files
     end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -17,6 +17,7 @@ module Deas::SinatraApp
         c.dump_errors     = true
         c.method_override = false
         c.sessions        = false
+        c.show_exceptions = true
         c.static          = true
         c.routes          = [ @route ]
       end
@@ -51,6 +52,7 @@ module Deas::SinatraApp
         assert_equal false,                      settings.logging
         assert_equal false,                      settings.method_override
         assert_equal false,                      settings.sessions
+        assert_equal true,                       settings.show_exceptions
         assert_equal true,                       settings.static_files
         assert_equal @configuration.logger,      settings.deas_logger
       end


### PR DESCRIPTION
This exposes Sinatra's `show_exceptions` option through the
`Deas::Server`. This allows controlling when you get Sinatra's
error pages or just the generic ones.

Closes #11
