### PR TITLE
ensure a named url exists when configuring a redirect to it

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -229,6 +229,9 @@ module Deas::Server
 
     def redirect(http_method, path, to_path = nil, &block)
       url = self.configuration.urls[to_path]
+      if to_path.kind_of?(::Symbol) && url.nil?
+        raise ArgumentError, "no url named `#{to_path.inspect}`"
+      end
       proxy = Deas::RedirectProxy.new(url || to_path, &block)
       self.configuration.add_route(http_method, path, proxy)
     end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -222,9 +222,15 @@ module Deas::Server
       assert_equal exp_path, subject.url(:get_info, 'now')
     end
 
-    should "complain is building a named url that hasn't been defined" do
+    should "complain if building a named url that hasn't been defined" do
       assert_raises ArgumentError do
         subject.url(:get_all_info, 'now')
+      end
+    end
+
+    should "complain if redirecting to a named url that hasn't been defined" do
+      assert_raises ArgumentError do
+        subject.redirect(:get, '/somewhere', :not_defined_url)
       end
     end
 


### PR DESCRIPTION
Because we need to lookup the Url at redirect definition time, we
need to ensure the the Url has been defined before we can setup a
redirect to it.  We raise a helpful exception when the Url doesn't
exist to help the developer understand what is going on.

Now, this isn't ideal.  It forces url names to be specified as a
Symbol and it forces you to define your urls before defining the
redirects to them.  There isn't really anything to do about this -
just wanted to point it out in case a better implementation comes
up later.

@jcredding ready for review.
