### PR TITLE
Add `redirect` route helper for building routes that redirect

### DIFF
--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -96,7 +96,7 @@ module Deas
       log SummaryLine.new({
         'method'  => request.request_method,
         'path'    => request.path,
-        'handler' => env['deas.handler_class'],
+        'handler' => env['deas.handler_class_name'],
         'params'  => env['sinatra.params'],
         'time'    => env['deas.time_taken'],
         'status'  => status

--- a/lib/deas/redirect_handler.rb
+++ b/lib/deas/redirect_handler.rb
@@ -1,0 +1,34 @@
+require 'deas/view_handler'
+
+module Deas
+
+  module RedirectHandler
+
+    def self.new(path = nil, &block)
+      handler_class = Class.new do
+        include Deas::ViewHandler
+        include InstanceMethods
+        extend ClassMethods
+      end
+      handler_class.redirect_path = path ? proc{ path } : block
+      handler_class
+    end
+
+    module InstanceMethods
+
+      def run!
+        path = self.instance_eval(&self.class.redirect_path)
+        redirect path
+      end
+
+    end
+
+    module ClassMethods
+
+      attr_accessor :redirect_path
+
+    end
+
+  end
+
+end

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -5,11 +5,11 @@ module Deas
   class Route
     attr_reader :method, :path, :handler_class_name, :handler_class
 
-    def initialize(method, path, handler_class_name)
+    def initialize(method, path, handler_class_name, handler_class = nil)
       @method = method
       @path   = path
       @handler_class_name = handler_class_name
-      @handler_class      = nil
+      @handler_class      = handler_class
     end
 
     def constantize!
@@ -19,9 +19,9 @@ module Deas
 
     def run(sinatra_call)
       sinatra_call.request.env.tap do |env|
-        env['sinatra.params']     = sinatra_call.params
-        env['deas.handler_class'] = @handler_class
-        env['deas.logging'].call "  Handler: #{env['deas.handler_class']}"
+        env['sinatra.params']          = sinatra_call.params
+        env['deas.handler_class_name'] = @handler_class_name
+        env['deas.logging'].call "  Handler: #{env['deas.handler_class_name']}"
         env['deas.logging'].call "  Params:  #{env['sinatra.params'].inspect}"
       end
       Deas::SinatraRunner.run(@handler_class, sinatra_call)

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -22,10 +22,6 @@ module Deas
       raise NotImplementedError
     end
 
-    def redirect_to(*args)
-      raise NotImplementedError
-    end
-
   end
 
 end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -2,6 +2,7 @@ require 'ns-options'
 require 'ns-options/boolean'
 require 'pathname'
 require 'deas/template'
+require 'deas/redirect_handler'
 require 'deas/route'
 require 'deas/sinatra_app'
 
@@ -170,6 +171,14 @@ module Deas::Server
 
     def delete(path, handler_class_name)
       self.route(:delete, path, handler_class_name)
+    end
+
+    def redirect(http_method, path, to_path = nil, &block)
+      name          = 'Deas::RedirectHandler'
+      handler_class = Deas::RedirectHandler.new(to_path, &block)
+      Deas::Route.new(http_method, path, name, handler_class).tap do |route|
+        self.configuration.routes.push(route)
+      end
     end
 
     def route(http_method, path, handler_class_name)

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -45,10 +45,6 @@ module Deas
       @sinatra_call.redirect(*args)
     end
 
-    def redirect_to(path, *args)
-      @sinatra_call.redirect(@sinatra_call.to(path), *args)
-    end
-
     private
 
     def run_callbacks(callbacks)

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -36,6 +36,10 @@ module Deas
       [ args, block ].compact.flatten
     end
 
+    def redirect(*args)
+      [ :redirect, args ].compact.flatten
+    end
+
   end
 
 end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -47,9 +47,8 @@ module Deas
 
     # Helpers
 
-    def halt(*args);        @deas_runner.halt(*args);        end
-    def redirect(*args);    @deas_runner.redirect(*args);    end
-    def redirect_to(*args); @deas_runner.redirect_to(*args); end
+    def halt(*args);     @deas_runner.halt(*args);     end
+    def redirect(*args); @deas_runner.redirect(*args); end
 
     def render(*args, &block)
       @deas_runner.render(*args, &block)

--- a/test/support/fake_app.rb
+++ b/test/support/fake_app.rb
@@ -29,10 +29,6 @@ class FakeApp
     end
   end
 
-  def to(relative_path)
-    File.join("http://test.local", relative_path)
-  end
-
   def redirect(*args)
     halt 302, { 'Location' => args[0] }
   end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -25,11 +25,13 @@ class DeasTestServer
   get  '/with_layout',     'WithLayoutHandler'
   get  '/alt_with_layout', 'AlternateWithLayoutHandler'
   get  '/redirect',        'RedirectHandler'
-  get  '/redirect_to',     'RedirectToHandler'
   post '/session',         'SetSessionHandler'
   get  '/session',         'UseSessionHandler'
 
   get '/handler/tests.json', 'HandlerTestsHandler'
+
+  redirect :get, '/route_redirect',   '/somewhere'
+  redirect(:get, '/:prefix/redirect'){ "/#{params['prefix']}/somewhere" }
 
 end
 
@@ -100,21 +102,12 @@ class RedirectHandler
 
 end
 
-class RedirectToHandler
-  include Deas::ViewHandler
-
-  def run!
-    redirect_to '/somewhere'
-  end
-
-end
-
 class SetSessionHandler
   include Deas::ViewHandler
 
   def run!
     session[:secret] = 'session_secret'
-    redirect_to '/session'
+    redirect '/session'
   end
 
 end

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -64,9 +64,18 @@ module Deas
 
       assert_equal 302,               last_response.status
       assert_equal expected_location, last_response.headers['Location']
+    end
 
-      get '/redirect_to'
+    should "return a 302 redirect to the expected location " \
+           "when using a route redirect" do
+      get '/route_redirect'
       expected_location = 'http://example.org/somewhere'
+
+      assert_equal 302,               last_response.status
+      assert_equal expected_location, last_response.headers['Location']
+
+      get '/my_prefix/redirect'
+      expected_location = 'http://example.org/my_prefix/somewhere'
 
       assert_equal 302,               last_response.status
       assert_equal expected_location, last_response.headers['Location']

--- a/test/unit/redirect_handler_tests.rb
+++ b/test/unit/redirect_handler_tests.rb
@@ -1,0 +1,57 @@
+require 'assert'
+require 'deas/redirect_handler'
+require 'deas/test_helpers'
+
+module Deas::RedirectHandler
+
+  class BaseTests < Assert::Context
+    desc "Deas::RedirectHandler"
+    setup do
+      @handler_class = Deas::RedirectHandler.new('/somewhere')
+    end
+    subject{ @handler_class }
+
+    should have_accessors :redirect_path
+
+    should "build a redirect handler class" do
+      subject.included_modules.tap do |modules|
+        assert_includes Deas::ViewHandler, modules
+        assert_includes Deas::RedirectHandler::InstanceMethods, modules
+      end
+
+      assert_instance_of Proc, subject.redirect_path
+      assert_equal '/somewhere', subject.redirect_path.call
+    end
+
+    should "allow passing a block instead of a static path" do
+      path_proc = proc{ '/somewhere' }
+
+      handler_class = Deas::RedirectHandler.new(&path_proc)
+      assert_equal path_proc, handler_class.redirect_path
+    end
+
+  end
+
+  class RunTests < BaseTests
+    include Deas::TestHelpers
+
+    desc "when run"
+
+    should "redirect to the path that it was build with" do
+      @response = test_runner(@handler_class).run
+      assert_equal [ :redirect, "/somewhere" ], @response
+    end
+
+    should "redirect to the path returned from instance evaling the proc" do
+      path_proc = proc{ params['redirect_to'] }
+      handler_class = Deas::RedirectHandler.new(&path_proc)
+
+      @response = test_runner(handler_class, {
+        :params => { 'redirect_to' => '/go_here' }
+      }).run
+      assert_equal [ :redirect, "/go_here" ], @response
+    end
+
+  end
+
+end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -16,6 +16,13 @@ class Deas::Route
     should have_instance_methods :method, :path, :handler_class_name,
       :handler_class, :run
 
+    should "allow passing a constantized handler when initialized" do
+      route = Deas::Route.new(:get, '/test', 'TestViewHandler', TestViewHandler)
+
+      # handler class is set without calling constantize
+      assert_equal TestViewHandler, route.handler_class
+    end
+
     should "constantize the handler class with #constantize!" do
       assert_nil subject.handler_class
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -26,10 +26,6 @@ class Deas::Runner
       assert_raises(NotImplementedError){ subject.redirect }
     end
 
-    should "raise NotImplementedError with #redirect_to" do
-      assert_raises(NotImplementedError){ subject.redirect_to }
-    end
-
   end
 
 end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -125,6 +125,17 @@ module Deas::Server
       assert_equal 'DeleteAsset', route.handler_class_name
     end
 
+    should "add a redirect route using #redirect" do
+      subject.redirect(:get, '/invalid', '/assets')
+
+      route = subject.configuration.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :get,       route.method
+      assert_equal '/invalid', route.path
+      assert_equal 'Deas::RedirectHandler', route.handler_class_name
+      assert_not_nil route.handler_class
+    end
+
     should "allow defining any kind of route using #route" do
       subject.route(:options, '/get_info', 'GetInfo')
 
@@ -152,7 +163,7 @@ module Deas::Server
     end
 
     should "add and query helper modules using #template_helpers and #template_helper?" do
-      subject.template_helpers (helper_module = Module.new)
+      subject.template_helpers(helper_module = Module.new)
       assert subject.template_helper?(helper_module)
     end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -14,8 +14,8 @@ class Deas::SinatraRunner
     end
     subject{ @runner }
 
-    should have_instance_methods :run, :request, :response, :params, :logger,
-      :halt, :render, :session, :redirect, :redirect_to
+    should have_imeths :run, :request, :response, :params, :logger, :halt
+    should have_imeths :render, :session, :redirect
 
     should "return the sinatra_call's request with #request" do
       assert_equal @fake_sinatra_call.request, subject.request
@@ -56,13 +56,6 @@ class Deas::SinatraRunner
     should "call the sinatra_call's redirect method with #redirect" do
       return_value = catch(:halt){ subject.redirect('http://google.com') }
       expected = [ 302, { 'Location' => 'http://google.com' } ]
-
-      assert_equal expected, return_value
-    end
-
-    should "call the sinatra_call's redirect and to methods with #redirect_to" do
-      return_value = catch(:halt){ subject.redirect_to('/somewhere') }
-      expected = [ 302, { 'Location' => "http://test.local/somewhere" } ]
 
       assert_equal expected, return_value
     end


### PR DESCRIPTION
This adds a `redirect` helper for `Deas::Server`'s that allows
allows easily redirecting routes without having to define a
view handler. This is essentially a macro that builds the view
handler for the route and redirects in it's `run!` method.
