### PR TITLE
update url to generate paths with anchors

### DIFF
--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -25,13 +25,14 @@ module Deas
 
     def apply_hashed(path, params)
       # don't alter the given params
-      hash = params.dup
+      h = params.dup
 
       # ignore captures in applying params
-      captures = hash.delete(:captures) || hash.delete('captures') || []
-      splat    = hash.delete(:splat)    || hash.delete('splat')    || []
+      captures = h.delete(:captures) || h.delete('captures') || []
+      splat    = h.delete(:splat)    || h.delete('splat')    || []
+      anchor   = h.delete(:'#')      || h.delete('#')        || nil
 
-      apply_extra(apply_named(apply_splat(@path, splat), hash), hash)
+      apply_anchor(apply_extra(apply_named(apply_splat(path, splat), h), h), anchor)
     end
 
     def apply_splat(path, params)
@@ -51,6 +52,10 @@ module Deas
 
     def apply_extra(path, params)
       params.empty? ? path : "#{path}?#{Deas::Cgi.http_query(params)}"
+    end
+
+    def apply_anchor(path, anchor)
+      anchor.to_s.empty? ? path : "#{path}##{anchor}"
     end
 
   end

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -61,6 +61,44 @@ class Deas::Url
       })
     end
 
+    should "ignore any 'captures'" do
+      exp_path = "/a/goose/cooked/well"
+      assert_equal exp_path, subject.path_for({
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => ['cooked', 'well'],
+        'captures' => 'some-captures'
+      })
+    end
+
+    should "append anchors" do
+      exp_path = "/a/goose/cooked/well#an-anchor"
+      assert_equal exp_path, subject.path_for({
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => ['cooked', 'well'],
+        '#'     => 'an-anchor'
+      })
+    end
+
+    should "ignore empty anchors" do
+      exp_path = "/a/goose/cooked/well"
+      assert_equal exp_path, subject.path_for({
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => ['cooked', 'well'],
+        '#'     => nil
+      })
+
+      exp_path = "/a/goose/cooked/well"
+      assert_equal exp_path, subject.path_for({
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => ['cooked', 'well'],
+        '#'     => ''
+      })
+    end
+
     should "generate given ordered params only" do
       exp_path = "/a/:thing/*/*"
       assert_equal exp_path, subject.path_for('a')
@@ -103,7 +141,12 @@ class Deas::Url
     end
 
     should "not alter the given params" do
-      params = {'some' => 'thing'}
+      params = {
+        'some' => 'thing',
+        :captures => 'captures',
+        :splat => 'splat',
+        '#' => 'anchor'
+      }
       exp_params = params.dup
 
       subject.path_for(params)


### PR DESCRIPTION
This updates the `Url` class to make it generat paths with anchors.
Pass in a `#` key to the hashed args and its value will be appended
onto the path as an anchor.

For example:

``` ruby
url = Url.new('an-url', '/path/to/:value')
url.path_for({
  'value' => 'thing',
  '#' => 'this'
}) # => '/path/to/thing#this'
```

@jcredding ready for review.
