### PR TITLE
added a system test to ensure handlers can access protected call data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gemspec
 
 gem 'rake'
 gem 'pry'
+gem 'multi_json'
+gem 'yajl-ruby'

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -94,4 +94,24 @@ module Deas
 
   end
 
+  class HandlerTests < RackTests
+    desc "handler"
+    setup do
+      get 'handler/tests.json?a-param=something'
+
+      require 'multi_json'
+      @data = MultiJson.decode(last_response.body || "")
+    end
+
+    should "be able to access sinatra call data" do
+      assert_equal 'something',    @data['app_settings_a_setting']
+      assert_equal 'Logger',       @data['logger_class_name']
+      assert_equal 'GET',          @data['request_method']
+      assert_equal 'Content-Type', @data['response_firstheaderval']
+      assert_equal 'something',    @data['params_a_param']
+      assert_equal '{}',           @data['session_inspect']
+    end
+
+  end
+
 end


### PR DESCRIPTION
There was a hole in our tests related to the protected attributes
on a handler's call data.  Because we designed them to be protected
(ie a tempalate should not be able to go `view.request`), it made
them difficult to test so they weren't tested.

This crafts a system test where the handler accesses each protected
attribute and returns that data in a json response.  The test takes
the response and validates the data is as expected.  If you remove
a protected attribute from the handler, this will fail.

@jcredding ready for review.
