### PR TITLE
show exceptions: handle the `nil` exception backtrace edge case

### DIFF
--- a/lib/deas/show_exceptions.rb
+++ b/lib/deas/show_exceptions.rb
@@ -34,12 +34,9 @@ module Deas
     end
 
     class Body
-      def initialize(error)
-        @error = error
-      end
-
-      def content
-        @content ||= "#{@error.class}: #{@error.message}\n#{@error.backtrace.join("\n")}"
+      attr_reader :content
+      def initialize(e)
+        @content ||= "#{e.class}: #{e.message}\n#{(e.backtrace || []).join("\n")}"
       end
 
       def size

--- a/test/unit/show_exceptions_tests.rb
+++ b/test/unit/show_exceptions_tests.rb
@@ -7,11 +7,10 @@ class Deas::ShowExceptions
   class BaseTests < Assert::Context
     desc "Deas::ShowExceptions"
     setup do
-      exception = nil
-      begin; raise 'test'; rescue Exception => exception; end
+      exception = Sinatra::NotFound.new
       @app = proc do |env|
         env['sinatra.error'] = exception
-        [ 500, {}, [] ]
+        [ 404, {}, [] ]
       end
       @exception = exception
       @show_exceptions = Deas::ShowExceptions.new(@app)
@@ -23,7 +22,7 @@ class Deas::ShowExceptions
     should "return a body that contains details about the exception" do
       status, headers, body = subject.call({})
       expected_body = "#{@exception.class}: #{@exception.message}\n" \
-                      "#{@exception.backtrace.join("\n")}"
+                      "#{(@exception.backtrace || []).join("\n")}"
       expected_body_size = Rack::Utils.bytesize(expected_body).to_s
 
       assert_equal expected_body_size, headers['Content-Length']


### PR DESCRIPTION
Stupid `Sinatra::NotFound` exception has a `nil` backtrace.  Was
causing this to blow up.

@jcredding check out this hilarity.
