### PR TITLE
no singletons: have the sinatra call be aware of its template rendering scope

### DIFF
--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -28,11 +28,12 @@ module Deas
         set :show_exceptions,  server_config.show_exceptions
         set :static,           server_config.static_files
         set :reload_templates, server_config.reload_templates
-        set :logging,         false
+        set :logging,          false
 
         # custom settings
-        set :deas_error_procs, server_config.error_procs
-        set :logger,           server_config.logger
+        set :deas_template_scope, server_config.template_scope
+        set :deas_error_procs,    server_config.error_procs
+        set :logger,              server_config.logger
 
         server_config.middlewares.each do |middleware_args|
           use *middleware_args
@@ -41,8 +42,6 @@ module Deas
 
         # routes
         server_config.routes.each do |route|
-          # defines Sinatra routes like:
-          #   get('/'){ ... }
           send(route.method, route.path){ route.run(self) }
         end
 

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -39,6 +39,10 @@ module Deas
       "#<#{self.class}:#{reference} @request=#{self.request.inspect}>"
     end
 
+    def ==(other_handler)
+      self.class == other_handler.class
+    end
+
     protected
 
     # Helpers

--- a/test/support/fake_app.rb
+++ b/test/support/fake_app.rb
@@ -13,18 +13,19 @@ class FakeApp
     @params   = @request.params
     @session  = @request.session
     @response = FakeResponse.new
-    @settings = OpenStruct.new({ })
+    @settings = OpenStruct.new(:deas_template_scope => Deas::Template::Scope)
   end
 
   def halt(*args)
     throw :halt, args
   end
 
-  def erb(*args, &block)
+  # return the template name for each nested calls
+  def erb(name, opts, &block)
     if block
-      [ args, block.call ].flatten
+      [ name, opts, block.call ].flatten
     else
-      args
+      [ name, opts ]
     end
   end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -42,17 +42,15 @@ class Deas::SinatraRunner
       assert_equal [ 'test' ], return_value
     end
 
-    should "call the sinatra_call's erb method with #render" do
-      return_value = subject.render('index')
+    should "render the template with a :view local and the handler layouts with #render" do
+      exp_handler = FlagViewHandler.new(subject)
+      exp_layouts = FlagViewHandler.layouts
+      exp_result = Deas::Template.new(@fake_sinatra_call, 'index', {
+        :locals => { :view => exp_handler },
+        :layout => exp_layouts
+      }).render
 
-      assert_equal :web,   return_value[0]
-      assert_equal :index, return_value[2]
-
-      options = return_value[3]
-      assert_instance_of Deas::Template::RenderScope, options[:scope]
-
-      expected_locals = { :view => subject.instance_variable_get("@handler") }
-      assert_equal(expected_locals, options[:locals])
+      assert_equal exp_result, subject.render('index')
     end
 
     should "call the sinatra_call's redirect method with #redirect" do


### PR DESCRIPTION
This moves the template helper api to the server DSL.  You now add
and query template helper modules using your server class.  The main
benefit here is that it is a) associated with your server and not
a global singleton render scope and b) it is a simpler implementation.

The server config just tracks a list of helper modules and at app
create time, creates a scope, mixes in the helper modules, and sets
it in the app settings.  Then when a template is rendered, it looks
up its scope from the sinatra call's settings.  There is no global
render scope - each app has its own template rendering scope. However,
the scope is only built once, at app creation time, like the previous
implementation.

@jcredding ready for review.
