### PR TITLE
rename server views/public "folder" opts to "root"

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -18,9 +18,9 @@ module Deas::Server
 
     option :env,  String,   :default => 'development'
 
-    option :root,          Pathname, :required => true
-    option :public_folder, Pathname
-    option :views_folder,  Pathname
+    option :root,        Pathname, :required => true
+    option :public_root, Pathname
+    option :views_root,  Pathname
 
     option :dump_errors,      NsOptions::Boolean, :default => false
     option :method_override,  NsOptions::Boolean, :default => true
@@ -44,8 +44,8 @@ module Deas::Server
       # Configuration class `root`, which will not update these options as
       # expected.
       super((values || {}).merge({
-        :public_folder => proc{ self.root.join('public') },
-        :views_folder  => proc{ self.root.join('views') }
+        :public_root => proc{ self.root.join('public') },
+        :views_root  => proc{ self.root.join('views') }
       }))
       @settings = {}
       @error_procs, @init_procs, @template_helpers, @middlewares = [], [], [], []
@@ -127,12 +127,12 @@ module Deas::Server
       self.configuration.root *args
     end
 
-    def public_folder(*args)
-      self.configuration.public_folder *args
+    def public_root(*args)
+      self.configuration.public_root *args
     end
 
-    def views_folder(*args)
-      self.configuration.views_folder *args
+    def views_root(*args)
+      self.configuration.views_root *args
     end
 
     def dump_errors(*args)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -13,8 +13,8 @@ module Deas
         set :environment, server_config.env
         set :root,        server_config.root
 
-        set :public_folder, server_config.public_folder
-        set :views,         server_config.views_folder
+        set :public_folder, server_config.public_root
+        set :views,         server_config.views_root
 
         set :dump_errors,      server_config.dump_errors
         set :method_override,  server_config.method_override

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -18,7 +18,7 @@ class Deas::Server::Configuration
 
     # sinatra-based options
 
-    should have_imeths :env, :root, :public_folder, :views_folder
+    should have_imeths :env, :root, :public_root, :views_root
     should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
     should have_imeths :static_files, :reload_templates, :default_charset
 
@@ -35,8 +35,8 @@ class Deas::Server::Configuration
     end
 
     should "default the public and views folders based off the root" do
-      assert_equal subject.root.join('public'), subject.public_folder
-      assert_equal subject.root.join('views'), subject.views_folder
+      assert_equal subject.root.join('public'), subject.public_root
+      assert_equal subject.root.join('views'), subject.views_root
     end
 
     should "default the Sinatra flags" do

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -16,7 +16,7 @@ module Deas::Server
     should have_imeths :new, :configuration
 
     # DSL for sinatra-based settings
-    should have_imeths :env, :root, :public_folder, :views_folder
+    should have_imeths :env, :root, :public_root, :views_root
     should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
     should have_imeths :static_files, :reload_templates, :default_charset
 
@@ -41,11 +41,11 @@ module Deas::Server
       subject.root '/path/to/root'
       assert_equal '/path/to/root', config.root.to_s
 
-      subject.public_folder '/path/to/public'
-      assert_equal '/path/to/public', config.public_folder.to_s
+      subject.public_root '/path/to/public'
+      assert_equal '/path/to/public', config.public_root.to_s
 
-      subject.views_folder '/path/to/views'
-      assert_equal '/path/to/views', config.views_folder.to_s
+      subject.views_root '/path/to/views'
+      assert_equal '/path/to/views', config.views_root.to_s
 
       subject.dump_errors true
       assert_equal true, config.dump_errors


### PR DESCRIPTION
This is to make them named more consistently with other settings
(ie `root`) and make them feel more "unix-y".

This amounted to a bunch of renames - no behavior changes, just API
changes.

Closes #58.

@jcredding ready for review.
