### PR TITLE
`.new` method on Deas::Server module

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -107,6 +107,12 @@ module Deas::Server
     receiver.class_eval{ extend ClassMethods }
   end
 
+  def self.new(&block)
+    server_class = Class.new{ include Deas::Server }
+    server_class.class_eval(&block) if !block.nil?
+    server_class.new
+  end
+
   module ClassMethods
 
     def new

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -106,4 +106,26 @@ module Deas::Server
 
   end
 
+  class NewTests < BaseTests
+    desc "module #new method"
+    subject{ Deas::Server }
+
+    should have_imeth :new
+
+    should "build a sinatra app with the given configuration" do
+      server_app = subject.new do
+        root Dir.pwd
+        env 'staging'
+      end
+
+      # don't know of a better way to test this b/c you get back a crappy
+      # Sinatra "app" thingy.  It works
+
+      assert includes Sinatra::Templates, server_app.included_modules
+      assert_includes Sinatra::Helpers,   server_app.included_modules
+      assert_includes Rack::Utils,        server_app.included_modules
+    end
+
+  end
+
 end


### PR DESCRIPTION
This is some syntactical sugar for defining server apps using a
given configuration block.  There is no behavior changes here,
just an alternate way of defining a server so that you don't _have_
to define a class and mixin the Deas::Server module.

@jcredding ready for review.
