### PR TITLE
Have test runner render method return the args it was called with

### DIFF
--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -30,8 +30,8 @@ module Deas
       throw(:halt, args)
     end
 
-    def render(*args)
-      "test runner render"
+    def render(*args, &block)
+      [ args, block ].compact.flatten
     end
 
   end

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -5,6 +5,14 @@ class TestViewHandler
 
 end
 
+class RenderViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    render "my_template", :some => :option
+  end
+end
+
 class FlagViewHandler
   include Deas::ViewHandler
   before{ @before_hook_called = true }

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -79,6 +79,12 @@ module Deas::ViewHandler
       assert_equal [ 'layouts/web', 'layouts/search' ], handler_class.layouts
     end
 
+    should "be able to render templates" do
+      return_value = test_runner(RenderViewHandler).run
+      assert_equal "my_template",        return_value[0]
+      assert_equal({ :some => :option }, return_value[1])
+    end
+
   end
 
   class WithMethodFlagsTests < BaseTests


### PR DESCRIPTION
This is a more useful case and can be used in testing to make
sure the view handler renders the expected template and options.
