### PR TITLE
status handling

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -22,6 +22,10 @@ module Deas
       raise NotImplementedError
     end
 
+    def status(*args)
+      raise NotImplementedError
+    end
+
     def render(*args)
       raise NotImplementedError
     end

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -44,6 +44,10 @@ module Deas
       }.merge(opts || {}))
     end
 
+    def status(*args)
+      @sinatra_call.status(*args)
+    end
+
     def render(template_name, options = nil, &block)
       options ||= {}
       options[:locals] = { :view => @handler }.merge(options[:locals] || {})

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -46,6 +46,12 @@ module Deas
 
     ContentTypeArgs = Struct.new(:value, :opts)
 
+    def status(value)
+      StatusArgs.new(value)
+    end
+
+    StatusArgs = Struct.new(:value)
+
     def render(template_name, options = nil, &block)
       RenderArgs.new(template_name, options, block)
     end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -50,6 +50,7 @@ module Deas
     def halt(*args);         @deas_runner.halt(*args);         end
     def redirect(*args);     @deas_runner.redirect(*args);     end
     def content_type(*args); @deas_runner.content_type(*args); end
+    def status(*args);       @deas_runner.status(*args);       end
 
     def render(*args, &block)
       @deas_runner.render(*args, &block)

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -27,9 +27,8 @@ class FakeSinatraCall
     halt 302, { 'Location' => args[0] }
   end
 
-  def content_type(*args)
-    args
-  end
+  def content_type(*args); args; end
+  def status(*args);       args; end
 
   # return the template name for each nested calls
   def erb(name, opts, &block)

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -70,3 +70,12 @@ class ContentTypeViewHandler
   end
 
 end
+
+class StatusViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    status 422
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -13,7 +13,7 @@ class Deas::Runner
 
     should have_reader  :app_settings
     should have_readers :request, :response, :params, :logger, :session
-    should have_imeths :halt, :redirect, :content_type, :render
+    should have_imeths :halt, :redirect, :content_type, :status, :render
 
     should "raise NotImplementedError with #halt" do
       assert_raises(NotImplementedError){ subject.halt }
@@ -25,6 +25,10 @@ class Deas::Runner
 
     should "raise NotImplementedError with #content_type" do
       assert_raises(NotImplementedError){ subject.content_type }
+    end
+
+    should "raise NotImplementedError with #status" do
+      assert_raises(NotImplementedError){ subject.status }
     end
 
     should "raise NotImplementedError with #render" do

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -15,7 +15,7 @@ class Deas::SinatraRunner
     subject{ @runner }
 
     should have_imeths :run, :request, :response, :params, :logger, :session
-    should have_imeths :halt, :redirect, :content_type, :render
+    should have_imeths :halt, :redirect, :content_type, :status, :render
 
     should "return the sinatra_call's request with #request" do
       assert_equal @fake_sinatra_call.request, subject.request
@@ -55,6 +55,10 @@ class Deas::SinatraRunner
 
       expected = @fake_sinatra_call.content_type('text/plain', :charset => 'latin1')
       assert_equal expected, subject.content_type('text/plain', :charset => 'latin1')
+    end
+
+    should "call the sinatra_call's status to set the response status" do
+      assert_equal [422], subject.status(422)
     end
 
     should "render the template with a :view local and the handler layouts with #render" do

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -186,4 +186,16 @@ module Deas::ViewHandler
 
   end
 
+  class StatusTests < BaseTests
+    desc "status"
+
+    should "should set the response status" do
+      runner = test_runner(StatusViewHandler)
+      status_args = runner.run
+
+      assert_equal 422, status_args.value
+    end
+
+  end
+
 end


### PR DESCRIPTION
This adds a `status` method available to the handler for manually
setting the response status.  This is implemented by pipeing the
call to the underying sinatra `status` method.  It uses the same
API and returns/performs the same function.

@jcredding more of the same - ready for review.
