### PR TITLE
have the test runner `halt` return a `HaltArgs` class for use in testing

### DIFF
--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -29,7 +29,17 @@ module Deas
     # Helpers
 
     def halt(*args)
-      throw(:halt, args)
+      throw(:halt, HaltArgs.new(args))
+    end
+
+    class HaltArgs < Struct.new(:body, :headers, :status)
+      def initialize(args)
+        super(*[
+          !args.last.kind_of?(::Hash) && !args.last.kind_of?(::Integer) ? args.pop : nil,
+          args.last.kind_of?(::Hash) ? args.pop : nil,
+          args.first.kind_of?(::Integer) ? args.first : nil
+        ])
+      end
     end
 
     def redirect(path, *halt_args)

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -166,9 +166,9 @@ module Deas::ViewHandler
       })
       runner.run
 
-      assert_equal 200,                                runner.return_value[0]
-      assert_equal({ 'Content-Type' => 'text/plain' }, runner.return_value[1])
-      assert_equal 'test halting',                     runner.return_value[2]
+      assert_equal 200,                                runner.return_value.status
+      assert_equal({ 'Content-Type' => 'text/plain' }, runner.return_value.headers)
+      assert_equal 'test halting',                     runner.return_value.body
     end
 
   end


### PR DESCRIPTION
This class provides named attributes for writing clearer assertions.
This is as opposed to the previous method that just blindly returned
the args given and your assertions accessed attributes using the `[]`
operator.

This is to help you write more clear tests.

@jcredding ready for review.  Closes #74.
