### PR TITLE
build routers with a dsl-block

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -8,8 +8,9 @@ module Deas
 
     attr_accessor :urls, :routes
 
-    def initialize
+    def initialize(&block)
       @urls, @routes = {}, []
+      self.instance_eval(&block) if !block.nil?
     end
 
     def view_handler_ns(value = nil)

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -108,6 +108,15 @@ class Deas::Router
       assert_not_nil route.handler_class
     end
 
+    should "instance eval any given block" do
+      router = Deas::Router.new do
+        get('/things', 'ListThings')
+      end
+
+      assert_equal 1, router.routes.size
+      assert_instance_of Deas::Route, router.routes.first
+    end
+
   end
 
   class NamedUrlTests < BaseTests


### PR DESCRIPTION
This updates the router class so that you can create and configuring
it by passing a configuration block.  This block will be instance
eval'd on the router.

This adds no behavior changes, just allows for syntactical sugar
when defining routers.

@jcredding ready for review.
