### PR TITLE
some cleanups to the routing API

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -227,7 +227,7 @@ module Deas::Server
       self.route(:delete, path, handler_class_name)
     end
 
-    def redirect(http_method, from_path, to_path = nil, &block)
+    def redirect(from_path, to_path = nil, &block)
       to_url = self.configuration.urls[to_path]
       if to_path.kind_of?(::Symbol) && to_url.nil?
         raise ArgumentError, "no url named `#{to_path.inspect}`"
@@ -236,7 +236,7 @@ module Deas::Server
 
       from_url = self.configuration.urls[from_path]
       from_url_path = from_url.path if from_url
-      self.configuration.add_route(http_method, from_url_path || from_path, proxy)
+      self.configuration.add_route(:get, from_url_path || from_path, proxy)
     end
 
     def route(http_method, from_path, handler_class_name)

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -40,8 +40,8 @@ class DeasTestServer
 
   get '/handler/tests.json', 'HandlerTestsHandler'
 
-  redirect :get, '/route_redirect',   '/somewhere'
-  redirect(:get, '/:prefix/redirect'){ "/#{params['prefix']}/somewhere" }
+  redirect '/route_redirect',   '/somewhere'
+  redirect('/:prefix/redirect'){ "/#{params['prefix']}/somewhere" }
 
 end
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -154,7 +154,7 @@ module Deas::Server
     end
 
     should "add a redirect route using #redirect" do
-      subject.redirect(:get, '/invalid', '/assets')
+      subject.redirect('/invalid', '/assets')
 
       route = subject.configuration.routes[0]
       assert_instance_of Deas::Route, route
@@ -213,12 +213,12 @@ module Deas::Server
 
     should "complain if redirecting to a named url that hasn't been defined" do
       assert_raises ArgumentError do
-        subject.redirect(:get, '/somewhere', :not_defined_url)
+        subject.redirect('/somewhere', :not_defined_url)
       end
     end
 
     should "redirect using a url name instead of a path" do
-      subject.redirect(:get, :get_info, '/somewhere')
+      subject.redirect(:get_info, '/somewhere')
       url   = subject.configuration.urls[:get_info]
       route = subject.configuration.routes.last
 


### PR DESCRIPTION
This is two cleanups to the server's routing api (the commits tell the story).  Both are removals of legacy logic that have become unnecessary as the api has evolved.

This is a non-backwards-compatible change - yay still in pre-1.0-release mode!

@jcredding ready for review.
