### PR TITLE
headers handling

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -10,25 +10,12 @@ module Deas
       @handler = @handler_class.new(self)
     end
 
-    def halt(*args)
-      raise NotImplementedError
-    end
-
-    def redirect(*args)
-      raise NotImplementedError
-    end
-
-    def content_type(*args)
-      raise NotImplementedError
-    end
-
-    def status(*args)
-      raise NotImplementedError
-    end
-
-    def render(*args)
-      raise NotImplementedError
-    end
+    def halt(*args);         raise NotImplementedError; end
+    def redirect(*args);     raise NotImplementedError; end
+    def content_type(*args); raise NotImplementedError; end
+    def status(*args);       raise NotImplementedError; end
+    def headers(*args);      raise NotImplementedError; end
+    def render(*args);       raise NotImplementedError; end
 
   end
 

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -48,6 +48,10 @@ module Deas
       @sinatra_call.status(*args)
     end
 
+    def headers(*args)
+      @sinatra_call.headers(*args)
+    end
+
     def render(template_name, options = nil, &block)
       options ||= {}
       options[:locals] = { :view => @handler }.merge(options[:locals] || {})

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -52,6 +52,12 @@ module Deas
 
     StatusArgs = Struct.new(:value)
 
+    def headers(value)
+      HeadersArgs.new(value)
+    end
+
+    HeadersArgs = Struct.new(:value)
+
     def render(template_name, options = nil, &block)
       RenderArgs.new(template_name, options, block)
     end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -51,6 +51,7 @@ module Deas
     def redirect(*args);     @deas_runner.redirect(*args);     end
     def content_type(*args); @deas_runner.content_type(*args); end
     def status(*args);       @deas_runner.status(*args);       end
+    def headers(*args);      @deas_runner.headers(*args);      end
 
     def render(*args, &block)
       @deas_runner.render(*args, &block)

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -29,6 +29,7 @@ class FakeSinatraCall
 
   def content_type(*args); args; end
   def status(*args);       args; end
+  def headers(*args);      args; end
 
   # return the template name for each nested calls
   def erb(name, opts, &block)

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -79,3 +79,14 @@ class StatusViewHandler
   end
 
 end
+
+class HeadersViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    headers \
+      'other' => "other",
+      'a-header' => 'some value'
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -31,6 +31,10 @@ class Deas::Runner
       assert_raises(NotImplementedError){ subject.status }
     end
 
+    should "raise NotImplementedError with #headers" do
+      assert_raises(NotImplementedError){ subject.headers }
+    end
+
     should "raise NotImplementedError with #render" do
       assert_raises(NotImplementedError){ subject.render }
     end

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -61,6 +61,14 @@ class Deas::SinatraRunner
       assert_equal [422], subject.status(422)
     end
 
+    should "call the sinatra_call's status to set the response status" do
+      exp_headers = {
+        'a-header' => 'some value',
+        'other'    => 'other'
+      }
+      assert_equal [exp_headers], subject.headers(exp_headers)
+    end
+
     should "render the template with a :view local and the handler layouts with #render" do
       exp_handler = FlagViewHandler.new(subject)
       exp_layouts = FlagViewHandler.layouts

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -198,4 +198,20 @@ module Deas::ViewHandler
 
   end
 
+  class HeadersTests < BaseTests
+    desc "headers"
+
+    should "should set the response status" do
+      runner = test_runner(HeadersViewHandler)
+      headers_args = runner.run
+      exp_headers = {
+        'a-header' => 'some value',
+        'other'    => 'other'
+      }
+
+      assert_equal exp_headers, headers_args.value
+    end
+
+  end
+
 end


### PR DESCRIPTION
This adds a `headers` method available to the handler for manually
setting the response headers.  This is implemented by pipeing the
call to the underying sinatra `headers` method.  It uses the same
API and returns/performs the same function.

@jcredding more of the same - ready for review.
