### PR TITLE
apply "extra" url_for hashed params to the url query

### DIFF
--- a/lib/deas/cgi.rb
+++ b/lib/deas/cgi.rb
@@ -1,0 +1,31 @@
+module Deas
+
+  module Cgi
+    # taken from http://ruby-doc.org/stdlib/libdoc/cgi/rdoc/index.html
+    # => not requiring 'cgi' to save on memory usage
+
+    def self.escape(string)
+      string.gsub(/([^ a-zA-Z0-9_.-]+)/n) do
+        '%' + $1.unpack('H2' * $1.size).join('%').upcase
+      end.gsub(' ', '%20')
+    end
+
+    def self.http_query(value, key_ns = nil)
+      # optimized version taken from:
+      # http://github.com/kelredd/useful/blob/master/lib/useful/ruby_extensions/hash.rb
+      value.sort{|a,b| a[0].to_s <=> b[0].to_s}.collect do |key_val|
+        key, val = key_val
+        key_s = key_ns ? "#{key_ns}[#{key_val[0].to_s}]" : key_val[0].to_s
+        if key_val[1].kind_of?(::Array)
+          key_val[1].sort.collect{|i| "#{key_s}[]=#{Deas::Cgi.escape(i.to_s)}"}.join('&')
+        elsif key_val[1].kind_of?(::Hash)
+          Deas::Cgi.http_query(key_val[1], key_s)
+        else
+          "#{key_s}=#{Deas::Cgi.escape(key_val[1].to_s)}"
+        end
+      end.join('&')
+    end
+
+  end
+
+end

--- a/test/unit/cgi_tests.rb
+++ b/test/unit/cgi_tests.rb
@@ -1,0 +1,36 @@
+require 'assert'
+require 'deas/cgi'
+
+module Deas::Cgi
+
+  class UnitTests < Assert::Context
+    desc "Deas::Cgi"
+    subject{ Deas::Cgi }
+
+    should have_imeths :escape, :http_query
+
+    should "cgi-escape data values" do
+      exp = "Right%21%20%5BSaid%5D%20Fred.%0D%0A"
+      assert_equal exp, Deas::Cgi.escape("Right! [Said] Fred.\r\n")
+    end
+
+    should "create http query strings" do
+      exp = "name=thomas%20hardy%20%2F%20thomas%20handy"
+      assert_equal exp, Deas::Cgi.http_query(:name => 'thomas hardy / thomas handy')
+
+      exp = "id=23423&since=2009-10-14"
+      assert_equal exp, Deas::Cgi.http_query(:id => 23423, :since => "2009-10-14")
+
+      exp = "id[]=1&id[]=2"
+      assert_equal exp, Deas::Cgi.http_query(:id => [1,2])
+
+      exp = "poo[bar]=2&poo[foo]=1"
+      assert_equal exp, Deas::Cgi.http_query(:poo => {:foo => 1, :bar => 2})
+
+      exp = "poo[bar][bar1]=1&poo[bar][bar2]=nasty&poo[foo]=1"
+      assert_equal exp, Deas::Cgi.http_query(:poo => {:foo => 1, :bar => {:bar1 => 1, :bar2 => "nasty"}})
+    end
+
+  end
+
+end

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -5,7 +5,7 @@ require 'test/support/view_handlers'
 
 class Deas::Url
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::Url"
     setup do
       @url = Deas::Url.new(:get_info, '/info')
@@ -22,7 +22,7 @@ class Deas::Url
 
   end
 
-  class PathForTests < BaseTests
+  class PathForTests < UnitTests
     desc "when generating paths"
     setup do
       @url = Deas::Url.new(:some_thing, '/:some/:thing/*/*')
@@ -47,6 +47,17 @@ class Deas::Url
         'some'  => 'a',
         :thing  => 'goose',
         'splat' => ['cooked', 'well']
+      })
+    end
+
+    should "append other (additional) params as query params" do
+      exp_path = "/a/goose/cooked/well?aye=a%20a%20a&bee=b"
+      assert_equal exp_path, subject.path_for({
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => ['cooked', 'well'],
+        'bee'   => 'b',
+        :aye    => 'a a a'
       })
     end
 


### PR DESCRIPTION
This updates the router so that you can pass "extra" hashed param
values and have them be added as query parameters on the generated
url.

I also added a helper module `Cgi` for doing some optimized cgi
handling for the query string generation.  It robustly builds
the query string given a hash value and escapes query values
appropriately.  Bringing in 'cgi' is not very memory-friendly and
this accomplishes the same effect.

Closes #103.

@jcredding ready for review.
