### PR TITLE
rename `url` to `url_for`; add `url` method for defining named urls

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -242,17 +242,19 @@ module Deas::Server
       end
       proxy = Deas::RouteProxy.new(handler_class_name)
 
-      if url_name && !url_name.to_s.empty?
-        if !path.kind_of?(::String)
-          raise ArgumentError, "invalid path `#{path.inspect}` - "\
-                               "can only provide a url name with String paths"
-        end
-        self.configuration.add_url(url_name.to_sym, path)
-      end
+      self.url(url_name, path) if url_name && !url_name.to_s.empty?
       self.configuration.add_route(http_method, path, proxy)
     end
 
-    def url(name, *args)
+    def url(name, path)
+      if !path.kind_of?(::String)
+        raise ArgumentError, "invalid path `#{path.inspect}` - "\
+                             "can only provide a url name with String paths"
+      end
+      self.configuration.add_url(name.to_sym, path)
+    end
+
+    def url_for(name, *args)
       url = self.configuration.urls[name.to_sym]
       raise ArgumentError, "no route named `#{name.to_sym.inspect}`" unless url
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -24,7 +24,7 @@ module Deas::Server
     should have_imeths :init, :error, :template_helpers, :template_helper?
     should have_imeths :use, :set, :view_handler_ns, :verbose_logging, :logger
     should have_imeths :get, :post, :put, :patch, :delete
-    should have_imeths :redirect, :route, :url
+    should have_imeths :redirect, :route, :url, :url_for
 
     should "allow setting it's configuration options" do
       config = subject.configuration
@@ -200,6 +200,16 @@ module Deas::Server
       @server_class.route(:get, '/info/:for', 'GetInfo', 'get_info')
     end
 
+    should "define a url given a name and a path" do
+      subject.url 'add_test', '/add-test'
+      url = subject.configuration.urls[:add_test]
+
+      assert_not_nil url
+      assert_kind_of Deas::Url, url
+      assert_equal :add_test, url.name
+      assert_equal '/add-test', url.path
+    end
+
     should "define a url for the route on the server" do
       url = subject.configuration.urls[:get_info]
 
@@ -218,13 +228,13 @@ module Deas::Server
     should "build a path for a url given params" do
       exp_path = "/info/now"
 
-      assert_equal exp_path, subject.url(:get_info, :for => 'now')
-      assert_equal exp_path, subject.url(:get_info, 'now')
+      assert_equal exp_path, subject.url_for(:get_info, :for => 'now')
+      assert_equal exp_path, subject.url_for(:get_info, 'now')
     end
 
     should "complain if building a named url that hasn't been defined" do
       assert_raises ArgumentError do
-        subject.url(:get_all_info, 'now')
+        subject.url_for(:get_all_info, 'now')
       end
     end
 


### PR DESCRIPTION
This renames the previous `url` method to `url_for`.  For one, this
is a more descriptive name: give me the _url for_ the named url and
data.  Also, this frees up the `url` method to be used to define
urls much like `route` defines routes.

This new `url` method is needed to define a named url without routing
to it.  You may  want or need to define a url but don't want a route
handler for that url.  This allows for that.

This will be used in a future PR where you can build redirects from
existing urls, btw.

@jcredding ready for review.  Are you OK with this rename?  I wanted a method to define urls like routes but wanted that method to be named `url`.  Let me know what you think.
