### PR TITLE
plugin mixin for defining formal plugin mixin modules

### DIFF
--- a/lib/deas/plugin.rb
+++ b/lib/deas/plugin.rb
@@ -1,0 +1,38 @@
+module Deas
+  module Plugin
+
+    # use the Plugin mixin to define your own custom plugins you want to mixin
+    # on your Deas view handlers.  Define included hooks using `plugin_included`.
+    # this allows you to define multiple hooks separately and ensures the hooks
+    # will only be called once - even if your plugin is mixed in multiple times.
+
+    def self.included(receiver)
+      receiver.class_eval do
+        extend ClassMethods
+
+        # install an included hook that first checks if this plugin has
+        # already been installed on the reciever.  If it has not been,
+        # class eval each callback on the receiver.
+
+        def self.included(plugin_receiver)
+          return if self.deas_plugin_receivers.include?(plugin_receiver)
+
+          self.deas_plugin_receivers.push(plugin_receiver)
+          self.deas_plugin_included_hooks.each do |hook|
+            plugin_receiver.class_eval(&hook)
+          end
+        end
+
+      end
+    end
+
+    module ClassMethods
+
+      def deas_plugin_receivers; @plugin_receivers ||= []; end
+      def deas_plugin_included_hooks; @plugin_included_hooks ||= []; end
+      def plugin_included(&hook); self.deas_plugin_included_hooks << hook; end
+
+    end
+
+  end
+end

--- a/test/unit/plugin_tests.rb
+++ b/test/unit/plugin_tests.rb
@@ -1,0 +1,95 @@
+require 'assert'
+require 'deas/plugin'
+
+module Deas::Plugin
+
+  class BaseTests < Assert::Context
+    TestPlugin = Module.new do
+      include Deas::Plugin
+
+      plugin_included{ inc_hook1 }
+      plugin_included{ inc_hook2 }
+    end
+
+    desc "Deas::Plugin"
+    setup do
+      @receiver = Class.new do
+        def self.inc_hook1;   @hook1_count ||= 0; @hook1_count += 1; end
+        def self.hook1_count; @hook1_count ||= 0; end
+        def self.inc_hook2;   @hook2_count ||= 0; @hook2_count += 1; end
+        def self.hook2_count; @hook2_count ||= 0; end
+      end
+
+      @hook1 = proc{ 1 }
+      @hook2 = proc{ 2 }
+
+      @plugin = Module.new{ include Deas::Plugin }
+    end
+    subject{ @plugin }
+
+    should have_imeths :deas_plugin_included_hooks, :deas_plugin_receivers
+    should have_imeths :plugin_included
+
+    should "have no plugin_included_hooks by default" do
+      assert_empty subject.deas_plugin_included_hooks
+    end
+
+    should "have no plugin_receivers by default" do
+      assert_empty subject.deas_plugin_receivers
+    end
+
+    should "append hooks with #plugin_included" do
+      subject.plugin_included(&@hook1)
+      subject.plugin_included(&@hook2)
+
+      assert_equal @hook1, subject.deas_plugin_included_hooks.first
+      assert_equal @hook2, subject.deas_plugin_included_hooks.last
+    end
+
+    should "call the plugin included hooks when mixed in" do
+      assert_equal 0, @receiver.hook1_count
+      assert_equal 0, @receiver.hook2_count
+
+      @receiver.send(:include, BaseTests::TestPlugin)
+
+      assert_equal 1, @receiver.hook1_count
+      assert_equal 1, @receiver.hook2_count
+    end
+
+    should "call hooks once when mixed in multiple times" do
+      @receiver.send(:include, BaseTests::TestPlugin)
+
+      assert_equal 1, @receiver.hook1_count
+      assert_equal 1, @receiver.hook2_count
+
+      @receiver.send(:include, BaseTests::TestPlugin)
+
+      assert_equal 1, @receiver.hook1_count
+      assert_equal 1, @receiver.hook2_count
+    end
+
+    should "call hooks once when mixed in by a 3rd party" do
+      third_party = Module.new do
+        def self.included(receiver)
+          receiver.send(:include, BaseTests::TestPlugin)
+        end
+      end
+      @receiver.send(:include, third_party)
+
+      assert_equal 1, @receiver.hook1_count
+      assert_equal 1, @receiver.hook2_count
+
+      @receiver.send(:include, BaseTests::TestPlugin)
+
+      assert_equal 1, @receiver.hook1_count
+      assert_equal 1, @receiver.hook2_count
+
+      @receiver.send(:include, third_party)
+
+      assert_equal 1, @receiver.hook1_count
+      assert_equal 1, @receiver.hook2_count
+    end
+
+  end
+
+end


### PR DESCRIPTION
Use this mixin to define formal Deas plugins.  Plugins are modules
that can be included onto your view handlers to extend their
behavior.  Plugins can be useful for adding methods to the receivers
API or adding in callbacks on behalf of the receiver.

All of this can be accomplished using typical Ruby modules.  However,
if a `self.included` hook is used to do the actions, they may be
run many times (each time something includes your module).

Not all actions are safe to call multiple times.  Added handler callbacks,
for example, should only be done once.  If you normal modules with
`self.included` hooks, you cannot guarantee those included hooks will
only run once.

This is where Deas plugins can help.  Mixin `Deas::Plugin` into your
plugin modules.  Then define as many `plugin_included` hooks as you
like.  When the module is included on a receiver, Deas::Plugin makes
sure each hook is class eval'd on the receiver and that it is only
eval'd once - no matter how many times the module is included (even
if a 3rd-party includes it on behalf of the receiver).

@jcredding ready for review.
