### PR TITLE
change the default `sessions` setting to be `false`

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -22,7 +22,7 @@ module Deas
 
       option :dump_errors,      NsOptions::Boolean, :default => false
       option :method_override,  NsOptions::Boolean, :default => true
-      option :sessions,         NsOptions::Boolean, :default => true
+      option :sessions,         NsOptions::Boolean, :default => false
       option :show_exceptions,  NsOptions::Boolean, :default => false
       option :static_files,     NsOptions::Boolean, :default => true
       option :reload_templates, NsOptions::Boolean, :default => false

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -1,82 +1,95 @@
 require 'assert'
 require 'rack/test'
 
-class MakingRequestsTests < Assert::Context
-  include Rack::Test::Methods
+module Deas
 
-  desc "Making requests using rack test"
-  setup do
-    @app = Deas.app.new
+  class RackTests < Assert::Context
+    include Rack::Test::Methods
+
+    desc "Deas' the rack app"
+    setup do
+      @app = Deas.app.new
+    end
+
+    def app; @app; end
+
+    should "return a 200 response with a GET to '/show'" do
+      get '/show', 'message' => 'this is a test'
+
+      expected_body = "show page: this is a test\n" \
+                      "Stuff: Show Info\n"
+      assert_equal 200,           last_response.status
+      assert_equal expected_body, last_response.body
+    end
+
+    should "allow halting with a custom response" do
+      get '/halt', 'with' => 234
+
+      assert_equal 234, last_response.status
+    end
+
+    should "return a 404 response with an undefined route and " \
+           "run the defined error procs" do
+      get '/not_defined'
+
+      assert_equal 404, last_response.status
+      assert_equal "Couldn't be found", last_response.body
+    end
+
+    should "return a 500 response with an error route and " \
+           "run the defined error procs" do
+      get '/error'
+
+      assert_equal 500, last_response.status
+      assert_equal "Oops, something went wrong", last_response.body
+    end
+
+    should "return a 200 response and use all the layouts" do
+      get '/with_layout'
+
+      expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layout\n"
+      assert_equal 200,           last_response.status
+      assert_equal expected_body, last_response.body
+
+      get '/alt_with_layout'
+
+      assert_equal 200,           last_response.status
+      assert_equal expected_body, last_response.body
+    end
+
+    should "return a 302 redirecting to the expected locations" do
+      get '/redirect'
+      expected_location = 'http://google.com'
+
+      assert_equal 302,               last_response.status
+      assert_equal expected_location, last_response.headers['Location']
+
+      get '/redirect_to'
+      expected_location = 'http://example.org/somewhere'
+
+      assert_equal 302,               last_response.status
+      assert_equal expected_location, last_response.headers['Location']
+    end
+
   end
 
-  should "return a 200 response with a GET to '/show'" do
-    get '/show', 'message' => 'this is a test'
+  class SessionTests < RackTests
+    desc "with sessions enabled"
+    setup do
+      orig_sessions = Deas.app.settings.sessions
+      Deas.app.set :sessions, true
+      @app = Deas.app.new
+      Deas.app.set :sessions, orig_sessions
+    end
 
-    expected_body = "show page: this is a test\n" \
-                    "Stuff: Show Info\n"
-    assert_equal 200,           last_response.status
-    assert_equal expected_body, last_response.body
-  end
+    should "return a 200 response and the session value" do
+      post '/session'
+      follow_redirect!
 
-  should "allow halting with a custom response" do
-    get '/halt', 'with' => 234
+      assert_equal 200,              last_response.status
+      assert_equal 'session_secret', last_response.body
+    end
 
-    assert_equal 234, last_response.status
-  end
-
-  should "return a 404 response with an undefined route and " \
-         "run the defined error procs" do
-    get '/not_defined'
-
-    assert_equal 404, last_response.status
-    assert_equal "Couldn't be found", last_response.body
-  end
-
-  should "return a 500 response with an error route and " \
-         "run the defined error procs" do
-    get '/error'
-
-    assert_equal 500, last_response.status
-    assert_equal "Oops, something went wrong", last_response.body
-  end
-
-  should "return a 200 response and use all the layouts" do
-    get '/with_layout'
-
-    expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layout\n"
-    assert_equal 200,           last_response.status
-    assert_equal expected_body, last_response.body
-
-    get '/alt_with_layout'
-
-    assert_equal 200,           last_response.status
-    assert_equal expected_body, last_response.body
-  end
-
-  should "return a 302 redirecting to the expected locations" do
-    get '/redirect'
-    expected_location = 'http://google.com'
-
-    assert_equal 302,               last_response.status
-    assert_equal expected_location, last_response.headers['Location']
-
-    get '/redirect_to'
-    expected_location = 'http://example.org/somewhere'
-
-    assert_equal 302,               last_response.status
-    assert_equal expected_location, last_response.headers['Location']
-  end
-
-  should "return a 200 response and the session value" do
-    post '/session'
-    follow_redirect!
-
-    assert_equal 200,              last_response.status
-    assert_equal 'session_secret', last_response.body
-  end
-
-  def app
-    @app
   end
 
 end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -203,7 +203,7 @@ class Deas::Server
     should "default the Sinatra flags" do
       assert_equal false, subject.dump_errors
       assert_equal true,  subject.method_override
-      assert_equal true,  subject.sessions
+      assert_equal false, subject.sessions
       assert_equal false, subject.show_exceptions
       assert_equal true,  subject.static_files
       assert_equal false, subject.reload_templates


### PR DESCRIPTION
This means that no session cookie is used by default.  This is the
responsibility of the developer and should not be enabled without
them doing it.

This helps with security as no cookies are used without the developer
knowing about it.

Closes #43.

@jcredding the diff on the system tests is ugly b/c I moved everything under the `Deas` module and renamed the contexts.  The gist is at the bottom of the diff (the added context).  The only reason I had to change it at all is b/c the session test assumed sessions were on.
