### PR TITLE
show method, path before handler in summary logs

### DIFF
--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -108,9 +108,11 @@ module Deas
   end
 
   module SummaryLine
+    def self.keys
+      %w{time status method path handler params}
+    end
     def self.new(line_attrs)
-      attr_keys = %w{time status handler method path params}
-      attr_keys.map{ |k| "#{k}=#{line_attrs[k].inspect}" }.join(' ')
+      self.keys.map{ |k| "#{k}=#{line_attrs[k].inspect}" }.join(' ')
     end
   end
 

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -41,4 +41,32 @@ module Deas::Logging
 
   end
 
+  class SummaryLineTests < Assert::Context
+    desc "Deas::SummaryLine"
+    subject{ Deas::SummaryLine }
+
+    should "output its attributes in a specific order" do
+      assert_equal %w{time status method path handler params}, subject.keys
+    end
+
+    should "output its attributes in a single line" do
+      line_attrs = {
+        'time' => 't',
+        'status' => 's',
+        'method' => 'm',
+        'path' => 'pth',
+        'handler' => 'h',
+        'params' => 'p',
+      }
+      exp_line = "time=\"t\" "\
+                 "status=\"s\" "\
+                 "method=\"m\" "\
+                 "path=\"pth\" "\
+                 "handler=\"h\" "\
+                 "params=\"p\""
+      assert_equal exp_line, subject.new(line_attrs)
+    end
+
+  end
+
 end


### PR DESCRIPTION
This is a readability improvement.  Plus, the method and path drive
the handler.

Closes #31 

@jcredding ready for review.
