### PR TITLE
normalize test runner params by making their values/keys strings

### DIFF
--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -75,7 +75,7 @@ class HaltViewHandler
   include Deas::ViewHandler
 
   def run!
-    halt_args = [ params['code'], params['headers'], params['body'] ].compact
+    halt_args = [ params['code'].to_i, params['headers'], params['body'] ].compact
     halt(*halt_args)
   end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -104,4 +104,65 @@ class Deas::TestRunner
 
   end
 
+  class ParamsTests < UnitTests
+    desc "normalizing params"
+
+    should "convert any non-Array or non-Hash values to strings" do
+      exp_params = {
+        'nil' => '',
+        'int' => '42',
+        'str' => 'string'
+      }
+      assert_equal exp_params, runner_params({
+        'nil' => nil,
+        'int' => 42,
+        'str' => 'string'
+      })
+    end
+
+    should "recursively convert array values to strings" do
+      exp_params = {
+        'array' => ['', '42', 'string']
+      }
+      assert_equal exp_params, runner_params({
+        'array' => [nil, 42, 'string']
+      })
+    end
+
+    should "recursively convert hash values to strings" do
+      exp_params = {
+        'values' => {
+          'nil' => '',
+          'int' => '42',
+          'str' => 'string'
+        }
+      }
+      assert_equal exp_params, runner_params({
+        'values' => {
+          'nil' => nil,
+          'int' => 42,
+          'str' => 'string'
+        }
+      })
+    end
+
+    should "convert any non-string hash keys to string keys" do
+      exp_params = {
+        'nil' => '',
+        'vals' => { '42' => 'int', 'str' => 'string' }
+      }
+      assert_equal exp_params, runner_params({
+        'nil' => '',
+        :vals => { 42 => :int, 'str' => 'string' }
+      })
+    end
+
+    private
+
+    def runner_params(params)
+      Deas::TestRunner.new(TestRunnerViewHandler, :params => params).params
+    end
+
+  end
+
 end


### PR DESCRIPTION
This is to better mimic how live params come in.  This helps to
ensure test-driven handlers aren't passing while live code fails
due to params coming in different live than they do in the test
env.

Closes #111.

@jcredding ready for review.
