### PR TITLE
Change Deas usage of Sinatra `show_exceptions` setting

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -7,6 +7,7 @@ require 'deas/template'
 require 'deas/logging'
 require 'deas/redirect_handler'
 require 'deas/route'
+require 'deas/show_exceptions'
 require 'deas/sinatra_app'
 
 module Deas; end
@@ -77,9 +78,10 @@ module Deas::Server
       self.settings[:erb] ||= {}
       self.settings[:erb][:outvar] ||= '@_out_buf'
 
-      # add the logging middleware args last.  This ensures that the logging
-      # happens just before the app gets the request and just after the app
-      # sends a response.
+      # append the show exceptions and loggine middlewares last.  This ensures
+      # that the logging and exception showing happens just before the app gets
+      # the request and just after the app sends a response.
+      self.middlewares << [Deas::ShowExceptions] if self.show_exceptions
       [*Deas::Logging.middleware(self.verbose_logging)].tap do |mw_args|
         self.middlewares << mw_args
       end

--- a/lib/deas/show_exceptions.rb
+++ b/lib/deas/show_exceptions.rb
@@ -1,0 +1,56 @@
+require 'rack/utils'
+
+module Deas
+
+  class ShowExceptions
+
+    def initialize(app)
+      @app = app
+    end
+
+    # The Rack call interface. The receiver acts as a prototype and runs
+    # each request in a clone object unless the +rack.run_once+ variable is
+    # set in the environment. Ripped from:
+    # http://github.com/rtomayko/rack-cache/blob/master/lib/rack/cache/context.rb
+    def call(env)
+      if env['rack.run_once']
+        call! env
+      else
+        clone.call! env
+      end
+    end
+
+    # The real Rack call interface.
+    def call!(env)
+      status, headers, body = @app.call(env)
+      if error = env['sinatra.error']
+        error_body = Body.new(error)
+
+        headers['Content-Length'] = error_body.size.to_s
+        headers['Content-Type'] = error_body.mime_type.to_s
+        body = [error_body.content]
+      end
+      [ status, headers, body ]
+    end
+
+    class Body
+      def initialize(error)
+        @error = error
+      end
+
+      def content
+        @content ||= "#{@error.class}: #{@error.message}\n#{@error.backtrace.join("\n")}"
+      end
+
+      def size
+        @size ||= Rack::Utils.bytesize(self.content)
+      end
+
+      def mime_type
+        @mime_type ||= "text/plain"
+      end
+    end
+
+  end
+
+end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -19,10 +19,15 @@ module Deas
         set :dump_errors,      server_config.dump_errors
         set :method_override,  server_config.method_override
         set :sessions,         server_config.sessions
-        set :show_exceptions,  server_config.show_exceptions
         set :static,           server_config.static_files
         set :reload_templates, server_config.reload_templates
         set :logging,          false
+
+        # raise_errors and show_exceptions prevent Deas error handlers from
+        # being called and Deas' logging doesn't finish. They should always be
+        # false.
+        set :raise_errors,     false
+        set :show_exceptions,  false
 
         # custom settings
         set :deas_template_scope, server_config.template_scope

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -35,6 +35,23 @@ class DeasTestServer
 
 end
 
+class DeasDevServer
+  include Deas::Server
+
+  # this server mimics a server in a "development" mode, that is, it has
+  # show_exceptions set to true
+
+  root TEST_SUPPORT_ROOT
+
+  logger TEST_LOGGER
+  verbose_logging true
+
+  show_exceptions true
+
+  get  '/error', 'ErrorHandler'
+
+end
+
 class ShowHandler
   include Deas::ViewHandler
 

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -130,15 +130,17 @@ class Deas::Server::Configuration
       assert_equal '@_out_buf', subject.settings[:erb][:outvar]
     end
 
-    should "add the Deas::Logging middleware to the end of the middlewares" do
+    should "add the Logging and ShowExceptions middleware to the end" do
+      num_middlewares = subject.middlewares.size
       assert subject.verbose_logging
-      assert_equal 1, subject.middlewares.size
-      assert_not_equal [Deas::VerboseLogging], subject.middlewares.last
+      assert_not_equal [Deas::ShowExceptions], subject.middlewares[-2]
+      assert_not_equal [Deas::VerboseLogging], subject.middlewares[-1]
 
       subject.validate!
 
-      assert_equal 2, subject.middlewares.size
-      assert_equal [Deas::VerboseLogging], subject.middlewares.last
+      assert_equal (num_middlewares+2), subject.middlewares.size
+      assert_equal [Deas::ShowExceptions], subject.middlewares[-2]
+      assert_equal [Deas::VerboseLogging], subject.middlewares[-1]
     end
 
   end

--- a/test/unit/show_exceptions_tests.rb
+++ b/test/unit/show_exceptions_tests.rb
@@ -1,0 +1,36 @@
+require 'assert'
+require 'rack/utils'
+require 'deas/show_exceptions'
+
+class Deas::ShowExceptions
+
+  class BaseTests < Assert::Context
+    desc "Deas::ShowExceptions"
+    setup do
+      exception = nil
+      begin; raise 'test'; rescue Exception => exception; end
+      @app = proc do |env|
+        env['sinatra.error'] = exception
+        [ 500, {}, [] ]
+      end
+      @exception = exception
+      @show_exceptions = Deas::ShowExceptions.new(@app)
+    end
+    subject{ @show_exceptions }
+
+    should have_imeths :call, :call!
+
+    should "return a body that contains details about the exception" do
+      status, headers, body = subject.call({})
+      expected_body = "#{@exception.class}: #{@exception.message}\n" \
+                      "#{@exception.backtrace.join("\n")}"
+      expected_body_size = Rack::Utils.bytesize(expected_body).to_s
+
+      assert_equal expected_body_size, headers['Content-Length']
+      assert_equal "text/plain",       headers['Content-Type']
+      assert_equal [expected_body],    body
+    end
+
+  end
+
+end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -41,13 +41,16 @@ module Deas::SinatraApp
         assert_equal 'path/to/somewhere/public', settings.public_folder.to_s
         assert_equal 'path/to/somewhere/views',  settings.views.to_s
         assert_equal true,                       settings.dump_errors
-        assert_equal false,                      settings.logging
         assert_equal false,                      settings.method_override
         assert_equal false,                      settings.sessions
-        assert_equal true,                       settings.show_exceptions
         assert_equal true,                       settings.static
         assert_equal true,                       settings.reload_templates
         assert_instance_of Deas::NullLogger,     settings.logger
+
+        # settings that are set but can't be changed
+        assert_equal false, settings.logging
+        assert_equal false, settings.raise_errors
+        assert_equal false, settings.show_exceptions
       end
     end
 


### PR DESCRIPTION
Sinatra's `show_exceptions` setting (and it's `raise_errors`
setting) are not compatible with Deas. They interfere with Deas'
logging and prevent it's error handler's from running. This is
odd behavior and is confusing when encountered in development.
To fix this, `show_exceptions` and `raise_errors` are always
disabled. Deas will now add a middleware that will show
exceptions similar to how Sinatra's `show_exceptions` worked if
the `show_exceptions` Deas option is configured for a server.
