### PR TITLE
adding "validation" to server configurations

### DIFF
--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -1,30 +1,11 @@
 require 'sinatra/base'
 require 'deas/error_handler'
-require 'deas/logging'
 
 module Deas
-
   module SinatraApp
 
     def self.new(server_config)
-      # the reason this is done here is b/c the below sinatra configuration is
-      # not considered valid until the init procs have been run and the routes
-      # have been constantized.
-      server_config.init_procs.each{ |p| p.call }
-      server_config.routes.each(&:constantize!)
-
-      # set the :erb :outvar setting if it hasn't been set.  this is used
-      # by template helpers and plugins and needs to be queryable.  the actual
-      # value doesn't matter - it just needs to be set
-      server_config.settings[:erb] ||= {}
-      server_config.settings[:erb][:outvar] ||= '@_out_buf'
-
-      # add the logging middleware args last.  This ensures that the logging
-      # happens just before the app gets the request and just after the app
-      # sends a response.
-      [*Deas::Logging.middleware(server_config.verbose_logging)].tap do |mw_args|
-        server_config.middlewares << mw_args
-      end
+      server_config.validate!
 
       Sinatra.new do
 
@@ -69,5 +50,4 @@ module Deas
     end
 
   end
-
 end

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -1,0 +1,146 @@
+require 'assert'
+require 'set'
+require 'test/support/view_handlers'
+require 'deas/exceptions'
+require 'deas/template'
+require 'deas/server'
+
+class Deas::Server::Configuration
+
+  class BaseTests < Assert::Context
+    desc "Deas::Server::Configuration"
+    setup do
+      @configuration = Deas::Server::Configuration.new
+      @configuration.root = TEST_SUPPORT_ROOT
+    end
+    subject{ @configuration }
+
+    # sinatra related options
+    should have_imeths :env, :root, :public_folder, :views_folder
+    should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
+    should have_imeths :static_files, :reload_templates
+
+    # server handling options
+    should have_imeths :error_procs, :init_procs, :logger, :middlewares, :settings
+    should have_imeths :verbose_logging, :routes, :view_handler_ns
+
+    should have_reader :template_helpers
+    should have_imeths :valid?, :validate!
+
+    should "default the env to 'development'" do
+      assert_equal 'development', subject.env
+    end
+
+    should "default the public and views folders based off the root" do
+      assert_equal subject.root.join('public'), subject.public_folder
+      assert_equal subject.root.join('views'), subject.views_folder
+    end
+
+    should "default the Sinatra flags" do
+      assert_equal false, subject.dump_errors
+      assert_equal true,  subject.method_override
+      assert_equal false, subject.sessions
+      assert_equal false, subject.show_exceptions
+      assert_equal true,  subject.static_files
+      assert_equal false, subject.reload_templates
+    end
+
+    should "default the handling options" do
+      assert_empty subject.error_procs
+      assert_empty subject.init_procs
+      assert_instance_of Deas::NullLogger, subject.logger
+      assert_empty subject.middlewares
+      assert_empty subject.settings
+      assert_equal true, subject.verbose_logging
+      assert_empty subject.routes
+      assert_nil   subject.view_handler_ns
+      assert_empty subject.template_helpers
+    end
+
+    should "build a template scope including its template helpers" do
+      config = Deas::Server::Configuration.new
+      config.template_helpers << (helper_module = Module.new)
+
+      assert_includes Deas::Template::Scope, config.template_scope.ancestors
+      assert_includes helper_module, config.template_scope.included_modules
+    end
+
+    should "not be valid until validate! has been run" do
+      assert_not subject.valid?
+
+      subject.validate!
+      assert subject.valid?
+    end
+
+    should "complain if validating and `root` isn't set" do
+      config = Deas::Server::Configuration.new
+      assert_raises(Deas::ServerRootError){ config.validate! }
+      assert_nothing_raised{ config.root '/path/to/root'; config.validate! }
+    end
+
+  end
+
+  class ValidationTests < BaseTests
+    desc "when successfully validated"
+    setup do
+      @initialized = false
+      @other_initialized = false
+      @route = Deas::Route.new(:get, '/something', 'TestViewHandler')
+
+      @configuration = Deas::Server::Configuration.new.tap do |c|
+        c.env              = 'staging'
+        c.root             = 'path/to/somewhere'
+        c.dump_errors      = true
+        c.method_override  = false
+        c.sessions         = false
+        c.show_exceptions  = true
+        c.static           = true
+        c.reload_templates = true
+        c.routes           = [ @route ]
+        c.middlewares      = [ ['MyMiddleware'] ]
+      end
+      @configuration.init_procs << proc{ @initialized = true }
+      @configuration.init_procs << proc{ @other_initialized = true }
+    end
+
+    should "call init procs" do
+      assert_equal false, @initialized
+      assert_equal false, @other_initialized
+
+      subject.validate!
+
+      assert_equal true, @initialized
+      assert_equal true, @other_initialized
+    end
+
+    should "call constantize! on all routes" do
+      assert_nil @route.handler_class
+
+      subject.validate!
+
+      assert_equal TestViewHandler, @route.handler_class
+    end
+
+    should "default the :erb :outvar setting in the SinatraApp it creates" do
+      assert_nil subject.settings[:erb]
+
+      subject.validate!
+
+      assert_kind_of ::Hash, subject.settings[:erb]
+      assert_equal '@_out_buf', subject.settings[:erb][:outvar]
+    end
+
+    should "add the Deas::Logging middleware to the end of the middlewares" do
+      assert subject.verbose_logging
+      assert_equal 1, subject.middlewares.size
+      assert_not_equal [Deas::VerboseLogging], subject.middlewares.last
+
+      subject.validate!
+
+      assert_equal 2, subject.middlewares.size
+      assert_equal [Deas::VerboseLogging], subject.middlewares.last
+    end
+
+  end
+
+end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -1,10 +1,8 @@
 require 'assert'
 require 'set'
-require 'deas/exceptions'
-require 'deas/template'
+require 'logger'
 require 'deas/route'
 require 'deas/server'
-require 'logger'
 
 module Deas::Server
 
@@ -61,7 +59,7 @@ module Deas::Server
       assert_equal true, config.reload_templates
 
       subject.use 'MyMiddleware'
-      assert_equal Set.new([ ['MyMiddleware'] ]), config.middlewares
+      assert_equal [ ['MyMiddleware'] ], config.middlewares
 
       subject.set :testing_set_meth, 'it works!'
       assert_equal({ :testing_set_meth => 'it works!'}, config.settings)
@@ -167,76 +165,6 @@ module Deas::Server
     should "add and query helper modules" do
       subject.template_helpers(helper_module = Module.new)
       assert subject.template_helper?(helper_module)
-    end
-
-    should "complain if creating a new server with setting the `root`" do
-      assert_raises(Deas::ServerRootError){ subject.new }
-      assert_nothing_raised{ subject.root '/path/to/root'; subject.new }
-    end
-
-    should "default the :erb :outvar setting in the SinatraApp it creates" do
-      subject.root '/path/to/root'
-      assert_equal '@_out_buf', subject.new.settings.erb[:outvar]
-    end
-
-  end
-
-  class ConfigurationTests < BaseTests
-    desc "Configuration"
-    setup do
-      @configuration = Deas::Server::Configuration.new
-    end
-    subject{ @configuration }
-
-    # sinatra related options
-    should have_imeths :env, :root, :public_folder, :views_folder
-    should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
-    should have_imeths :static_files, :reload_templates
-
-    # server handling options
-    should have_imeths :error_procs, :init_procs, :logger, :middlewares, :settings
-    should have_imeths :verbose_logging, :routes, :view_handler_ns
-
-    should have_reader :template_helpers
-
-    should "default the env to 'development'" do
-      assert_equal 'development', subject.env
-    end
-
-    should "default the public and views folders based off the root" do
-      subject.root = TEST_SUPPORT_ROOT
-
-      assert_equal subject.root.join('public'), subject.public_folder
-      assert_equal subject.root.join('views'), subject.views_folder
-    end
-
-    should "default the Sinatra flags" do
-      assert_equal false, subject.dump_errors
-      assert_equal true,  subject.method_override
-      assert_equal false, subject.sessions
-      assert_equal false, subject.show_exceptions
-      assert_equal true,  subject.static_files
-      assert_equal false, subject.reload_templates
-    end
-
-    should "default the handling options" do
-      assert_empty subject.error_procs
-      assert_empty subject.init_procs
-      assert_instance_of Deas::NullLogger, subject.logger
-      assert_empty subject.middlewares
-      assert_empty subject.settings
-      assert_equal true, subject.verbose_logging
-      assert_empty subject.routes
-      assert_nil   subject.view_handler_ns
-      assert_empty subject.template_helpers
-    end
-
-    should "build a template scope including its template helpers" do
-      config = Deas::Server::Configuration.new
-      config.template_helpers << (helper_module = Module.new)
-
-      assert_includes Deas::Template::Scope, config.template_scope.ancestors
-      assert_includes helper_module, config.template_scope.included_modules
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -26,23 +26,12 @@ module Deas::SinatraApp
     end
     subject{ @sinatra_app }
 
+    should "ensure its config is valid" do
+      assert @configuration.valid?
+    end
+
     should "be a kind of Sinatra::Base" do
       assert_equal Sinatra::Base, subject.superclass
-    end
-
-    should "call init procs when initialized" do
-      initialized = false
-      other_initialized = false
-      @configuration.init_procs << proc{ initialized = true }
-      @configuration.init_procs << proc{ other_initialized = true }
-      @sinatra_app = Deas::SinatraApp.new(@configuration)
-
-      assert_equal true, initialized
-      assert_equal true, other_initialized
-    end
-
-    should "call constantize! on all routes" do
-      assert_equal TestViewHandler, @route.handler_class
     end
 
     should "have it's configuration set based on the server configuration" do


### PR DESCRIPTION
This is born out of the `SinatraApp` needing to ensure its given
configuration  is valid.  With recent refactors a bunch of logic
has been accumulating in a set of code the SinatraApp `new` method
was calling before it created the Sinatra app.

Essentially the method needed to ensure that the config was valid.
But the configuration itself should know what that means - it is not
the responsibility of the SinatraApp to do all the things to make
a configuration valid.

So this moves all the validation logic into the configuration class,
adds the `valid?` and `validate!` methods to query and run the logic,
and then updates the server and sinatra app config handling to ensure
the validation gets run.

The result is still one config per server but now the configuration
can easily be validated by the sinatra app.

I reorganized the tests a bit.  I moved the configuration tests into
their own file as that logic has grown substantially.  With this
design, I was also able to add a formal unit test for the adding of the
Logging middleware.  Before this had only been tested implicitly by the
rack system tests.

@jcredding ready for review.  I'm gonna validate in some live scenarios and if all is well I'll go ahead and merge so I can progress other efforts - heads up!
