### PR TITLE
have the url generate its paths with '//' "squashed" to just '/'

### DIFF
--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -26,7 +26,7 @@ module Deas
     end
 
     def apply_ordered_params(path, params)
-      params.inject(path){ |p, v| p.sub(/\*+|\:\w+/i, v.to_s) }
+      params.inject(path){ |p, v| p.sub(/\*+|\:\w+/i, v.to_s) }.gsub(/\/\/+/, '/')
     end
 
   end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -146,6 +146,12 @@ class Deas::Router
       assert_equal exp_path, subject.url_for(:get_info, 'now')
     end
 
+    should "'squash' duplicate forward-slashes when building urls" do
+      exp_path = "/info/now"
+      assert_equal exp_path, subject.url_for(:get_info, :for => '/now')
+      assert_equal exp_path, subject.url_for(:get_info, '/now')
+    end
+
     should "complain if building a named url that hasn't been defined" do
       assert_raises ArgumentError do
         subject.url_for(:get_all_info, 'now')

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -73,15 +73,21 @@ class Deas::Url
 
       exp_path = "/goose/a/well/*"
       assert_equal exp_path, subject.path_for('a', 'well', 'some' => 'goose')
-    end
-
-    should "pass on this" do
 
       exp_path = "/a/goose/cooked/well"
       assert_equal exp_path, subject.path_for('ignore', 'these', 'params', {
         'some'  => 'a',
         :thing  => 'goose',
         'splat' => ['cooked', 'well']
+      })
+    end
+
+    should "'squash' duplicate forward-slashes" do
+      exp_path = "/a/goose/cooked/well/"
+      assert_equal exp_path, subject.path_for({
+        'some'  => '/a',
+        :thing  => '/goose',
+        'splat' => ['///cooked', 'well//']
       })
     end
 


### PR DESCRIPTION
This may come up, especially using urls as values in generating other
urls.  This is similare to how `File.join` works.

_This_ closes #98 
