### PR TITLE
log the handler and params at the beginning of the request

### DIFF
--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -66,9 +66,8 @@ module Deas
         log "  Method:  #{request.request_method.inspect}"
         log "  Path:    #{request.path.inspect}"
       end
+      env['deas.logging'] = Proc.new{ |msg| log(msg) }
       status, headers, body = super(env)
-      log "  Params:  #{env['sinatra.params'].inspect}"
-      log "  Handler: #{env['deas.handler_class']}"
       log_error(env['sinatra.error'])
       log "===== Completed in #{env['deas.time_taken']}ms (#{response_display(status)}) ====="
       [ status, headers, body ]
@@ -91,6 +90,7 @@ module Deas
     # This the real Rack call interface. It adds logging after super-ing to the
     # common logging behavior.
     def call!(env)
+      env['deas.logging'] = Proc.new{ |msg| } # no-op
       status, headers, body = super(env)
       request = Rack::Request.new(env)
       log SummaryLine.new({

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -21,6 +21,8 @@ module Deas
       sinatra_call.request.env.tap do |env|
         env['sinatra.params']     = sinatra_call.params
         env['deas.handler_class'] = @handler_class
+        env['deas.logging'].call "  Handler: #{env['deas.handler_class']}"
+        env['deas.logging'].call "  Params:  #{env['sinatra.params'].inspect}"
       end
       Deas::SinatraRunner.run(@handler_class, sinatra_call)
     end


### PR DESCRIPTION
In verbose logging, write a logging callback proc so you can log
the handler and params as soon as you know them.  This logs them
with the method and path info which makes the most logical sense.
Plus you don't get request-related logs broken up by other handler-
related logs.

This also logs the handler class before the params b/c that is the
most logical order of attrs is: method, path, handler, params.

The summary logging's callback proc is a no-op since these logs
aren't used in summary logging.

We still need to set the handler class and params in the `env`
b/c summary logging needs access to them.

@jcredding ready for review.
