### PR TITLE
force params hashes with string-only keys

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -13,7 +13,7 @@ module Deas
       @sinatra_call  = sinatra_call
       @app_settings  = @sinatra_call.settings
       @logger        = @sinatra_call.settings.logger
-      @params        = @sinatra_call.params
+      @params        = normalize_params(@sinatra_call.params)
       @request       = @sinatra_call.request
       @response      = @sinatra_call.response
       @session       = @sinatra_call.session
@@ -79,6 +79,22 @@ module Deas
 
     def get_content_type(template_name)
       File.extname(template_name)[1..-1] || 'html'
+    end
+
+    def normalize_params(params)
+      StringifiedKeys.new(params)
+    end
+
+    module StringifiedKeys
+      def self.new(value)
+        if value.is_a?(::Array)
+          value.map{ |i| StringifiedKeys.new(i) }
+        elsif Rack::Utils.params_hash_type?(value)
+          value.inject({}){ |h, (k, v)| h[k.to_s] = StringifiedKeys.new(v); h }
+        else
+          value
+        end
+      end
     end
 
   end

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -6,7 +6,7 @@ require 'deas/sinatra_runner'
 
 class Deas::SinatraRunner
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::SinatraRunner"
     setup do
       @fake_sinatra_call = FakeSinatraCall.new
@@ -82,7 +82,7 @@ class Deas::SinatraRunner
 
   end
 
-  class RunTests < BaseTests
+  class RunTests < UnitTests
     desc "run"
     setup do
       @return_value = @runner.run
@@ -102,6 +102,45 @@ class Deas::SinatraRunner
 
     should "return the handler's run! return value" do
       assert_equal true, @return_value
+    end
+
+  end
+
+  class ParamsTests < UnitTests
+    desc "normalizing params"
+
+    should "convert any non-string hash keys to string keys" do
+      exp_params = {
+        'a' => 'aye',
+        'b' => 'bee',
+        'attachment' => {
+          'tempfile' => 'a-file',
+          'content_type' => 'whatever'
+        },
+        'attachments' => [
+          { 'tempfile' => 'a-file' },
+          { 'tempfile' => 'b-file' }
+        ]
+      }
+      assert_equal exp_params, runner_params({
+        :a  => 'aye',
+        'b' => 'bee',
+        'attachment' => {
+          :tempfile => 'a-file',
+          :content_type => 'whatever'
+        },
+        'attachments' => [
+          { :tempfile  => 'a-file' },
+          { 'tempfile' => 'b-file' }
+        ]
+      })
+    end
+
+    private
+
+    def runner_params(params)
+      @fake_sinatra_call.params = params
+      Deas::SinatraRunner.new(FlagViewHandler, @fake_sinatra_call).params
     end
 
   end


### PR DESCRIPTION
This updates the sinatra runner to have it normalize its incoming
params hash that it gets from Sinatra.  Right now all this normalization
does is force all params keys to be strings.

The reason for adding this is rack imposes no standard.  So typically
hash keys come in as strings but, for example, the nested hash data
for a multipart uploaded file has symbol keys.  This is inconsistent
and can cause testing headaches.  Sinatra tries to "help" by making
their params "indifferent" in that you can access any string keys
with their symbol equivalent.  However this fixes a symptom more
than the actual problem.  The problem is that params keys should
have consistent formats all the way down.  This forces that and
strings (as opposed to symbols) are chosen as they can more easily
represent varying values and this is the default for how params
come in with Rack.

So, in summary, both in the test runner and sinatra runner, all
incoming params are keyed using strings and should be accessed as
such.  This ensures params handling in handlers is consistent in
both live and test scenarios.

@jcredding ready for review.
