### PR TITLE
allow specifying a url name as the "from path" on a route

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -239,11 +239,15 @@ module Deas::Server
       self.configuration.add_route(http_method, from_url_path || from_path, proxy)
     end
 
-    def route(http_method, path, handler_class_name, url_name = nil)
+    def route(http_method, from_path, handler_class_name, url_name = nil)
       if self.view_handler_ns && !(handler_class_name =~ /^::/)
         handler_class_name = "#{self.view_handler_ns}::#{handler_class_name}"
       end
       proxy = Deas::RouteProxy.new(handler_class_name)
+
+      from_url = self.configuration.urls[from_path]
+      from_url_path = from_url.path if from_url
+      path = from_url_path || from_path
 
       self.url(url_name, path) if url_name && !url_name.to_s.empty?
       self.configuration.add_route(http_method, path, proxy)

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -253,6 +253,14 @@ module Deas::Server
       assert_equal url.path, route.path
     end
 
+    should "route using a url name instead of a path" do
+      subject.route(:get, :get_info, 'GetInfo')
+      url   = subject.configuration.urls[:get_info]
+      route = subject.configuration.routes.last
+
+      assert_equal url.path, route.path
+    end
+
   end
 
 end


### PR DESCRIPTION
This allows you to pre-define a named url using `url` and then use
that url in a later route.  There is no difference using this approach
vs. supplying a url name at route-time.  It is purely organizational
or preferential sugar for defining routes.

@jcredding ready for review.  I'm curious if pre-defining urls will make the routes file easier to read on large routes files?  Thoughts?
