### PR TITLE
Minor cleanups and fixes for edge cases

### DIFF
--- a/lib/deas.rb
+++ b/lib/deas.rb
@@ -6,6 +6,9 @@ require 'deas/server'
 require 'deas/sinatra_app'
 require 'deas/view_handler'
 
+# TODO - remove with future version of Rack (> v1.5.2)
+require 'deas/rack_request_fix'
+
 ENV['DEAS_ROUTES_FILE'] ||= 'config/routes'
 
 module Deas

--- a/lib/deas/rack_request_fix.rb
+++ b/lib/deas/rack_request_fix.rb
@@ -1,0 +1,23 @@
+require 'rack'
+
+class Rack::Request
+
+  # Pulled from rack master on 2013-05-01. This modifies the rack port lookup
+  # to look at HTTP_X_FORWARDED_PROTO and make a decision. This lookup is
+  # missing from v1.5.2 and causes our Production setup (stunnel and haproxy)
+  # to not work correctly.
+  def port
+    if port = host_with_port.split(/:/)[1]
+      port.to_i
+    elsif port = @env['HTTP_X_FORWARDED_PORT']
+      port.to_i
+    elsif @env.has_key?("HTTP_X_FORWARDED_HOST")
+      DEFAULT_PORTS[scheme]
+    elsif @env.has_key?("HTTP_X_FORWARDED_PROTO")
+      DEFAULT_PORTS[@env['HTTP_X_FORWARDED_PROTO']]
+    else
+      @env["SERVER_PORT"].to_i
+    end
+  end
+
+end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -30,7 +30,7 @@ module Deas
         set :runner_logger, server_config.runner_logger
 
         server_config.middlewares.each do |middleware_args|
-          app.use *middleware_args
+          use *middleware_args
         end
 
         # routes


### PR DESCRIPTION
#### Switch to using `Sinatra.new` to create the dynamic Sinatra app

This is the recommended way to do this in the documentation, so I
feel more comfortable moving to it. This should help future-proof
our logic and doesn't alter the functionality.
#### Add rack request fix to detect `HTTP_X_FORWARDED_PROTO`

This fixes the rack request port logic to consider the header
`HTTP_X_FORWARDED_PROTO`. This is in the the master branch of
rack but is not in a rolled version yet. This ensures that SSL
forwarding is handled correctly when we redirect in Sinatra
apps.
