### PR TITLE
have the logging middleware set the rack logger for each request env

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency("rack",       ["~> 1.5"])
   gem.add_dependency("sinatra",    ["~> 1.4"])
 
-  gem.add_development_dependency("assert")
+  gem.add_development_dependency("assert", ["~>2.3"])
   gem.add_development_dependency("assert-mocha")
   gem.add_development_dependency("assert-rack-test")
   gem.add_development_dependency('haml')

--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -30,14 +30,17 @@ module Deas
 
     # The real Rack call interface.
     # This is the common behavior for both the verbose and summary logging
-    # middlewares. It times the response and returns it as is.
+    # middlewares. It sets rack's logger, times the response and returns it as is.
     def call!(env)
+      env['rack.logger'] = @logger
+
       status, headers, body = nil, nil, nil
       benchmark = Benchmark.measure do
         status, headers, body = @app.call(env)
       end
       log_error(env['sinatra.error'])
       env['deas.time_taken'] = RoundedTime.new(benchmark.real)
+
       [ status, headers, body ]
     end
 


### PR DESCRIPTION
This updates Deas' logging middleware to have it set the logger for
the rack env of each request.  This ensures that logger calls in
the template scope (which use Sinatra's `logger` helper) use the
configured logger (if any).

Previously, b/c we are setting Sinatra's `:logging` config to `false`,
Sinatra was setting `env['rack.logger'] to some rack null-logger.
Sinatra's`logger`template helper method just uses whatever is in
`env['rack.logger']` so logging in templates would always use this
null-logger.  This ensures logging in templates now always uses Deas'
configured logger.

@jcredding ready for review.
