### PR TITLE
move all server routing concerns into a `Router` object

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -1,0 +1,77 @@
+require 'deas/redirect_proxy'
+require 'deas/route_proxy'
+require 'deas/route'
+require 'deas/url'
+
+module Deas
+  class Router
+
+    attr_accessor :urls, :routes
+
+    def initialize
+      @urls, @routes = {}, []
+    end
+
+    def view_handler_ns(value = nil)
+      @view_handler_ns = value if !value.nil?
+      @view_handler_ns
+    end
+
+    def url(name, path)
+      if !path.kind_of?(::String)
+        raise ArgumentError, "invalid path `#{path.inspect}` - "\
+                             "can only provide a url name with String paths"
+      end
+      add_url(name.to_sym, path)
+    end
+
+    def url_for(name, *args)
+      url = self.urls[name.to_sym]
+      raise ArgumentError, "no route named `#{name.to_sym.inspect}`" unless url
+
+      url.path_for(*args)
+    end
+
+    def get(path, handler_name);    self.route(:get,    path, handler_name); end
+    def post(path, handler_name);   self.route(:post,   path, handler_name); end
+    def put(path, handler_name);    self.route(:put,    path, handler_name); end
+    def patch(path, handler_name);  self.route(:patch,  path, handler_name); end
+    def delete(path, handler_name); self.route(:delete, path, handler_name); end
+
+    def route(http_method, from_path, handler_class_name)
+      if self.view_handler_ns && !(handler_class_name =~ /^::/)
+        handler_class_name = "#{self.view_handler_ns}::#{handler_class_name}"
+      end
+      proxy = Deas::RouteProxy.new(handler_class_name)
+
+      from_url = self.urls[from_path]
+      from_url_path = from_url.path if from_url
+      add_route(http_method, from_url_path || from_path, proxy)
+    end
+
+    def redirect(from_path, to_path = nil, &block)
+      to_url = self.urls[to_path]
+      if to_path.kind_of?(::Symbol) && to_url.nil?
+        raise ArgumentError, "no url named `#{to_path.inspect}`"
+      end
+      proxy = Deas::RedirectProxy.new(to_url || to_path, &block)
+
+      from_url = self.urls[from_path]
+      from_url_path = from_url.path if from_url
+      add_route(:get, from_url_path || from_path, proxy)
+    end
+
+    private
+
+    def add_url(name, path)
+      self.urls[name] = Deas::Url.new(name, path)
+    end
+
+    def add_route(http_method, path, proxy)
+      Deas::Route.new(http_method, path, proxy).tap{ |r| self.routes.push(r) }
+    end
+
+  end
+
+end
+

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -1,0 +1,170 @@
+require 'assert'
+require 'deas/router'
+
+class Deas::Router
+
+  class BaseTests < Assert::Context
+    desc "Deas::Router"
+    setup do
+      @router = Deas::Router.new
+    end
+    subject{ @router }
+
+    should have_accessors :urls, :routes
+    should have_imeths :view_handler_ns
+    should have_imeths :url, :url_for
+    should have_imeths :get, :post, :put, :patch, :delete
+    should have_imeths :route, :redirect
+
+    should "have no view_handler_ns, urls, or routes by default" do
+      assert_nil subject.view_handler_ns
+      assert_empty subject.urls
+      assert_empty subject.routes
+    end
+
+    should "add a GET route using #get" do
+      subject.get('/things', 'ListThings')
+
+      route = subject.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :get,         route.method
+      assert_equal '/things',    route.path
+      assert_equal 'ListThings', route.handler_proxy.handler_class_name
+    end
+
+    should "add a POST route using #post" do
+      subject.post('/things', 'CreateThing')
+
+      route = subject.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :post,         route.method
+      assert_equal '/things',     route.path
+      assert_equal 'CreateThing', route.handler_proxy.handler_class_name
+    end
+
+    should "add a PUT route using #put" do
+      subject.put('/things/:id', 'UpdateThing')
+
+      route = subject.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :put,          route.method
+      assert_equal '/things/:id', route.path
+      assert_equal 'UpdateThing', route.handler_proxy.handler_class_name
+    end
+
+    should "add a PATCH route using #patch" do
+      subject.patch('/things/:id', 'UpdateThing')
+
+      route = subject.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :patch,        route.method
+      assert_equal '/things/:id', route.path
+      assert_equal 'UpdateThing', route.handler_proxy.handler_class_name
+    end
+
+    should "add a DELETE route using #delete" do
+      subject.delete('/things/:id', 'DeleteThing')
+
+      route = subject.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :delete,       route.method
+      assert_equal '/things/:id', route.path
+      assert_equal 'DeleteThing', route.handler_proxy.handler_class_name
+    end
+
+    should "allow defining any kind of route using #route" do
+      subject.route(:options, '/get_info', 'GetInfo')
+
+      route = subject.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :options,    route.method
+      assert_equal '/get_info', route.path
+      assert_equal 'GetInfo',   route.handler_proxy.handler_class_name
+    end
+
+    should "set a view handler namespace and use it when defining routes" do
+      subject.view_handler_ns 'MyStuff'
+      assert_equal 'MyStuff', subject.view_handler_ns
+
+      # should use the ns
+      route = subject.route(:get, '/ns_test', 'NsTest')
+      assert_equal 'MyStuff::NsTest', route.handler_proxy.handler_class_name
+
+      # should ignore the ns when the leading colons are present
+      route = subject.route(:post, '/no_ns_test', '::NoNsTest')
+      assert_equal '::NoNsTest', route.handler_proxy.handler_class_name
+    end
+
+    should "add a redirect route using #redirect" do
+      subject.redirect('/invalid', '/assets')
+
+      route = subject.routes[0]
+      assert_instance_of Deas::Route, route
+      assert_equal :get,       route.method
+      assert_equal '/invalid', route.path
+      assert_equal 'Deas::RedirectHandler', route.handler_proxy.handler_class_name
+
+      route.validate!
+      assert_not_nil route.handler_class
+    end
+
+  end
+
+  class NamedUrlTests < BaseTests
+    desc "when using named urls"
+    setup do
+      @router.url('get_info', '/info/:for')
+    end
+
+    should "define a url given a name and a path" do
+      url = subject.urls[:get_info]
+
+      assert_not_nil url
+      assert_kind_of Deas::Url, url
+      assert_equal :get_info, url.name
+      assert_equal '/info/:for', url.path
+    end
+
+    should "complain if defining a url with a non-string path" do
+      assert_raises ArgumentError do
+        subject.url(:get_info, /^\/info/)
+      end
+    end
+
+    should "build a path for a url given params" do
+      exp_path = "/info/now"
+      assert_equal exp_path, subject.url_for(:get_info, :for => 'now')
+      assert_equal exp_path, subject.url_for(:get_info, 'now')
+    end
+
+    should "complain if building a named url that hasn't been defined" do
+      assert_raises ArgumentError do
+        subject.url_for(:get_all_info, 'now')
+      end
+    end
+
+    should "complain if redirecting to a named url that hasn't been defined" do
+      assert_raises ArgumentError do
+        subject.redirect('/somewhere', :not_defined_url)
+      end
+    end
+
+    should "redirect using a url name instead of a path" do
+      subject.redirect(:get_info, '/somewhere')
+      url   = subject.urls[:get_info]
+      route = subject.routes.last
+
+      assert_equal url.path, route.path
+    end
+
+    should "route using a url name instead of a path" do
+      subject.route(:get, :get_info, 'GetInfo')
+      url   = subject.urls[:get_info]
+      route = subject.routes.last
+
+      assert_equal url.path, route.path
+    end
+
+  end
+
+end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -1,8 +1,8 @@
 require 'assert'
-require 'set'
-require 'logger'
-require 'deas/route'
 require 'deas/server'
+
+require 'logger'
+require 'deas/router'
 
 module Deas::Server
 
@@ -25,6 +25,12 @@ module Deas::Server
     should have_imeths :use, :set, :view_handler_ns, :verbose_logging, :logger
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :redirect, :route, :url, :url_for
+
+    # DSL for server routing settings
+    should have_imeths :router, :view_handler_ns
+    should have_imeths :url, :url_for
+    should have_imeths :get, :post, :put, :patch, :delete
+    should have_imeths :route, :redirect
 
     should "allow setting it's configuration options" do
       config = subject.configuration
@@ -90,147 +96,12 @@ module Deas::Server
       assert subject.template_helper?(helper_module)
     end
 
-    should "set a namespace and use it when defining routes" do
-      subject.view_handler_ns 'MyStuff'
-      assert_equal 'MyStuff', subject.configuration.view_handler_ns
+    should "have a router by default and allow overriding it" do
+      assert_kind_of Deas::Router, subject.router
 
-      # should use the ns
-      route = subject.route(:get, '/ns_test', 'NsTest')
-      assert_equal 'MyStuff::NsTest', route.handler_proxy.handler_class_name
-
-      # should ignore the ns when the leading colons are present
-      route = subject.route(:post, '/no_ns_test', '::NoNsTest')
-      assert_equal '::NoNsTest', route.handler_proxy.handler_class_name
-    end
-
-    should "add a GET route using #get" do
-      subject.get('/things', 'ListThings')
-
-      route = subject.configuration.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :get,         route.method
-      assert_equal '/things',    route.path
-      assert_equal 'ListThings', route.handler_proxy.handler_class_name
-    end
-
-    should "add a POST route using #post" do
-      subject.post('/things', 'CreateThing')
-
-      route = subject.configuration.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :post,         route.method
-      assert_equal '/things',     route.path
-      assert_equal 'CreateThing', route.handler_proxy.handler_class_name
-    end
-
-    should "add a PUT route using #put" do
-      subject.put('/things/:id', 'UpdateThing')
-
-      route = subject.configuration.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :put,          route.method
-      assert_equal '/things/:id', route.path
-      assert_equal 'UpdateThing', route.handler_proxy.handler_class_name
-    end
-
-    should "add a PATCH route using #patch" do
-      subject.patch('/things/:id', 'UpdateThing')
-
-      route = subject.configuration.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :patch,        route.method
-      assert_equal '/things/:id', route.path
-      assert_equal 'UpdateThing', route.handler_proxy.handler_class_name
-    end
-
-    should "add a DELETE route using #delete" do
-      subject.delete('/things/:id', 'DeleteThing')
-
-      route = subject.configuration.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :delete,       route.method
-      assert_equal '/things/:id', route.path
-      assert_equal 'DeleteThing', route.handler_proxy.handler_class_name
-    end
-
-    should "add a redirect route using #redirect" do
-      subject.redirect('/invalid', '/assets')
-
-      route = subject.configuration.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :get,       route.method
-      assert_equal '/invalid', route.path
-      assert_equal 'Deas::RedirectHandler', route.handler_proxy.handler_class_name
-
-      route.validate!
-      assert_not_nil route.handler_class
-    end
-
-    should "allow defining any kind of route using #route" do
-      subject.route(:options, '/get_info', 'GetInfo')
-
-      route = subject.configuration.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :options,    route.method
-      assert_equal '/get_info', route.path
-      assert_equal 'GetInfo',   route.handler_proxy.handler_class_name
-    end
-
-  end
-
-  class NamedUrlTests < BaseTests
-    desc "when using named urls"
-    setup do
-      @server_class.url('get_info', '/info/:for')
-    end
-
-    should "define a url given a name and a path" do
-      url = subject.configuration.urls[:get_info]
-
-      assert_not_nil url
-      assert_kind_of Deas::Url, url
-      assert_equal :get_info, url.name
-      assert_equal '/info/:for', url.path
-    end
-
-    should "complain if defining a url with a non-string path" do
-      assert_raises ArgumentError do
-        subject.url(:get_info, /^\/info/)
-      end
-    end
-
-    should "build a path for a url given params" do
-      exp_path = "/info/now"
-      assert_equal exp_path, subject.url_for(:get_info, :for => 'now')
-      assert_equal exp_path, subject.url_for(:get_info, 'now')
-    end
-
-    should "complain if building a named url that hasn't been defined" do
-      assert_raises ArgumentError do
-        subject.url_for(:get_all_info, 'now')
-      end
-    end
-
-    should "complain if redirecting to a named url that hasn't been defined" do
-      assert_raises ArgumentError do
-        subject.redirect('/somewhere', :not_defined_url)
-      end
-    end
-
-    should "redirect using a url name instead of a path" do
-      subject.redirect(:get_info, '/somewhere')
-      url   = subject.configuration.urls[:get_info]
-      route = subject.configuration.routes.last
-
-      assert_equal url.path, route.path
-    end
-
-    should "route using a url name instead of a path" do
-      subject.route(:get, :get_info, 'GetInfo')
-      url   = subject.configuration.urls[:get_info]
-      route = subject.configuration.routes.last
-
-      assert_equal url.path, route.path
+      new_router = Deas::Router.new
+      subject.router new_router
+      assert_same new_router, subject.router
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -13,6 +13,9 @@ module Deas::SinatraApp
     setup do
       proxy = Deas::RouteProxy.new('TestViewHandler')
       @route = Deas::Route.new(:get, '/something', proxy)
+      @router = Deas::Router.new
+      @router.routes = [ @route ]
+
       @configuration = Deas::Server::Configuration.new.tap do |c|
         c.env              = 'staging'
         c.root             = 'path/to/somewhere'
@@ -22,7 +25,7 @@ module Deas::SinatraApp
         c.show_exceptions  = true
         c.static           = true
         c.reload_templates = true
-        c.routes           = [ @route ]
+        c.router           = @router
       end
       @sinatra_app = Deas::SinatraApp.new(@configuration)
     end


### PR DESCRIPTION
This defines a new object, `Router`, that encapsulates all routing
concerns for a server.  This also updates the server's routing
and configuration to use a router instance.

There is no change to the Server api.  You still define routes on
a server like you did before and everything works as it did.

This does add some new routing options.  You can now define a router
independent of the server.  This allows you to define and access
urls and routes without _having_ to define and initialize a Server.
You can define a custom router and tell your server to use it.

To summarize, this decouples routing from server definition.

@jcredding ready for review.  Does this line up with what you had in mind when we talked this morning?
