### PR TITLE
expose the sinatra `send_file` method through to the view handler

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -16,6 +16,7 @@ module Deas
     def status(*args);       raise NotImplementedError; end
     def headers(*args);      raise NotImplementedError; end
     def render(*args);       raise NotImplementedError; end
+    def send_file(*args);    raise NotImplementedError; end
 
   end
 

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -67,6 +67,10 @@ module Deas
       Deas::Template.new(@sinatra_call, template_name, options).render(&block)
     end
 
+    def send_file(*args, &block)
+      @sinatra_call.send_file(*args, &block)
+    end
+
     private
 
     def run_callbacks(callbacks)

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -74,6 +74,12 @@ module Deas
 
     RenderArgs = Struct.new(:template_name, :options, :block)
 
+    def send_file(file_path, options = nil, &block)
+      SendFileArgs.new(file_path, options, block)
+    end
+
+    SendFileArgs = Struct.new(:file_path, :options, :block)
+
   end
 
 end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -53,9 +53,8 @@ module Deas
     def status(*args);       @deas_runner.status(*args);       end
     def headers(*args);      @deas_runner.headers(*args);      end
 
-    def render(*args, &block)
-      @deas_runner.render(*args, &block)
-    end
+    def render(*args, &block);    @deas_runner.render(*args, &block);    end
+    def send_file(*args, &block); @deas_runner.send_file(*args, &block); end
 
     def app_settings; @deas_runner.app_settings; end
     def logger;       @deas_runner.logger;       end

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -13,15 +13,23 @@ class RenderViewHandler
   end
 end
 
+class SendFileViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    send_file "my_file.txt", :some => :option
+  end
+end
+
 class FlagViewHandler
   include Deas::ViewHandler
   before{ @before_hook_called = true }
   after{  @after_hook_called  = true }
   layout 'web'
 
-  attr_reader :before_init_called, :init_bang_called, :after_init_called,
-    :before_run_called, :run_bang_called, :after_run_called,
-    :before_hook_called, :after_hook_called, :second_before_init_called
+  attr_reader :before_init_called, :init_bang_called, :after_init_called
+  attr_reader :before_run_called, :run_bang_called, :after_run_called
+  attr_reader :before_hook_called, :after_hook_called, :second_before_init_called
 
   before_init do
     @before_init_called = true

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -11,9 +11,14 @@ class Deas::Runner
     end
     subject{ @runner }
 
-    should have_reader  :app_settings
+    should have_reader :app_settings
     should have_readers :request, :response, :params, :logger, :session
-    should have_imeths :halt, :redirect, :content_type, :status, :render
+    should have_imeths :halt, :redirect, :content_type, :status
+    should have_imeths :render, :send_file
+
+    should "raise NotImplementedError with #send_file" do
+      assert_raises(NotImplementedError){ subject.send_file }
+    end
 
     should "raise NotImplementedError with #halt" do
       assert_raises(NotImplementedError){ subject.halt }

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -33,6 +33,12 @@ module Deas::ViewHandler
       assert_equal({ :some => :option }, render_args.options)
     end
 
+    should "be able to send files" do
+      send_file_args = test_runner(SendFileViewHandler).run
+      assert_equal "my_file.txt",        send_file_args.file_path
+      assert_equal({ :some => :option }, send_file_args.options)
+    end
+
     should "allow specifying the layouts using #layout or #layouts" do
       handler_class = Class.new{ include Deas::ViewHandler }
 


### PR DESCRIPTION
This exposes sinatra's `send_file` method to deas view handlers
for file sending goodness.

Includes a test runner variant that returns the named args for
testing goodness.

Nothing new here - just piping stuff through like all the other
protected view handler sinatra methods.

@jcredding ready for review.
