### PR TITLE
Return `RenderArgs` object when test runner renders

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -34,11 +34,11 @@ module Deas
       @sinatra_call.halt(*args)
     end
 
-    def render(name, options = nil, &block)
+    def render(template_name, options = nil, &block)
       options ||= {}
       options[:locals] = { :view => @handler }.merge(options[:locals] || {})
       options[:layout] ||= @handler_class.layouts
-      Deas::Template.new(@sinatra_call, name, options).render(&block)
+      Deas::Template.new(@sinatra_call, template_name, options).render(&block)
     end
 
     def redirect(*args)

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -32,12 +32,20 @@ module Deas
       throw(:halt, args)
     end
 
-    def render(*args, &block)
-      [ args, block ].compact.flatten
+    def render(template_name, options = nil, &block)
+      RenderArgs.new(template_name, options, block)
     end
 
-    def redirect(*args)
-      [ :redirect, args ].compact.flatten
+    def redirect(path, *halt_args)
+      RedirectArgs.new(path, halt_args)
+    end
+
+    RenderArgs = Struct.new(:template_name, :options, :block)
+
+    class RedirectArgs < Struct.new(:path, :halt_args)
+      def redirect?
+        true
+      end
     end
 
   end

--- a/test/unit/redirect_handler_tests.rb
+++ b/test/unit/redirect_handler_tests.rb
@@ -38,18 +38,20 @@ module Deas::RedirectHandler
     desc "when run"
 
     should "redirect to the path that it was build with" do
-      @response = test_runner(@handler_class).run
-      assert_equal [ :redirect, "/somewhere" ], @response
+      render_args = test_runner(@handler_class).run
+      assert_equal true,         render_args.redirect?
+      assert_equal '/somewhere', render_args.path
     end
 
     should "redirect to the path returned from instance evaling the proc" do
       path_proc = proc{ params['redirect_to'] }
       handler_class = Deas::RedirectHandler.new(&path_proc)
 
-      @response = test_runner(handler_class, {
+      render_args = test_runner(handler_class, {
         :params => { 'redirect_to' => '/go_here' }
       }).run
-      assert_equal [ :redirect, "/go_here" ], @response
+      assert_equal true,       render_args.redirect?
+      assert_equal '/go_here', render_args.path
     end
 
   end

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -28,9 +28,9 @@ module Deas::ViewHandler
     end
 
     should "be able to render templates" do
-      return_value = test_runner(RenderViewHandler).run
-      assert_equal "my_template",        return_value[0]
-      assert_equal({ :some => :option }, return_value[1])
+      render_args = test_runner(RenderViewHandler).run
+      assert_equal "my_template",        render_args.template_name
+      assert_equal({ :some => :option }, render_args.options)
     end
 
     should "allow specifying the layouts using #layout or #layouts" do


### PR DESCRIPTION
This adds a `RenderArgs` object that is returned when the test
runner `render` method is called. This is an easier to use
object than an array of arguments and makes the tests
easier to read.
