### PR TITLE
store the configured server `settings` as a Hash to prevent duplicates

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -33,7 +33,7 @@ module Deas::Server
     option :init_procs,      Array, :default => []
     option :logger,                 :default => proc{ Deas::NullLogger.new }
     option :middlewares,     Set,   :default => []
-    option :settings,        Array, :default => []
+    option :settings,        Hash,  :default => {}
     option :verbose_logging,        :default => true
     option :routes,          Array, :default => []
     option :view_handler_ns, String
@@ -147,8 +147,8 @@ module Deas::Server
       self.configuration.middlewares << args
     end
 
-    def set(*args)
-      self.configuration.settings << args
+    def set(name, value)
+      self.configuration.settings[name.to_sym] = value
     end
 
     def view_handler_ns(*args)

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -69,7 +69,7 @@ module Deas::Server
       assert_equal Set.new([ ['MyMiddleware'] ]), config.middlewares
 
       subject.set :testing_set_meth, 'it works!'
-      assert_equal [ [:testing_set_meth, 'it works!'] ], config.settings
+      assert_equal({ :testing_set_meth => 'it works!'}, config.settings)
 
       stdout_logger = Logger.new(STDOUT)
       subject.logger stdout_logger


### PR DESCRIPTION
No need to store these in an array and then apply and potentially
re-apply the same setting over and over.  If the user specifies
the same setting twice, the Hash will force that only the last
setting will be applied.

@jcredding more handling cleanups.  No behavior change.  Ready for review.
