### PR TITLE
template engine: look in `:views` option first, fallback to sinatra views

### DIFF
--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -18,7 +18,7 @@ module Deas
     def engine(template_name)
       return 'erb' if @sinatra_call.settings.views.nil?
 
-      views_path = Pathname.new(@sinatra_call.settings.views)
+      views_path = Pathname.new(@options[:views] || @sinatra_call.settings.views)
       template = Dir.glob("#{views_path.join(template_name.to_s)}.*").first.to_s
       File.extname(template)[1..-1] || 'erb'
     end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -23,25 +23,25 @@ class Deas::Template
     end
 
     should "know a named template's render engine" do
-      views_exist = FakeApp.new(:views => TEST_SUPPORT_ROOT.join('views'))
-      template = Deas::Template.new(views_exist, 'whatever')
+      fake_app = FakeApp.new(:views => TEST_SUPPORT_ROOT.join('views'))
 
-      assert_equal 'erb',    template.engine('layout1')
-      assert_equal 'haml',   template.engine('haml_layout1')
-      assert_equal 'other',  template.engine('some.html.file')
-      assert_equal 'engine', template.engine('some_file')
-      assert_equal 'erb',    template.engine('some_no_engine_extension')
-      assert_equal 'erb',    template.engine('does_not_exist')
+      views_exist = Deas::Template.new(fake_app, 'whatever')
+      assert_equal 'erb',    views_exist.engine('layout1')
+      assert_equal 'haml',   views_exist.engine('haml_layout1')
+      assert_equal 'other',  views_exist.engine('some.html.file')
+      assert_equal 'engine', views_exist.engine('some_file')
+      assert_equal 'erb',    views_exist.engine('some_no_engine_extension')
+      assert_equal 'erb',    views_exist.engine('does_not_exist')
 
-      views_no_exist = FakeApp.new(:views => '/does/not/exist')
-      template_no_exist = Deas::Template.new(views_no_exist, 'whatever')
-
-      assert_equal 'erb', template_no_exist.engine('layout1')
-      assert_equal 'erb', template_no_exist.engine('haml_layout1')
-      assert_equal 'erb', template_no_exist.engine('some.html.file')
-      assert_equal 'erb', template_no_exist.engine('some_file')
-      assert_equal 'erb', template_no_exist.engine('some_no_engine_extension')
-      assert_equal 'erb', template_no_exist.engine('does_not_exist')
+      views_no_exist = Deas::Template.new(fake_app, 'whatever', {
+        :views => '/does/not/exist'
+      })
+      assert_equal 'erb', views_no_exist.engine('layout1')
+      assert_equal 'erb', views_no_exist.engine('haml_layout1')
+      assert_equal 'erb', views_no_exist.engine('some.html.file')
+      assert_equal 'erb', views_no_exist.engine('some_file')
+      assert_equal 'erb', views_no_exist.engine('some_no_engine_extension')
+      assert_equal 'erb', views_no_exist.engine('does_not_exist')
 
     end
 


### PR DESCRIPTION
This alters the algorithm for looking up a named-template's rendering
engine.  Before, if the template had a custom `:views` option, it
would be ignored in this algorithm.

This alters to first look in the templates `:views` option and fallback
to the main sinatra `:views` setting if no custom option is specified.
This enables plugins to define their own template files and have their
engine properly be detected.

No major behavior changes to the engine rendering scheme - this is
just a patch to the previous effort.

@jcredding ready for review.
