### PR TITLE
allow specifying a url name as the "from path" on a redirect

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -227,13 +227,16 @@ module Deas::Server
       self.route(:delete, path, handler_class_name, url_name)
     end
 
-    def redirect(http_method, path, to_path = nil, &block)
-      url = self.configuration.urls[to_path]
-      if to_path.kind_of?(::Symbol) && url.nil?
+    def redirect(http_method, from_path, to_path = nil, &block)
+      to_url = self.configuration.urls[to_path]
+      if to_path.kind_of?(::Symbol) && to_url.nil?
         raise ArgumentError, "no url named `#{to_path.inspect}`"
       end
-      proxy = Deas::RedirectProxy.new(url || to_path, &block)
-      self.configuration.add_route(http_method, path, proxy)
+      proxy = Deas::RedirectProxy.new(to_url || to_path, &block)
+
+      from_url = self.configuration.urls[from_path]
+      from_url_path = from_url.path if from_url
+      self.configuration.add_route(http_method, from_url_path || from_path, proxy)
     end
 
     def route(http_method, path, handler_class_name, url_name = nil)

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -195,22 +195,22 @@ module Deas::Server
   end
 
   class NamedUrlTests < BaseTests
-    desc "when defining a route with a url name"
+    desc "when using named urls"
     setup do
-      @server_class.route(:get, '/info/:for', 'GetInfo', 'get_info')
+      @server_class.url('get_info', '/info/:for')
     end
 
     should "define a url given a name and a path" do
-      subject.url 'add_test', '/add-test'
-      url = subject.configuration.urls[:add_test]
+      url = subject.configuration.urls[:get_info]
 
       assert_not_nil url
       assert_kind_of Deas::Url, url
-      assert_equal :add_test, url.name
-      assert_equal '/add-test', url.path
+      assert_equal :get_info, url.name
+      assert_equal '/info/:for', url.path
     end
 
     should "define a url for the route on the server" do
+      subject.route(:get, '/info/:for', 'GetInfo', 'get_info')
       url = subject.configuration.urls[:get_info]
 
       assert_not_nil url
@@ -226,6 +226,7 @@ module Deas::Server
     end
 
     should "build a path for a url given params" do
+      subject.route(:get, '/info/:for', 'GetInfo', 'get_info')
       exp_path = "/info/now"
 
       assert_equal exp_path, subject.url_for(:get_info, :for => 'now')
@@ -242,6 +243,14 @@ module Deas::Server
       assert_raises ArgumentError do
         subject.redirect(:get, '/somewhere', :not_defined_url)
       end
+    end
+
+    should "redirect using a url name instead of a path" do
+      subject.redirect(:get, :get_info, '/somewhere')
+      url   = subject.configuration.urls[:get_info]
+      route = subject.configuration.routes.last
+
+      assert_equal url.path, route.path
     end
 
   end


### PR DESCRIPTION
This allows you to pre-define a named url using `url` and then use
that url in a later redirect.  The net-effect is you can name urls
used in redirects like you would name urls used in routing.

@jcredding ready for review.
