### PR TITLE
properly handler splat and captures params in url generation

### DIFF
--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -18,12 +18,15 @@ module Deas
     private
 
     def apply_named_params(path, params)
-      splat = params[:splat] || params['splat'] || '*'
-      params.inject(path){ |s, (k, v)| s.gsub(":#{k}", v) }.gsub("*", splat)
+      # ignore captures in applying params
+      captures   = params.delete(:captures) || params.delete('captures') || []
+      splat      = params.delete(:splat)    || params.delete('splat')    || []
+      splat_path = splat.inject(path){ |p, v| p.sub(/\*+/, v.to_s) }
+      params.inject(splat_path){ |p, (k, v)| p.gsub(":#{k}", v.to_s) }
     end
 
     def apply_ordered_params(path, params)
-      params.inject(path){ |s, p| s.sub(/\*+|\:\w+/i, p) }
+      params.inject(path){ |p, v| p.sub(/\*+|\:\w+/i, v.to_s) }
     end
 
   end

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -25,50 +25,63 @@ class Deas::Url
   class PathForTests < BaseTests
     desc "when generating paths"
     setup do
-      @url = Deas::Url.new(:some_thing, '/:some/:thing/*')
+      @url = Deas::Url.new(:some_thing, '/:some/:thing/*/*')
     end
 
     should "generate given named params only" do
-      exp_path = "/a/goose/*"
+      exp_path = "/a/goose/*/*"
       assert_equal exp_path, subject.path_for({
         'some' => 'a',
         :thing => 'goose'
       })
 
+      exp_path = "/a/goose/cooked-well/*"
+      assert_equal exp_path, subject.path_for({
+        'some' => 'a',
+        :thing => 'goose',
+        :splat => ['cooked-well']
+      })
+
       exp_path = "/a/goose/cooked/well"
       assert_equal exp_path, subject.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => 'cooked/well'
+        'splat' => ['cooked', 'well']
       })
     end
 
     should "generate given ordered params only" do
-      exp_path = "/a/:thing/*"
+      exp_path = "/a/:thing/*/*"
       assert_equal exp_path, subject.path_for('a')
 
-      exp_path = "/a/goose/*"
+      exp_path = "/a/goose/*/*"
       assert_equal exp_path, subject.path_for('a', 'goose')
 
+      exp_path = "/a/goose/cooked-well/*"
+      assert_equal exp_path, subject.path_for('a', 'goose', 'cooked-well')
+
       exp_path = "/a/goose/cooked/well"
-      assert_equal exp_path, subject.path_for('a', 'goose', 'cooked/well')
+      assert_equal exp_path, subject.path_for('a', 'goose', 'cooked', 'well')
     end
 
     should "generate given mixed ordered and named params" do
-      exp_path = "/:some/:thing/*"
+      exp_path = "/:some/:thing/*/*"
       assert_equal exp_path, subject.path_for
 
-      exp_path = "/a/goose/*"
+      exp_path = "/a/goose/*/*"
       assert_equal exp_path, subject.path_for('a', 'thing' => 'goose')
 
-      exp_path = "/goose/a/well"
+      exp_path = "/goose/a/well/*"
       assert_equal exp_path, subject.path_for('a', 'well', 'some' => 'goose')
+    end
+
+    should "pass on this" do
 
       exp_path = "/a/goose/cooked/well"
-      assert_equal exp_path, subject.path_for('these', 'are', 'ignored', {
+      assert_equal exp_path, subject.path_for('ignore', 'these', 'params', {
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => 'cooked/well'
+        'splat' => ['cooked', 'well']
       })
     end
 


### PR DESCRIPTION
The Url class wasn't handling splat params as an Array.  Sinatra
provides the splat param as an Array and this was causing the named
params stuff to blow up in live testing.

Same thing for the default captures param Sinatra supplies.  For
our url generation, we don't support the captures param so it needs
to be ignored.

This updates the tests and the behavior to treat the splat as an
Array and properly reduce the splat array to a path with `*` subbed
for splat values.

@jcredding ready for review - another edge-case I ran into when live testing.
