### PR TITLE
update the view handler `layout` method to append layouts

### DIFF
--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -73,8 +73,7 @@ module Deas
     module ClassMethods
 
       def layout(*args)
-        @layouts = args unless args.empty?
-        @layouts
+        (@layouts ||= []).tap{ |l| l.push(*args) }
       end
       alias :layouts :layout
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -37,10 +37,10 @@ module Deas::ViewHandler
       handler_class = Class.new{ include Deas::ViewHandler }
 
       handler_class.layout 'layouts/app'
-      assert_equal [ 'layouts/app' ], handler_class.layouts
+      assert_equal ['layouts/app'], handler_class.layouts
 
       handler_class.layouts 'layouts/web', 'layouts/search'
-      assert_equal [ 'layouts/web', 'layouts/search' ], handler_class.layouts
+      assert_equal ['layouts/app', 'layouts/web', 'layouts/search'], handler_class.layouts
     end
 
   end


### PR DESCRIPTION
This is a backwards incompatible change with the previous behavior.
Before, this method would _reset_ its value to the given layout set.

This allows plugins to append layouts onto the current set of layouts
without having knowledge of the current set.

@jcredding ready for review.
