### PR TITLE
dup the incoming hashed params in the when generating router urls

### DIFF
--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -24,10 +24,14 @@ module Deas
     end
 
     def apply_hashed(path, params)
+      # don't alter the given params
+      hash = params.dup
+
       # ignore captures in applying params
-      captures = params.delete(:captures) || params.delete('captures') || []
-      splat    = params.delete(:splat)    || params.delete('splat')    || []
-      apply_extra(apply_named(apply_splat(@path, splat), params), params)
+      captures = hash.delete(:captures) || hash.delete('captures') || []
+      splat    = hash.delete(:splat)    || hash.delete('splat')    || []
+
+      apply_extra(apply_named(apply_splat(@path, splat), hash), hash)
     end
 
     def apply_splat(path, params)

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -102,6 +102,14 @@ class Deas::Url
       })
     end
 
+    should "not alter the given params" do
+      params = {'some' => 'thing'}
+      exp_params = params.dup
+
+      subject.path_for(params)
+      assert_equal exp_params, params
+    end
+
   end
 
 end


### PR DESCRIPTION
Since we are deleting keys from the hashed params, we need to dup
the incoming hash to ensure we aren't altering incoming user data.

@jcredding should have caught this in the last PR, ready for review.
