### PR TITLE
have redirects support specifying url names as the redirect path

### DIFF
--- a/lib/deas/redirect_proxy.rb
+++ b/lib/deas/redirect_proxy.rb
@@ -1,4 +1,5 @@
 require 'deas/view_handler'
+require 'deas/url'
 
 module Deas
   class RedirectProxy
@@ -16,12 +17,25 @@ module Deas
 
         def self.name; 'Deas::RedirectHandler'; end
 
+        attr_reader :redirect_path
+
+        def init!
+          @redirect_path = self.instance_eval(&self.class.redirect_path)
+        end
+
         def run!
-          redirect self.instance_eval(&self.class.redirect_path)
+          redirect @redirect_path
         end
 
       end
-      @handler_class.redirect_path = path ? proc{ path } : block
+
+      @handler_class.redirect_path = if path.nil?
+        block
+      elsif path.kind_of?(Deas::Url)
+        proc{ path.path_for(params) }
+      else
+        proc{ path }
+      end
       @handler_class_name = @handler_class.name
     end
 

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -228,7 +228,8 @@ module Deas::Server
     end
 
     def redirect(http_method, path, to_path = nil, &block)
-      proxy = Deas::RedirectProxy.new(to_path, &block)
+      url = self.configuration.urls[to_path]
+      proxy = Deas::RedirectProxy.new(url || to_path, &block)
       self.configuration.add_route(http_method, path, proxy)
     end
 


### PR DESCRIPTION
This will generate the url with the given params.  If the params line
up with what the url needs, then the url will be generated appropriately.

If custom url generation is needed, use the block redirect form
instead.

This is the final step to closing #77.

@jcredding ready for review.  There is a bit of noise in the tests on this one.  I had to reconfigure some stuff to be able to test this form of redirect appropriately.  This also exposed some "weak tests" that were already in place on redirect testing so I cleaned that up in the process.
