### PR TITLE
Allow multiple `init` and `run` callbacks using class methods

### DIFF
--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -41,11 +41,6 @@ module Deas
 
     protected
 
-    def before_init; end
-    def after_init;  end
-    def before_run;  end
-    def after_run;   end
-
     # Helpers
 
     def halt(*args);        @deas_runner.halt(*args);        end
@@ -63,7 +58,9 @@ module Deas
     def session;  @deas_runner.session;  end
 
     def run_callback(callback)
-      self.send(callback.to_s)
+      (self.class.send("#{callback}_callbacks") || []).each do |callback|
+        self.instance_eval(&callback)
+      end
     end
 
     module ClassMethods
@@ -82,6 +79,38 @@ module Deas
 
       def after_callbacks
         @after_callbacks ||= []
+      end
+
+      def before_init(&block)
+        self.before_init_callbacks << block
+      end
+
+      def before_init_callbacks
+        @before_init_callbacks ||= []
+      end
+
+      def after_init(&block)
+        self.after_init_callbacks << block
+      end
+
+      def after_init_callbacks
+        @after_init_callbacks ||= []
+      end
+
+      def before_run(&block)
+        self.before_run_callbacks << block
+      end
+
+      def before_run_callbacks
+        @before_run_callbacks ||= []
+      end
+
+      def after_run(&block)
+        self.after_run_callbacks << block
+      end
+
+      def after_run_callbacks
+        @after_run_callbacks ||= []
       end
 
       def layout(*args)

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -13,21 +13,24 @@ class FlagViewHandler
 
   attr_reader :before_init_called, :init_bang_called, :after_init_called,
     :before_run_called, :run_bang_called, :after_run_called,
-    :before_hook_called, :after_hook_called
+    :before_hook_called, :after_hook_called, :second_before_init_called
 
-  def before_init
+  before_init do
     @before_init_called = true
+  end
+  before_init do
+    @second_before_init_called = true
   end
 
   def init!
     @init_bang_called = true
   end
 
-  def after_init
+  after_init do
     @after_init_called = true
   end
 
-  def before_run
+  before_run do
     @before_run_called = true
   end
 
@@ -35,7 +38,7 @@ class FlagViewHandler
     @run_bang_called = true
   end
 
-  def after_run
+  after_run do
     @after_run_called = true
   end
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -15,8 +15,13 @@ module Deas::ViewHandler
     subject{ @handler }
 
     should have_instance_methods :init, :init!, :run, :run!
-    should have_class_methods :before, :before_callbacks, :after,
-      :after_callbacks, :layout, :layouts
+    should have_class_methods :before,      :before_callbacks
+    should have_class_methods :after,       :after_callbacks
+    should have_class_methods :before_init, :before_init_callbacks
+    should have_class_methods :after_init,  :after_init_callbacks
+    should have_class_methods :before_run,  :before_run_callbacks
+    should have_class_methods :after_run,   :after_run_callbacks
+    should have_class_methods :layout, :layouts
 
     should "raise a NotImplementedError if run! is not overwritten" do
       assert_raises(NotImplementedError){ subject.run! }
@@ -34,6 +39,34 @@ module Deas::ViewHandler
       TestViewHandler.after(&after_proc)
 
       assert_includes after_proc, TestViewHandler.after_callbacks
+    end
+
+    should "store procs in #before_init_callbacks with #before_init" do
+      before_init_proc = proc{ }
+      TestViewHandler.before_init(&before_init_proc)
+
+      assert_includes before_init_proc, TestViewHandler.before_init_callbacks
+    end
+
+    should "store procs in #after_init_callbacks with #after_init" do
+      after_init_proc = proc{ }
+      TestViewHandler.after_init(&after_init_proc)
+
+      assert_includes after_init_proc, TestViewHandler.after_init_callbacks
+    end
+
+    should "store procs in #before_run_callbacks with #before_run" do
+      before_run_proc = proc{ }
+      TestViewHandler.before_run(&before_run_proc)
+
+      assert_includes before_run_proc, TestViewHandler.before_run_callbacks
+    end
+
+    should "store procs in #after_run_callbacks with #after_run" do
+      after_run_proc = proc{ }
+      TestViewHandler.after_run(&after_run_proc)
+
+      assert_includes after_run_proc, TestViewHandler.after_run_callbacks
     end
 
     should "allow specifying the layouts using #layout or #layouts" do
@@ -55,6 +88,7 @@ module Deas::ViewHandler
 
     should "have called `init!` and it's callbacks" do
       assert_equal true, subject.before_init_called
+      assert_equal true, subject.second_before_init_called
       assert_equal true, subject.init_bang_called
       assert_equal true, subject.after_init_called
     end


### PR DESCRIPTION
This changes the view handlers callbacks for before/after
init/run to use a class level DSL instead of defining the
correctly named method. This allows configuring multiple of
these procs and having them all run. This is useful when mixins
each add their own callback. With this, callbacks don't have to
worry about `super`ing to make sure all defined callbacks are
run.

Closes #33
