### PR TITLE
specify url names on routes

### DIFF
--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -1,0 +1,11 @@
+module Deas
+  class Url
+
+    attr_reader :name, :path
+
+    def initialize(name, path)
+      @name, @path = name, path
+    end
+
+  end
+end

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -16,17 +16,19 @@ class Deas::Server::Configuration
     end
     subject{ @configuration }
 
-    # sinatra related options
+    # sinatra-based options
+
     should have_imeths :env, :root, :public_folder, :views_folder
     should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
-    should have_imeths :static_files, :reload_templates
+    should have_imeths :static_files, :reload_templates, :default_charset
 
     # server handling options
-    should have_imeths :error_procs, :init_procs, :logger, :middlewares, :settings
-    should have_imeths :verbose_logging, :routes, :view_handler_ns, :default_charset
 
-    should have_reader :template_helpers
-    should have_imeths :valid?, :validate!
+    should have_imeths :logger, :verbose_logging, :view_handler_ns
+
+    should have_accessors :settings, :error_procs, :init_procs, :template_helpers
+    should have_accessors :middlewares, :routes, :urls
+    should have_imeths :valid?, :validate!, :template_scope, :add_route
 
     should "default the env to 'development'" do
       assert_equal 'development', subject.env
@@ -47,15 +49,19 @@ class Deas::Server::Configuration
     end
 
     should "default the handling options" do
+      assert_instance_of Deas::NullLogger, subject.logger
+      assert_equal true, subject.verbose_logging
+      assert_nil subject.view_handler_ns
+    end
+
+    should "default its stored configuration" do
+      assert_empty subject.settings
       assert_empty subject.error_procs
       assert_empty subject.init_procs
-      assert_instance_of Deas::NullLogger, subject.logger
-      assert_empty subject.middlewares
-      assert_empty subject.settings
-      assert_equal true, subject.verbose_logging
-      assert_empty subject.routes
-      assert_nil   subject.view_handler_ns
       assert_empty subject.template_helpers
+      assert_empty subject.middlewares
+      assert_empty subject.routes
+      assert_empty subject.urls
     end
 
     should "build a template scope including its template helpers" do
@@ -102,8 +108,8 @@ class Deas::Server::Configuration
         c.show_exceptions  = true
         c.static           = true
         c.reload_templates = true
-        c.routes           = [ @route ]
         c.middlewares      = [ ['MyMiddleware'] ]
+        c.routes           = [ @route ]
       end
       @configuration.init_procs << proc{ @initialized = true }
       @configuration.init_procs << proc{ @other_initialized = true }

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -58,7 +58,7 @@ module Deas::SinatraApp
 
     should "define Sinatra routes for every route in the configuration" do
       get_routes = subject.routes[@route.method.to_s.upcase] || []
-      sinatra_route = get_routes.detect{|route| route[0].match(@route.path) }
+      sinatra_route = get_routes.detect{ |route| route[0].match(@route.path) }
 
       assert_not_nil sinatra_route
     end

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -1,0 +1,24 @@
+require 'assert'
+require 'deas/url'
+
+require 'test/support/view_handlers'
+
+class Deas::Url
+
+  class BaseTests < Assert::Context
+    desc "Deas::Url"
+    setup do
+      @url = Deas::Url.new(:get_info, '/info')
+    end
+    subject{ @url }
+
+    should have_readers :name, :path
+
+    should "know its name and path info" do
+      assert_equal :get_info, subject.name
+      assert_equal '/info', subject.path
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds the (optional) ability to specify a url name when defining
routes.  This will configure a `Url` object for that name with the
given route's path and store it on the server's configuration.

Urls are only created if a url name is given and the path for the
route is given as a `String`.  This url object will eventually be
used to generate route strings given the name and some optional
parameters.

Also, this contains a bunch of "cleanups" to the options on the server
configuration as well.  This is just to better organize them (there
are a lot) and help with readability.

Partially addresses #77.

@jcredding this is step 1 in generating urls - ready for review.
