### PR TITLE
Minor test tweaks for Rubinius compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gem 'rake'
 gem 'pry'
 gem 'multi_json'
 gem 'yajl-ruby'
+
+platform :rbx do
+  gem 'rubysl', '~> 2.0'
+end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -230,7 +230,7 @@ class HandlerTestsHandler
     set_data('app_settings_a_setting'){ self.app_settings.a_setting }
     set_data('logger_class_name'){ self.logger.class.name }
     set_data('request_method'){ self.request.request_method.to_s }
-    set_data('response_firstheaderval'){ self.response.headers.sort.first.to_s }
+    set_data('response_firstheader'){ self.response.headers.keys.first }
     set_data('params_a_param'){ self.params['a-param'] }
     set_data('session_inspect'){ self.session.inspect }
   end

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -2,6 +2,8 @@ require 'assert'
 require 'assert-rack-test'
 require 'deas'
 
+require 'haml'
+
 module Deas
 
   class RackTestsContext < Assert::Context
@@ -153,7 +155,7 @@ module Deas
       assert_equal 'something',    @data['app_settings_a_setting']
       assert_equal 'Logger',       @data['logger_class_name']
       assert_equal 'GET',          @data['request_method']
-      assert_equal 'Content-Type', @data['response_firstheaderval']
+      assert_equal 'Content-Type', @data['response_firstheader']
       assert_equal 'something',    @data['params_a_param']
       assert_equal '{}',           @data['session_inspect']
     end


### PR DESCRIPTION
This tweaks the test suite for compatibility with Rubinius. This
required only one change to the test suite. We were relying on
`Array#to_s` which behaves different between MRI and Rubinius.
This modifies the test to not use the `to_s` method but still
keeps the integrity of the test intact. This also manually
includes "haml" to avoid a warning from tilt.