### PR TITLE
Add error handling by configuring error procs on `Deas::Server`

### DIFF
--- a/lib/deas/error_handler.rb
+++ b/lib/deas/error_handler.rb
@@ -1,0 +1,35 @@
+module Deas
+
+  class ErrorHandler
+
+    def self.run(*args)
+      self.new(*args).run
+    end
+
+    def initialize(exception, sinatra_call, error_procs)
+      @exception    = exception
+      @sinatra_call = sinatra_call
+
+      @error_procs = [*error_procs].compact
+    end
+
+    def run
+      response = nil
+      @error_procs.each do |error_proc|
+        begin
+          result = @sinatra_call.instance_exec(@exception, &error_proc)
+          response = result if result
+        rescue Exception => proc_exception
+          @exception = proc_exception
+          # reset the response if an exception occurs while evaulating the
+          # error procs -- a new exception will now be handled by the
+          # remaining procs
+          response = nil
+        end
+      end
+      response
+    end
+
+  end
+
+end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -28,6 +28,7 @@ module Deas
       option :reload_templates, NsOptions::Boolean, :default => false
 
       # server handling options
+      option :error_procs,     Array, :default => []
       option :init_proc,       Proc,  :default => proc{ }
       option :logger,                 :default => proc{ Deas::NullLogger.new }
       option :middlewares,     Array, :default => []
@@ -98,6 +99,10 @@ module Deas
     end
 
     # Server handling DSL
+
+    def error(&block)
+      self.configuration.error_procs << block
+    end
 
     def init(&block)
       self.configuration.init_proc = block

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -9,6 +9,15 @@ class Deas::Server
   logger Logger.new(File.open(log_file_path, 'w'))
   verbose_logging true
 
+  error do |exception|
+    case exception
+    when Sinatra::NotFound
+      halt 404, "Couldn't be found"
+    when Exception
+      halt 500, "Oops, something went wrong"
+    end
+  end
+
   get  '/show',            'ShowHandler'
   get  '/halt',            'HaltHandler'
   get  '/error',           'ErrorHandler'

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -24,16 +24,20 @@ class MakingRequestsTests < Assert::Context
     assert_equal 234, last_response.status
   end
 
-  should "return a 404 response with an undefined route" do
+  should "return a 404 response with an undefined route and " \
+         "run the defined error procs" do
     get '/not_defined'
 
     assert_equal 404, last_response.status
+    assert_equal "Couldn't be found", last_response.body
   end
 
-  should "return a 500 response with an error route" do
+  should "return a 500 response with an error route and " \
+         "run the defined error procs" do
     get '/error'
 
     assert_equal 500, last_response.status
+    assert_equal "Oops, something went wrong", last_response.body
   end
 
   should "return a 200 response and use all the layouts" do

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -1,0 +1,104 @@
+require 'assert'
+require 'deas/error_handler'
+
+class Deas::ErrorHandler
+
+  class BaseTests < Assert::Context
+    desc "Deas::ErrorHandler"
+    setup do
+      @exception = RuntimeError.new
+      @fake_app  = FakeApp.new
+      @error_handler = Deas::ErrorHandler.new(@exception, @fake_app, [])
+    end
+    subject{ @error_handler }
+
+    should have_instance_methods :run
+    should have_class_methods :run
+
+  end
+
+  class RunTests < BaseTests
+    desc "run"
+    setup do
+      @error_procs = [ proc do |exception|
+        settings.exception_that_occurred = exception
+        "my return value"
+      end ]
+
+      @error_handler = Deas::ErrorHandler.new(@exception, @fake_app, @error_procs)
+      @response = @error_handler.run
+    end
+
+    should "run the proc in the context of the app" do
+      assert_equal @exception, @fake_app.settings.exception_that_occurred
+    end
+
+    should "return whatever the proc returns" do
+      assert_equal "my return value", @response
+    end
+
+  end
+
+  class RunWithMultipleProcsTests < BaseTests
+    desc "run with multiple procs"
+    setup do
+      @error_procs = [
+        proc do |exception|
+          settings.first_proc_run = true
+          'first'
+        end,
+        proc do |exception|
+          settings.second_proc_run = true
+          'second'
+        end,
+        proc do |exception|
+          settings.third_proc_run = true
+          nil
+        end
+      ]
+
+      @error_handler = Deas::ErrorHandler.new(@exception, @fake_app, @error_procs)
+      @response = @error_handler.run
+    end
+
+    should "run all the error procs" do
+      assert_equal true, @fake_app.settings.first_proc_run
+      assert_equal true, @fake_app.settings.second_proc_run
+      assert_equal true, @fake_app.settings.third_proc_run
+    end
+
+    should "return the last non-nil response" do
+      assert_equal 'second', @response
+    end
+
+  end
+
+  class RunWithProcsThatHaltTests < BaseTests
+    desc "run with a proc that halts"
+    setup do
+      @error_procs = [
+        proc do |exception|
+          settings.first_proc_run = true
+          halt 401
+        end,
+        proc do |exception|
+          settings.second_proc_run = true
+        end
+      ]
+
+      @error_handler = Deas::ErrorHandler.new(@exception, @fake_app, @error_procs)
+      @response = catch(:halt){ @error_handler.run }
+    end
+
+    should "run error procs until one halts" do
+      assert_equal true, @fake_app.settings.first_proc_run
+      assert_nil @fake_app.settings.second_proc_run
+    end
+
+    should "return whatever was halted" do
+      assert_equal [ 401 ], @response
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds error handling by allowing setting error procs on
the `Deas::Server`. These procs are triggered anytime Sinatra
would trigger it's `error` or `not_found` handlers. They are
passed the exception and evaluated in Sinatra's context, which
allows doing anything possible with Sinatra. This allows apps to
setup error handling easily with the all the features of
Sinatra.

Closes #21
