### PR TITLE
add a `set` method to the server API

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -30,6 +30,7 @@ module Deas::Server
     option :init_procs,      Array, :default => []
     option :logger,                 :default => proc{ Deas::NullLogger.new }
     option :middlewares,     Array, :default => []
+    option :settings,        Array, :default => []
     option :verbose_logging,        :default => true
     option :routes,          Array, :default => []
     option :view_handler_ns, String
@@ -137,6 +138,10 @@ module Deas::Server
 
     def use(*args)
       self.configuration.middlewares << args
+    end
+
+    def set(*args)
+      self.configuration.settings << args
     end
 
     def view_handler_ns(*args)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -35,9 +35,9 @@ module Deas
         set :deas_error_procs,    server_config.error_procs
         set :logger,              server_config.logger
 
-        server_config.middlewares.each do |middleware_args|
-          use *middleware_args
-        end
+        server_config.settings.each{ |set_args| set *set_args }
+        server_config.middlewares.each{ |use_args| use *use_args }
+
         use Deas::Logging.middleware(server_config.verbose_logging)
 
         # routes

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -22,7 +22,7 @@ module Deas::Server
 
     # DSL for server handling
     should have_imeths :init, :template_helpers, :template_helper?, :error
-    should have_imeths :logger, :use, :view_handler_ns, :verbose_logging
+    should have_imeths :logger, :use, :set, :view_handler_ns, :verbose_logging
     should have_imeths :get, :post, :put, :patch, :delete, :route
 
     should "allow setting it's configuration options" do
@@ -60,6 +60,9 @@ module Deas::Server
 
       subject.use 'MyMiddleware'
       assert_equal [ ['MyMiddleware'] ], config.middlewares
+
+      subject.set :testing_set_meth, 'it works!'
+      assert_equal [ [:testing_set_meth, 'it works!'] ], config.settings
 
       stdout_logger = Logger.new(STDOUT)
       subject.logger stdout_logger
@@ -168,7 +171,7 @@ module Deas::Server
     should have_imeths :static_files, :reload_templates
 
     # server handling options
-    should have_imeths :error_procs, :init_procs, :logger, :middlewares
+    should have_imeths :error_procs, :init_procs, :logger, :middlewares, :settings
     should have_imeths :verbose_logging, :routes, :view_handler_ns
 
     should have_reader :template_helpers
@@ -198,6 +201,7 @@ module Deas::Server
       assert_empty subject.init_procs
       assert_instance_of Deas::NullLogger, subject.logger
       assert_empty subject.middlewares
+      assert_empty subject.settings
       assert_equal true, subject.verbose_logging
       assert_empty subject.routes
       assert_nil   subject.view_handler_ns


### PR DESCRIPTION
This allows for setting custom settings on the sinatra app by 3rd-party
stuff.

Some things, like custom error procs, can be set by 3rd-party tools
but are instance eval'd in the sinatra call.  If the 3rd-party needed
to access some of its own custom data or configs, it would have to
implement them as a Singleton to get access to them.  That's no good.

This allows the 3rd party to instead set their custom data as a setting
and then they can access via the sinatra call's settings.

This is a bit "dangerous" in that a 3rd-party can potentially override
the settings applied by the other 3rd parties or even Deas itself. In
general, namespaced settings _should_ be used to preven this, but
nothing guarantees that.  Just noting that here.

@jcredding thoughts on this?  ready for review.
