### PR TITLE
allow specifying multiple `init` blocks

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -29,7 +29,7 @@ module Deas
 
       # server handling options
       option :error_procs,     Array, :default => []
-      option :init_proc,       Proc,  :default => proc{ }
+      option :init_procs,      Array, :default => []
       option :logger,                 :default => proc{ Deas::NullLogger.new }
       option :middlewares,     Array, :default => []
       option :verbose_logging,        :default => true
@@ -105,7 +105,7 @@ module Deas
     end
 
     def init(&block)
-      self.configuration.init_proc = block
+      self.configuration.init_procs << block
     end
 
     def logger(*args)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -7,7 +7,10 @@ module Deas
   module SinatraApp
 
     def self.new(server_config)
-      server_config.init_proc.call
+      # the reason this is done here is b/c the below sinatra configuration is
+      # not considered valid until the init procs have been run and the routes
+      # have been constantized.
+      server_config.init_procs.each{ |p| p.call }
       server_config.routes.each(&:constantize!)
 
       Sinatra.new do

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -76,9 +76,11 @@ class Deas::Server
       subject.logger stdout_logger
       assert_equal stdout_logger, config.logger
 
+      assert_equal 0, config.init_procs.size
       init_proc = proc{ }
       subject.init(&init_proc)
-      assert_equal init_proc, config.init_proc
+      assert_equal 1, config.init_procs.size
+      assert_equal init_proc, config.init_procs.first
     end
 
     should "add a GET route using #get" do
@@ -172,7 +174,7 @@ class Deas::Server
     should have_imeths :static_files, :reload_templates
 
     # server handling options
-    should have_imeths :init_proc, :logger, :verbose_logging, :middlewares
+    should have_imeths :init_procs, :logger, :verbose_logging, :middlewares
     should have_imeths :routes, :view_handler_ns
 
     should "default the env to 'development'" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -32,10 +32,13 @@ module Deas::SinatraApp
 
     should "call init procs when initialized" do
       initialized = false
-      @configuration.init_proc = proc{ initialized = true }
+      other_initialized = false
+      @configuration.init_procs << proc{ initialized = true }
+      @configuration.init_procs << proc{ other_initialized = true }
       @sinatra_app = Deas::SinatraApp.new(@configuration)
 
       assert_equal true, initialized
+      assert_equal true, other_initialized
     end
 
     should "call constantize! on all routes" do


### PR DESCRIPTION
This allows you to define multiple `init` blocks on your deas server
and have them all get run when the sinatra app is created.

This is so multiple "plugins" or whatever can add initialization
to the base Deas server.

@jcredding ready for review.
