### PR TITLE
Expose Sinatra `use` statements for modifying the middlewares

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -29,9 +29,10 @@ module Deas
       option :static_files,    NsOptions::Boolean, :default => true
 
       # Deas specific options
-      option :init_proc, Proc,   :default => proc{ }
-      option :logger,            :default => proc{ Deas::NullLogger.new }
-      option :verbose_logging,   :default => true
+      option :init_proc,       Proc,  :default => proc{ }
+      option :logger,                 :default => proc{ Deas::NullLogger.new }
+      option :middlewares,     Array, :default => []
+      option :verbose_logging,        :default => true
 
       option :routes,          Array, :default => []
       option :view_handler_ns, String
@@ -100,6 +101,10 @@ module Deas
 
     def logger(*args)
       self.configuration.logger *args
+    end
+
+    def use(*args)
+      self.configuration.middlewares << args
     end
 
     def verbose_logging(*args)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -29,6 +29,10 @@ module Deas
         app.set :logger,        server_config.logger
         app.set :runner_logger, server_config.runner_logger
 
+        server_config.middlewares.each do |middleware_args|
+          app.use *middleware_args
+        end
+
         # routes
         server_config.routes.each do |route|
           # defines Sinatra routes like:

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -23,7 +23,7 @@ class Deas::Server
     subject{ Deas::Server }
 
     should have_instance_methods :configuration, :init, :view_handler_ns,
-      :get, :post, :put, :patch, :delete, :route
+      :get, :post, :put, :patch, :delete, :route, :use
 
     should "be a singleton" do
       assert_includes Singleton, subject.included_modules
@@ -58,6 +58,9 @@ class Deas::Server
 
       subject.static_files false
       assert_equal false, config.static_files
+
+      subject.use 'MyMiddleware'
+      assert_equal [ ['MyMiddleware'] ], config.middlewares
 
       stdout_logger = Logger.new(STDOUT)
       subject.logger stdout_logger
@@ -155,7 +158,8 @@ class Deas::Server
 
     should have_instance_methods :env, :root, :app_file, :public_folder,
       :views_folder, :dump_errors, :method_override, :sessions, :static_files,
-      :init_proc, :logger, :routes, :view_handler_ns, :show_exceptions
+      :init_proc, :logger, :routes, :view_handler_ns, :show_exceptions,
+      :middlewares
 
     should "default the env to 'development'" do
       assert_equal 'development', subject.env
@@ -196,6 +200,10 @@ class Deas::Server
 
     should "default routes to an empty array" do
       assert_equal [], subject.routes
+    end
+
+    should "default middlewares to an empty array" do
+      assert_equal [], subject.middlewares
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -42,19 +42,20 @@ module Deas::SinatraApp
     end
 
     should "have it's configuration set based on the server configuration" do
-      subject.settings do |settings|
-        assert_equal 'staging',                  settings.env
-        assert_equal 'path/to/somewhere',        settings.root
+      subject.settings.tap do |settings|
+        assert_equal 'staging',                  settings.environment
+        assert_equal 'path/to/somewhere',        settings.root.to_s
         assert_equal @configuration.app_file,    settings.app_file
-        assert_equal 'path/to/somewhere/public', settings.public_folder
-        assert_equal 'path/to/somewhere/views',  settings.views
+        assert_equal 'path/to/somewhere/public', settings.public_folder.to_s
+        assert_equal 'path/to/somewhere/views',  settings.views.to_s
         assert_equal true,                       settings.dump_errors
         assert_equal false,                      settings.logging
         assert_equal false,                      settings.method_override
         assert_equal false,                      settings.sessions
         assert_equal true,                       settings.show_exceptions
-        assert_equal true,                       settings.static_files
-        assert_equal @configuration.logger,      settings.deas_logger
+        assert_equal true,                       settings.static
+        assert_instance_of Deas::RunnerLogger,   settings.runner_logger
+        assert_instance_of Deas::NullLogger,     settings.logger
       end
     end
 


### PR DESCRIPTION
This adds a `use` method to `Deas::Server` that will take
middleware configurations. These `use` calls are stored up and
piped to the Sinatra application, allow middleware to be added
as it normally would with Sinatra.
