### PR TITLE
content type and charset handling

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -18,6 +18,10 @@ module Deas
       raise NotImplementedError
     end
 
+    def content_type(*args)
+      raise NotImplementedError
+    end
+
     def render(*args)
       raise NotImplementedError
     end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -31,14 +31,15 @@ module Deas::Server
     option :reload_templates, NsOptions::Boolean, :default => false
 
     # server handling options
-    option :error_procs,     Array, :default => []
-    option :init_procs,      Array, :default => []
-    option :logger,                 :default => proc{ Deas::NullLogger.new }
-    option :middlewares,     Array, :default => []
-    option :settings,        Hash,  :default => {}
-    option :verbose_logging,        :default => true
-    option :routes,          Array, :default => []
+    option :error_procs,     Array,  :default => []
+    option :init_procs,      Array,  :default => []
+    option :logger,                  :default => proc{ Deas::NullLogger.new }
+    option :middlewares,     Array,  :default => []
+    option :settings,        Hash,   :default => {}
+    option :verbose_logging,         :default => true
+    option :routes,          Array,  :default => []
     option :view_handler_ns, String
+    option :default_charset, String, :default => 'utf-8'
 
     attr_reader :template_helpers
 
@@ -190,6 +191,10 @@ module Deas::Server
 
     def logger(*args)
       self.configuration.logger *args
+    end
+
+    def default_charset(*args)
+      self.configuration.default_charset *args
     end
 
     def get(path, handler_class_name)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -30,9 +30,10 @@ module Deas
         set :show_exceptions,  false
 
         # custom settings
-        set :deas_template_scope, server_config.template_scope
-        set :deas_error_procs,    server_config.error_procs
-        set :logger,              server_config.logger
+        set :deas_template_scope,  server_config.template_scope
+        set :deas_error_procs,     server_config.error_procs
+        set :deas_default_charset, server_config.default_charset
+        set :logger,               server_config.logger
 
         server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -38,6 +38,12 @@ module Deas
       @sinatra_call.redirect(*args)
     end
 
+    def content_type(value, opts=nil)
+      @sinatra_call.content_type(value, {
+        :charset => @sinatra_call.settings.deas_default_charset
+      }.merge(opts || {}))
+    end
+
     def render(template_name, options = nil, &block)
       options ||= {}
       options[:locals] = { :view => @handler }.merge(options[:locals] || {})

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -40,6 +40,12 @@ module Deas
       def redirect?; true; end
     end
 
+    def content_type(value, opts={})
+      ContentTypeArgs.new(value, opts)
+    end
+
+    ContentTypeArgs = Struct.new(:value, :opts)
+
     def render(template_name, options = nil, &block)
       RenderArgs.new(template_name, options, block)
     end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -47,8 +47,9 @@ module Deas
 
     # Helpers
 
-    def halt(*args);     @deas_runner.halt(*args);     end
-    def redirect(*args); @deas_runner.redirect(*args); end
+    def halt(*args);         @deas_runner.halt(*args);         end
+    def redirect(*args);     @deas_runner.redirect(*args);     end
+    def content_type(*args); @deas_runner.content_type(*args); end
 
     def render(*args, &block)
       @deas_runner.render(*args, &block)

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -14,12 +14,21 @@ class FakeSinatraCall
     @session  = @request.session
     @response = FakeResponse.new
     @settings = OpenStruct.new(settings.merge({
-      :deas_template_scope => Deas::Template::Scope
+      :deas_template_scope => Deas::Template::Scope,
+      :deas_default_charset => 'utf-8'
     }))
   end
 
   def halt(*args)
     throw :halt, args
+  end
+
+  def redirect(*args)
+    halt 302, { 'Location' => args[0] }
+  end
+
+  def content_type(*args)
+    args
   end
 
   # return the template name for each nested calls
@@ -29,10 +38,6 @@ class FakeSinatraCall
     else
       [ name, opts ]
     end
-  end
-
-  def redirect(*args)
-    halt 302, { 'Location' => args[0] }
   end
 
 end

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -61,3 +61,12 @@ class HaltViewHandler
   end
 
 end
+
+class ContentTypeViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    content_type 'text/plain', :charset => 'latin1'
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -13,17 +13,22 @@ class Deas::Runner
 
     should have_reader  :app_settings
     should have_readers :request, :response, :params, :logger, :session
+    should have_imeths :halt, :redirect, :content_type, :render
 
     should "raise NotImplementedError with #halt" do
       assert_raises(NotImplementedError){ subject.halt }
     end
 
-    should "raise NotImplementedError with #render" do
-      assert_raises(NotImplementedError){ subject.render }
-    end
-
     should "raise NotImplementedError with #redirect" do
       assert_raises(NotImplementedError){ subject.redirect }
+    end
+
+    should "raise NotImplementedError with #content_type" do
+      assert_raises(NotImplementedError){ subject.content_type }
+    end
+
+    should "raise NotImplementedError with #render" do
+      assert_raises(NotImplementedError){ subject.render }
     end
 
   end

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -22,7 +22,7 @@ class Deas::Server::Configuration
 
     # server handling options
     should have_imeths :error_procs, :init_procs, :logger, :middlewares, :settings
-    should have_imeths :verbose_logging, :routes, :view_handler_ns
+    should have_imeths :verbose_logging, :routes, :view_handler_ns, :default_charset
 
     should have_reader :template_helpers
     should have_imeths :valid?, :validate!
@@ -76,6 +76,10 @@ class Deas::Server::Configuration
       config = Deas::Server::Configuration.new
       assert_raises(Deas::ServerRootError){ config.validate! }
       assert_nothing_raised{ config.root '/path/to/root'; config.validate! }
+    end
+
+    should "use `utf-8` as the default_charset by default" do
+      assert_equal 'utf-8', subject.default_charset
     end
 
   end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -23,6 +23,7 @@ module Deas::Server
     # DSL for server handling
     should have_imeths :init, :error, :template_helpers, :template_helper?
     should have_imeths :use, :set, :view_handler_ns, :verbose_logging, :logger
+    should have_imeths :default_charset
     should have_imeths :get, :post, :put, :patch, :delete, :redirect, :route
 
     should "allow setting it's configuration options" do
@@ -79,6 +80,9 @@ module Deas::Server
       stdout_logger = Logger.new(STDOUT)
       subject.logger stdout_logger
       assert_equal stdout_logger, config.logger
+
+      subject.default_charset 'latin1'
+      assert_equal 'latin1', config.default_charset
     end
 
     should "add and query helper modules" do

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -15,7 +15,7 @@ class Deas::SinatraRunner
     subject{ @runner }
 
     should have_imeths :run, :request, :response, :params, :logger, :session
-    should have_imeths :halt, :redirect, :render
+    should have_imeths :halt, :redirect, :content_type, :render
 
     should "return the sinatra_call's request with #request" do
       assert_equal @fake_sinatra_call.request, subject.request
@@ -42,6 +42,21 @@ class Deas::SinatraRunner
       assert_equal [ 'test' ], return_value
     end
 
+    should "call the sinatra_call's redirect method with #redirect" do
+      return_value = catch(:halt){ subject.redirect('http://google.com') }
+      expected = [ 302, { 'Location' => 'http://google.com' } ]
+
+      assert_equal expected, return_value
+    end
+
+    should "call the sinatra_call's content_type method using the default_charset" do
+      expected = @fake_sinatra_call.content_type('text/plain', :charset => 'utf-8')
+      assert_equal expected, subject.content_type('text/plain')
+
+      expected = @fake_sinatra_call.content_type('text/plain', :charset => 'latin1')
+      assert_equal expected, subject.content_type('text/plain', :charset => 'latin1')
+    end
+
     should "render the template with a :view local and the handler layouts with #render" do
       exp_handler = FlagViewHandler.new(subject)
       exp_layouts = FlagViewHandler.layouts
@@ -51,13 +66,6 @@ class Deas::SinatraRunner
       }).render
 
       assert_equal exp_result, subject.render('index')
-    end
-
-    should "call the sinatra_call's redirect method with #redirect" do
-      return_value = catch(:halt){ subject.redirect('http://google.com') }
-      expected = [ 302, { 'Location' => 'http://google.com' } ]
-
-      assert_equal expected, return_value
     end
 
   end

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -173,4 +173,17 @@ module Deas::ViewHandler
 
   end
 
+  class ContentTypeTests < BaseTests
+    desc "content_type"
+
+    should "should set the response content_type/charset" do
+      runner = test_runner(ContentTypeViewHandler)
+      content_type_args = runner.run
+
+      assert_equal 'text/plain', content_type_args.value
+      assert_equal({:charset => 'latin1'}, content_type_args.opts)
+    end
+
+  end
+
 end


### PR DESCRIPTION
First off, this adds a new server DSL-method/config `default_charset`.
Use this to override the default value `'utf-8'`.

Second, provides a `content_type` method ot the view handler that
will use the `default_charset` if a specific charset is not given.

@jcredding ready for review.
