### PR TITLE
raise custom err if creating a new server without setting the `root`

### DIFF
--- a/lib/deas.rb
+++ b/lib/deas.rb
@@ -2,6 +2,7 @@ require 'ns-options'
 require 'pathname'
 
 require 'deas/version'
+require 'deas/exceptions'
 require 'deas/server'
 require 'deas/view_handler'
 

--- a/lib/deas/exceptions.rb
+++ b/lib/deas/exceptions.rb
@@ -1,0 +1,11 @@
+module Deas
+
+  Error = Class.new(RuntimeError)
+  ServerError = Class.new(Error)
+  ServerRootError = Class.new(ServerError) do
+    def message
+      "server `root` not set but required"
+    end
+  end
+
+end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -2,6 +2,7 @@ require 'ns-options'
 require 'ns-options/boolean'
 require 'pathname'
 require 'deas/template'
+require 'deas/exceptions'
 require 'deas/redirect_handler'
 require 'deas/route'
 require 'deas/sinatra_app'
@@ -15,7 +16,7 @@ module Deas::Server
     # Sinatra based options
     option :env,  String,   :default => 'development'
 
-    option :root,          Pathname
+    option :root,          Pathname, :required => true
     option :public_folder, Pathname
     option :views_folder,  Pathname
 
@@ -65,6 +66,7 @@ module Deas::Server
   module ClassMethods
 
     def new
+      raise Deas::ServerRootError if self.configuration.root.nil?
       Deas::SinatraApp.new(self.configuration)
     end
 

--- a/test/unit/exceptions_tests.rb
+++ b/test/unit/exceptions_tests.rb
@@ -1,0 +1,29 @@
+require 'assert'
+require 'deas/exceptions'
+
+module Deas
+
+  class ErrorTests < Assert::Context
+    desc "Deas"
+
+    should "provide an error exception that subclasses `RuntimeError" do
+      assert Deas::Error
+      assert_kind_of RuntimeError, Deas::Error.new
+    end
+
+    should "provide a server exception that subclasses `Error`" do
+      assert Deas::ServerError
+      assert_kind_of Deas::Error, Deas::ServerError.new
+    end
+
+    should "provide a server root exception that subclasses `ServerError`" do
+      assert Deas::ServerRootError
+
+      e = Deas::ServerRootError.new
+      assert_kind_of Deas::ServerError, e
+      assert_equal "server `root` not set but required", e.message
+    end
+
+  end
+
+end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -1,4 +1,5 @@
 require 'assert'
+require 'deas/exceptions'
 require 'deas/template'
 require 'deas/route'
 require 'deas/server'
@@ -24,6 +25,11 @@ module Deas::Server
     should have_imeths :init, :template_helpers, :template_helper?, :error
     should have_imeths :logger, :use, :set, :view_handler_ns, :verbose_logging
     should have_imeths :get, :post, :put, :patch, :delete, :route
+
+    should "complain if creating a new server with setting the `root`" do
+      assert_raises(Deas::ServerRootError){ subject.new }
+      assert_nothing_raised{ subject.root '/path/to/root'; subject.new }
+    end
 
     should "allow setting it's configuration options" do
       config = subject.configuration


### PR DESCRIPTION
First off this defines a bunch of deas-specific runtime error exception
classes.  This includes a `ServerRootError` class with a custom msg
that is intended to be raised when defining a server with no `root`.

The other part of this adds a check for a `nil` root when creating
a new server and raises the custom exception.

All this is to raise a friendly exception when (the only) required
configs are not set.  Right now `root` is the only setting required.

Before:

```
lib/deas/server.rb:47:in `initialize': undefined method `join' for nil:NilClass (NoMethodError)
```

After:

```
lib/deas/server.rb:69:in `new': server `root` not set but required (Deas::ServerRootError)
```

@jcredding this came up when I tried to whip up a vanilla Deas app for a quick test.  That error it originally raised wasn't helpful at all - thus this PR.  Ready for review.
