### PR TITLE
Add additional helpers for redirecting and using the session

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -2,7 +2,7 @@ module Deas
 
   class Runner
 
-    attr_accessor :request, :response, :params, :logger
+    attr_accessor :request, :response, :params, :logger, :session
 
     def initialize(handler_class)
       @handler_class = handler_class
@@ -14,6 +14,14 @@ module Deas
     end
 
     def render(*args)
+      raise NotImplementedError
+    end
+
+    def redirect(*args)
+      raise NotImplementedError
+    end
+
+    def redirect_to(*args)
       raise NotImplementedError
     end
 

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -13,6 +13,7 @@ module Deas
       @params        = @sinatra_call.params
       @request       = @sinatra_call.request
       @response      = @sinatra_call.response
+      @session       = @sinatra_call.session
       @time_taken    = nil
       @started_at    = nil
       super(handler_class)
@@ -72,7 +73,6 @@ module Deas
       @runner_logger.summary.send(level, "[Deas] #{message}")
     end
 
-
     # Helpers
 
     def halt(*args)
@@ -86,10 +86,13 @@ module Deas
       Deas::Template.new(@sinatra_call, name, options).render(&block)
     end
 
-    # TODO implement these
-    # redirect
-    # redirect_to
-    # session
+    def redirect(*args)
+      @sinatra_call.redirect(*args)
+    end
+
+    def redirect_to(path, *args)
+      @sinatra_call.redirect(@sinatra_call.to(path), *args)
+    end
 
     private
 

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -13,6 +13,7 @@ module Deas
       @params   = args.delete(:params) || {}
       @request  = args.delete(:request)
       @response = args.delete(:response)
+      @session  = args.delete(:session)
 
       super(handler_class)
       args.each{|key, value| @handler.send("#{key}=", value) }

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -48,13 +48,19 @@ module Deas
 
     # Helpers
 
-    def halt(*args);           @deas_runner.halt(*args);           end
-    def render(*args, &block); @deas_runner.render(*args, &block); end
+    def halt(*args);        @deas_runner.halt(*args);        end
+    def redirect(*args);    @deas_runner.redirect(*args);    end
+    def redirect_to(*args); @deas_runner.redirect_to(*args); end
+
+    def render(*args, &block)
+      @deas_runner.render(*args, &block)
+    end
 
     def logger;   @deas_runner.logger;   end
     def request;  @deas_runner.request;  end
     def response; @deas_runner.response; end
     def params;   @deas_runner.params;   end
+    def session;  @deas_runner.session;  end
 
     def run_callback(callback)
       self.send(callback.to_s)

--- a/test/support/fake_app.rb
+++ b/test/support/fake_app.rb
@@ -6,11 +6,12 @@ class FakeApp
   # Mimic's the context that is accessible in a Sinatra' route. Should provide
   # any methods needed to replace using an actual Sinatra app.
 
-  attr_accessor :request, :response, :params, :halt, :settings
+  attr_accessor :request, :response, :params, :settings, :session
 
   def initialize
-    @request = FakeRequest.new('GET','/something', {})
+    @request = FakeRequest.new('GET','/something', {}, OpenStruct.new)
     @params   = @request.params
+    @session  = @request.session
     @response = FakeResponse.new
     @settings = OpenStruct.new({
       :runner_logger => Deas::RunnerLogger.new(Deas::NullLogger.new, false)
@@ -18,7 +19,7 @@ class FakeApp
   end
 
   def halt(*args)
-    throw :halt, *args
+    throw :halt, args
   end
 
   def erb(*args, &block)
@@ -29,9 +30,17 @@ class FakeApp
     end
   end
 
+  def to(relative_path)
+    File.join("http://test.local", relative_path)
+  end
+
+  def redirect(*args)
+    halt 302, { 'Location' => args[0] }
+  end
+
 end
 
-class FakeRequest < Struct.new(:http_method, :path, :params)
+class FakeRequest < Struct.new(:http_method, :path, :params, :session)
   alias :request_method :http_method
 end
 FakeResponse = Struct.new(:status, :headers, :body)

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -9,15 +9,19 @@ class Deas::Server
   logger Logger.new(File.open(log_file_path, 'w'))
   verbose_logging true
 
-  get '/show',            'ShowTest'
-  get '/halt',            'HaltTest'
-  get '/error',           'ErrorTest'
-  get '/with_layout',     'WithLayoutTest'
-  get '/alt_with_layout', 'AlternateWithLayoutTest'
+  get '/show',            'ShowHandler'
+  get '/halt',            'HaltHandler'
+  get '/error',           'ErrorHandler'
+  get '/with_layout',     'WithLayoutHandler'
+  get '/alt_with_layout', 'AlternateWithLayoutHandler'
+  get '/redirect',        'RedirectHandler'
+  get '/redirect_to',     'RedirectToHandler'
+  get '/set_session',     'SetSessionHandler'
+  get '/use_session',     'UseSessionHandler'
 
 end
 
-class ShowTest
+class ShowHandler
   include Deas::ViewHandler
 
   attr_reader :message
@@ -32,7 +36,7 @@ class ShowTest
 
 end
 
-class HaltTest
+class HaltHandler
   include Deas::ViewHandler
 
   def init!
@@ -41,7 +45,7 @@ class HaltTest
 
 end
 
-class ErrorTest
+class ErrorHandler
   include Deas::ViewHandler
 
   def run!
@@ -50,7 +54,7 @@ class ErrorTest
 
 end
 
-class WithLayoutTest
+class WithLayoutHandler
   include Deas::ViewHandler
   layouts 'layout1', 'layout2', 'layout3'
 
@@ -60,7 +64,7 @@ class WithLayoutTest
 
 end
 
-class AlternateWithLayoutTest
+class AlternateWithLayoutHandler
   include Deas::ViewHandler
 
   def run!
@@ -71,6 +75,43 @@ class AlternateWithLayoutTest
         end
       end
     end
+  end
+
+end
+
+class RedirectHandler
+  include Deas::ViewHandler
+
+  def run!
+    redirect 'http://google.com', 'wrong place, buddy'
+  end
+
+end
+
+class RedirectToHandler
+  include Deas::ViewHandler
+
+  def run!
+    redirect_to '/somewhere'
+  end
+
+end
+
+class SetSessionHandler
+  include Deas::ViewHandler
+
+  def run!
+    session[:secret] = 'session_secret'
+    redirect_to '/use_session'
+  end
+
+end
+
+class UseSessionHandler
+  include Deas::ViewHandler
+
+  def run!
+    session[:secret]
   end
 
 end

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -36,7 +36,7 @@ class MakingRequestsTests < Assert::Context
     assert_equal 500, last_response.status
   end
 
-  should "work" do
+  should "return a 200 response and use all the layouts" do
     get '/with_layout'
 
     expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layout\n"
@@ -47,6 +47,28 @@ class MakingRequestsTests < Assert::Context
 
     assert_equal 200,           last_response.status
     assert_equal expected_body, last_response.body
+  end
+
+  should "return a 302 redirecting to the expected locations" do
+    get '/redirect'
+    expected_location = 'http://google.com'
+
+    assert_equal 302,               last_response.status
+    assert_equal expected_location, last_response.headers['Location']
+
+    get '/redirect_to'
+    expected_location = 'http://example.org/somewhere'
+
+    assert_equal 302,               last_response.status
+    assert_equal expected_location, last_response.headers['Location']
+  end
+
+  should "return a 200 response and the session value" do
+    get '/set_session'
+    follow_redirect!
+
+    assert_equal 200,              last_response.status
+    assert_equal 'session_secret', last_response.body
   end
 
   def app

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -11,7 +11,7 @@ class Deas::Runner
     end
     subject{ @runner }
 
-    should have_instance_methods :request, :response, :params, :logger
+    should have_instance_methods :request, :response, :params, :logger, :session
 
     should "raise NotImplementedError with #halt" do
       assert_raises(NotImplementedError){ subject.halt }
@@ -19,6 +19,14 @@ class Deas::Runner
 
     should "raise NotImplementedError with #render" do
       assert_raises(NotImplementedError){ subject.render }
+    end
+
+    should "raise NotImplementedError with #redirect" do
+      assert_raises(NotImplementedError){ subject.redirect }
+    end
+
+    should "raise NotImplementedError with #redirect_to" do
+      assert_raises(NotImplementedError){ subject.redirect_to }
     end
 
   end

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -15,7 +15,7 @@ class Deas::SinatraRunner
     subject{ @runner }
 
     should have_instance_methods :run, :request, :response, :params, :logger,
-      :halt, :render
+      :halt, :render, :session, :redirect, :redirect_to
 
     should "return the sinatra_call's request with #request" do
       assert_equal @fake_sinatra_call.request, subject.request
@@ -29,13 +29,17 @@ class Deas::SinatraRunner
       assert_equal @fake_sinatra_call.params, subject.params
     end
 
+    should "return the sinatra_call's session with #session" do
+      assert_equal @fake_sinatra_call.session, subject.session
+    end
+
     should "return the sinatra_call's settings logger with #logger" do
       assert_equal @fake_sinatra_call.settings.deas_logger, subject.logger
     end
 
     should "call the sinatra_call's halt with #halt" do
       return_value = catch(:halt){ subject.halt('test') }
-      assert_equal 'test', return_value
+      assert_equal [ 'test' ], return_value
     end
 
     should "call the sinatra_call's erb method with #render" do
@@ -51,10 +55,25 @@ class Deas::SinatraRunner
       assert_equal(expected_locals, options[:locals])
     end
 
-    should "not throw an exception with the setup or teardown methods" do
-      assert_nothing_raised  {subject.setup}
-      assert_nothing_raised {subject.teardown}
+    should "call the sinatra_call's redirect method with #redirect" do
+      return_value = catch(:halt){ subject.redirect('http://google.com') }
+      expected = [ 302, { 'Location' => 'http://google.com' } ]
+
+      assert_equal expected, return_value
     end
+
+    should "call the sinatra_call's redirect and to methods with #redirect_to" do
+      return_value = catch(:halt){ subject.redirect_to('/somewhere') }
+      expected = [ 302, { 'Location' => "http://test.local/somewhere" } ]
+
+      assert_equal expected, return_value
+    end
+
+    should "not throw an exception with the setup or teardown methods" do
+      assert_nothing_raised{ subject.setup }
+      assert_nothing_raised{ subject.teardown }
+    end
+
   end
 
   class RunTests < BaseTests


### PR DESCRIPTION
This adds view handler methods for redirecting and using the
session. This allows users to easily redirect requests using
either `redirect` or `redirect_to`. The `redirect_to` method
uses Sinatra's `to` helper method, the `redirect` method doesn't.
In addition to redirecting, if sessions are enabled, the
session can be accessed using `session`. This works the same way
it does in Sinatra. This exposes more of Sinatra's features to
the user through Deas view handler pattern.

Closes #12

@kellyredding - Redirecting is needed for a lot of auth stuff, so I'd like to have this in place.
