### PR TITLE
allow setting sinatra's `reload_templates` setting

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -25,6 +25,7 @@ module Deas
       option :sessions,         NsOptions::Boolean, :default => true
       option :show_exceptions,  NsOptions::Boolean, :default => false
       option :static_files,     NsOptions::Boolean, :default => true
+      option :reload_templates, NsOptions::Boolean, :default => false
 
       # server handling options
       option :init_proc,       Proc,  :default => proc{ }
@@ -90,6 +91,10 @@ module Deas
 
     def static_files(*args)
       self.configuration.static_files *args
+    end
+
+    def reload_templates(*args)
+      self.configuration.reload_templates *args
     end
 
     # Server handling DSL

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -24,6 +24,7 @@ module Deas
         set :sessions,         server_config.sessions
         set :show_exceptions,  server_config.show_exceptions
         set :static,           server_config.static_files
+        set :reload_templates, server_config.reload_templates
         set :logging,         false
 
         # custom settings

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -26,7 +26,7 @@ class Deas::Server
     # DSL for sinatra settings
     should have_imeths :env, :root, :public_folder, :views_folder
     should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
-    should have_imeths :static_files
+    should have_imeths :static_files, :reload_templates
 
     # DSL for server handling
     should have_imeths :init, :logger, :use, :view_handler_ns, :use
@@ -65,6 +65,9 @@ class Deas::Server
 
       subject.static_files false
       assert_equal false, config.static_files
+
+      subject.reload_templates true
+      assert_equal true, config.reload_templates
 
       subject.use 'MyMiddleware'
       assert_equal [ ['MyMiddleware'] ], config.middlewares
@@ -166,7 +169,7 @@ class Deas::Server
     # sinatra related options
     should have_imeths :env, :root, :app_file, :public_folder, :views_folder
     should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
-    should have_imeths :static_files
+    should have_imeths :static_files, :reload_templates
 
     # server handling options
     should have_imeths :init_proc, :logger, :verbose_logging, :middlewares
@@ -203,6 +206,7 @@ class Deas::Server
       assert_equal true,  subject.sessions
       assert_equal false, subject.show_exceptions
       assert_equal true,  subject.static_files
+      assert_equal false, subject.reload_templates
     end
 
     should "default the logger to a NullLogger" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -19,6 +19,7 @@ module Deas::SinatraApp
         c.sessions         = false
         c.show_exceptions  = true
         c.static           = true
+        c.reload_templates = true
         c.routes           = [ @route ]
       end
       @sinatra_app = Deas::SinatraApp.new(@configuration)
@@ -54,6 +55,7 @@ module Deas::SinatraApp
         assert_equal false,                      settings.sessions
         assert_equal true,                       settings.show_exceptions
         assert_equal true,                       settings.static
+        assert_equal true,                       settings.reload_templates
         assert_instance_of Deas::NullLogger,     settings.logger
       end
     end


### PR DESCRIPTION
This allows you to configure the `reload_templates` setting from
your routes file (server config).  This sets the Sinatra setting.

Use this to control whether templates are reloaded or not.  The
default is false (meaning you have to restart to see template
changes).

Closes #35.

@jcredding ready for review.
