### PR TITLE
fix for bug introduced in Sinatra v1.4.4

### DIFF
--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -34,7 +34,7 @@ module Deas
     def render(&block)
       template_names = [ @layouts, @name ].flatten.reverse
       top_render_proc = template_names.inject(block) do |render_proc, name|
-        proc{ @sinatra_call.send(engine(name), name, @options, &render_proc) }
+        proc{ @sinatra_call.send(engine(name), name, @options.dup, &render_proc) }
       end
       top_render_proc.call
     end

--- a/test/support/views/haml_with_layout.haml
+++ b/test/support/views/haml_with_layout.haml
@@ -1,1 +1,1 @@
-With Layout
+%span= view.class.inspect

--- a/test/support/views/with_layout.erb
+++ b/test/support/views/with_layout.erb
@@ -1,1 +1,1 @@
-With Layout
+With Layouts View: <%= view.class.inspect %>

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -68,29 +68,30 @@ module Deas
     end
 
     should "render erb templates using layouts" do
-      expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layout\n"
-
       get '/with_layout'
+      expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layouts View: WithLayoutHandler\n"
       assert_equal 200,           last_response.status
       assert_equal expected_body, last_response.body
 
       get '/alt_with_layout'
+      expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layouts View: AlternateWithLayoutHandler\n"
       assert_equal 200,           last_response.status
       assert_equal expected_body, last_response.body
     end
 
     should "render mixed (erb and other) templates using layouts" do
-      expected_body = "Layout 1\nWith Layout\n"
-
       get '/haml_with_layout'
+      expected_body = "Layout 1\n<span>HamlWithLayoutHandler</span>\n"
       assert_equal 200,           last_response.status
       assert_equal expected_body, last_response.body
 
       get '/with_haml_layout'
+      expected_body = "Layout 1\nWith Layouts View: WithHamlLayoutHandler\n"
       assert_equal 200,           last_response.status
       assert_equal expected_body, last_response.body
 
       get '/haml_with_haml_layout'
+      expected_body = "Layout 1\n<span>HamlWithHamlLayoutHandler</span>\n"
       assert_equal 200,           last_response.status
       assert_equal expected_body, last_response.body
     end


### PR DESCRIPTION
This manually dups the options before they are passed to Sinatra's
render method.  The new render method in v1.4.4 doesn't create a
copy of the options hash anymore.  So when they delete things from
the given options hash they are modifying the orig hash passed by
the user.

This breaks how Deas renders the layouts.  In Deas' implementation,
the same options hash is passed to all of the nested layouts.  So
they first layout render gets the options, but any subsequent layout
renders will have the modified options.  Specifically, the `:locals`
option is removed.  This means the first layout render will get the
locals - any subsequent will not get the locals.

Blargh.  Whatever.  This has Deas take responsibility for its own
options since it is reusing for all nested layouts.  Deas takes
responsibility for dup'ing the options for each layout render.  Why
is the performance always the one to suffer?

This also improves the rack tests to actual render some layout view
that use the locals.  This was needed to reproduce this error.

The change that is causing this error is here: https://github.com/sinatra/sinatra/compare/v1.4.3...v1.4.4#diff-f2bc16b264ca20ca842cf15d82960d34L773

@jcredding ready for review.
