### PR TITLE
have Urls generate paths given named/ordered params

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -248,6 +248,14 @@ module Deas::Server
       self.configuration.add_route(http_method, path, proxy)
     end
 
+    def url(name, *args)
+      url = self.configuration.urls[name.to_sym]
+      raise ArgumentError, "no route named `#{name.to_sym.inspect}`" unless url
+
+      url.path_for(*args)
+    end
+
   end
 
 end
+

--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -7,5 +7,24 @@ module Deas
       @name, @path = name, path
     end
 
+    def path_for(*args)
+      named, ordered = [
+        args.last.kind_of?(::Hash) ? args.pop : {},
+        args
+      ]
+      apply_ordered_params(apply_named_params(@path, named), ordered)
+    end
+
+    private
+
+    def apply_named_params(path, params)
+      splat = params[:splat] || params['splat'] || '*'
+      params.inject(path){ |s, (k, v)| s.gsub(":#{k}", v) }.gsub("*", splat)
+    end
+
+    def apply_ordered_params(path, params)
+      params.inject(path){ |s, p| s.sub(/\*+|\:\w+/i, p) }
+    end
+
   end
 end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -23,7 +23,8 @@ module Deas::Server
     # DSL for server handling settings
     should have_imeths :init, :error, :template_helpers, :template_helper?
     should have_imeths :use, :set, :view_handler_ns, :verbose_logging, :logger
-    should have_imeths :get, :post, :put, :patch, :delete, :redirect, :route
+    should have_imeths :get, :post, :put, :patch, :delete
+    should have_imeths :redirect, :route, :url
 
     should "allow setting it's configuration options" do
       config = subject.configuration
@@ -196,7 +197,7 @@ module Deas::Server
   class NamedUrlTests < BaseTests
     desc "when defining a route with a url name"
     setup do
-      @server_class.route(:get, '/info', 'GetInfo', 'get_info')
+      @server_class.route(:get, '/info/:for', 'GetInfo', 'get_info')
     end
 
     should "define a url for the route on the server" do
@@ -205,12 +206,25 @@ module Deas::Server
       assert_not_nil url
       assert_kind_of Deas::Url, url
       assert_equal :get_info, url.name
-      assert_equal '/info', url.path
+      assert_equal '/info/:for', url.path
     end
 
     should "complain if given a non-string path" do
       assert_raises ArgumentError do
-        @server_class.route(:get, /^\/info/, 'GetInfo', 'get_info')
+        subject.route(:get, /^\/info/, 'GetInfo', 'get_info')
+      end
+    end
+
+    should "build a path for a url given params" do
+      exp_path = "/info/now"
+
+      assert_equal exp_path, subject.url(:get_info, :for => 'now')
+      assert_equal exp_path, subject.url(:get_info, 'now')
+    end
+
+    should "complain is building a named url that hasn't been defined" do
+      assert_raises ArgumentError do
+        subject.url(:get_all_info, 'now')
       end
     end
 

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -13,10 +13,63 @@ class Deas::Url
     subject{ @url }
 
     should have_readers :name, :path
+    should have_imeth :path_for
 
     should "know its name and path info" do
       assert_equal :get_info, subject.name
       assert_equal '/info', subject.path
+    end
+
+  end
+
+  class PathForTests < BaseTests
+    desc "when generating paths"
+    setup do
+      @url = Deas::Url.new(:some_thing, '/:some/:thing/*')
+    end
+
+    should "generate given named params only" do
+      exp_path = "/a/goose/*"
+      assert_equal exp_path, subject.path_for({
+        'some' => 'a',
+        :thing => 'goose'
+      })
+
+      exp_path = "/a/goose/cooked/well"
+      assert_equal exp_path, subject.path_for({
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => 'cooked/well'
+      })
+    end
+
+    should "generate given ordered params only" do
+      exp_path = "/a/:thing/*"
+      assert_equal exp_path, subject.path_for('a')
+
+      exp_path = "/a/goose/*"
+      assert_equal exp_path, subject.path_for('a', 'goose')
+
+      exp_path = "/a/goose/cooked/well"
+      assert_equal exp_path, subject.path_for('a', 'goose', 'cooked/well')
+    end
+
+    should "generate given mixed ordered and named params" do
+      exp_path = "/:some/:thing/*"
+      assert_equal exp_path, subject.path_for
+
+      exp_path = "/a/goose/*"
+      assert_equal exp_path, subject.path_for('a', 'thing' => 'goose')
+
+      exp_path = "/goose/a/well"
+      assert_equal exp_path, subject.path_for('a', 'well', 'some' => 'goose')
+
+      exp_path = "/a/goose/cooked/well"
+      assert_equal exp_path, subject.path_for('these', 'are', 'ignored', {
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => 'cooked/well'
+      })
     end
 
   end


### PR DESCRIPTION
This adds behavior so that a Url can generate a path for given
parameter data.  Params can be name (given as a Hash) or ordered
and will be applied to the source path appropriately.

This also adds a convenience `url` method on the server for looking
up a named url and generating a path given some params data.

This is the other half to #84.  You can now name _and_ generate urls.  Like #84, this also addresses parts of #77.

@jcredding ready for review.
