### PR TITLE
have `partial` template scope method take/render a given block

### DIFF
--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -49,8 +49,8 @@ module Deas
         Template.new(@sinatra_call, name, options || {}).render(&block)
       end
 
-      def partial(name, locals = nil)
-        Partial.new(@sinatra_call, name, locals || {}).render
+      def partial(name, locals = nil, &block)
+        Partial.new(@sinatra_call, name, locals || {}).render(&block)
       end
 
       def escape_html(html)

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -33,11 +33,14 @@ class FakeSinatraCall
   def headers(*args);      args; end
 
   # return the template name for each nested calls
-  def erb(name, opts, &block)
+
+  RenderArgs = Struct.new(:template_name, :opts, :block_call_result)
+
+  def erb(template_name, opts, &block)
     if block
-      [ name, opts, block.call ].flatten
+      RenderArgs.new(template_name, opts, block.call)
     else
-      [ name, opts ]
+      RenderArgs.new(template_name, opts, nil)
     end
   end
 


### PR DESCRIPTION
This updates the `partial` method of the template scope class
behave more consistently with the `render` method and allows it
to take and then render with an optional block.

This allows you to, with some output capturing, render nested block
content on partial calls.  See https://github.com/redding/deas-erbtags/blob/master/lib/deas-erbtags/capture.rb
(`capture_partial` method) for an example.

This includes a bunch of test cleanups to the template tests to help
make them more readable and maintainable.

@jcredding ready for review.
