### PR TITLE
Add a `helpers` method to `Deas::Template`

### DIFF
--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -3,6 +3,11 @@ require 'rack'
 module Deas
 
   class Template
+
+    def self.helpers(*helper_modules)
+      Deas::Template::RenderScope.class_eval{ include *helper_modules }
+    end
+
     attr_reader :name, :options
 
     def initialize(sinatra_call, name, options = nil)

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -13,6 +13,7 @@ class Deas::Template
     subject{ @template }
 
     should have_instance_methods :name, :options, :render
+    should have_class_methods :helpers
 
     should "symbolize it's name" do
       assert_equal :"users/index", subject.name
@@ -27,6 +28,14 @@ class Deas::Template
 
       assert_equal subject.name,    return_value[0]
       assert_equal subject.options, return_value[1]
+    end
+
+    should "include modules on the RenderScope using helpers class method" do
+      helper_module = Module.new
+      Deas::Template.helpers(helper_module)
+
+      included_modules = Deas::Template::RenderScope.included_modules
+      assert_includes helper_module, included_modules
     end
 
   end


### PR DESCRIPTION
This adds a `helpers` class method to `Deas::Template`. This is
used to include modules onto the render scope for use in
templates.
