### PR TITLE
make the Deas logger available in the template scope

### DIFF
--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -63,6 +63,10 @@ module Deas
       end
       alias :u :escape_url
 
+      def logger
+        @sinatra_call.logger
+      end
+
       def ==(other_scope)
         self.sinatra_call == other_scope.sinatra_call
         self.class.included_modules == other_scope.class.included_modules

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -6,13 +6,14 @@ class FakeSinatraCall
   # Mimic's the context that is accessible in a Sinatra' route. Should provide
   # any methods needed to replace using an actual Sinatra app.
 
-  attr_accessor :request, :response, :params, :settings, :session
+  attr_accessor :request, :response, :params, :settings, :session, :logger
 
   def initialize(settings={})
     @request = FakeRequest.new('GET','/something', {}, OpenStruct.new)
     @params   = @request.params
     @session  = @request.session
     @response = FakeResponse.new
+    @logger   = Deas::NullLogger.new
     @settings = OpenStruct.new(settings.merge({
       :deas_template_scope => Deas::Template::Scope,
       :deas_default_charset => 'utf-8'

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -82,7 +82,9 @@ class Deas::Template
     end
     subject{ @scope }
 
-    should have_imeths :partial, :escape_html, :h, :escape_url, :u, :render
+    should have_reader :sinatra_call
+    should have_imeths :render, :partial, :escape_html, :h, :escape_url, :u
+    should have_imeths :logger
 
     should "call the sinatra_call's erb method with #partial" do
       return_value = subject.partial('part', :something => true)
@@ -125,6 +127,10 @@ class Deas::Template
 
       return_value = subject.u("/path/to/somewhere")
       assert_equal "%2Fpath%2Fto%2Fsomewhere", return_value
+    end
+
+    should "expose the sinatra call (and deas server) logger" do
+      assert_equal @fake_sinatra_call.logger, subject.logger
     end
 
   end


### PR DESCRIPTION
This allows you to make `logger` calls within your templates.

@jcredding ready for review. Closes #59.
