### PR TITLE
pipe the sinatra call settings to the view handler via `app_settings`

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -2,7 +2,8 @@ module Deas
 
   class Runner
 
-    attr_accessor :request, :response, :params, :logger, :session
+    attr_reader :app_settings
+    attr_reader :request, :response, :params, :logger, :session
 
     def initialize(handler_class)
       @handler_class = handler_class

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -11,7 +11,7 @@ module Deas
 
     def initialize(handler_class, sinatra_call)
       @sinatra_call  = sinatra_call
-      @handler_class = handler_class
+      @app_settings  = @sinatra_call.settings
       @logger        = @sinatra_call.settings.logger
       @params        = @sinatra_call.params
       @request       = @sinatra_call.request

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'deas/runner'
 
 module Deas
@@ -8,11 +9,12 @@ module Deas
 
     def initialize(handler_class, args = nil)
       args = (args || {}).dup
-      @logger   = args.delete(:logger) || Deas::NullLogger.new
-      @params   = args.delete(:params) || {}
-      @request  = args.delete(:request)
-      @response = args.delete(:response)
-      @session  = args.delete(:session)
+      @app_settings = OpenStruct.new(args.delete(:app_settings))
+      @logger       = args.delete(:logger) || Deas::NullLogger.new
+      @params       = args.delete(:params) || {}
+      @request      = args.delete(:request)
+      @response     = args.delete(:response)
+      @session      = args.delete(:session)
 
       super(handler_class)
       args.each{|key, value| @handler.send("#{key}=", value) }

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -55,11 +55,12 @@ module Deas
       @deas_runner.render(*args, &block)
     end
 
-    def logger;   @deas_runner.logger;   end
-    def request;  @deas_runner.request;  end
-    def response; @deas_runner.response; end
-    def params;   @deas_runner.params;   end
-    def session;  @deas_runner.session;  end
+    def app_settings; @deas_runner.app_settings; end
+    def logger;       @deas_runner.logger;       end
+    def request;      @deas_runner.request;      end
+    def response;     @deas_runner.response;     end
+    def params;       @deas_runner.params;       end
+    def session;      @deas_runner.session;      end
 
     def run_callback(callback)
       (self.class.send("#{callback}_callbacks") || []).each do |callback|

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -11,7 +11,8 @@ class Deas::Runner
     end
     subject{ @runner }
 
-    should have_instance_methods :request, :response, :params, :logger, :session
+    should have_reader  :app_settings
+    should have_readers :request, :response, :params, :logger, :session
 
     should "raise NotImplementedError with #halt" do
       assert_raises(NotImplementedError){ subject.halt }


### PR DESCRIPTION
This exposes the sinatra call's settings via the `app_settings`
method on a view handler.  This is needed with the no singleton
version of Deas so that view handlers can access app configuration
values and settings.  Previously the singleton provided this access.

@jcredding ready for review.  biggest change here is changing the accessors on the runner to just readers.  I like this (it limits down the API), but unsure if anything using deas expects accessors.  All tests pass though, so there's that.
