### PR TITLE
have test runner redirects also halt

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency("rack",       ["~> 1.5"])
   gem.add_dependency("sinatra",    ["~> 1.4"])
 
-  gem.add_development_dependency("assert", ["~>2.3"])
+  gem.add_development_dependency("assert", ["~> 2.8"])
   gem.add_development_dependency("assert-mocha")
   gem.add_development_dependency("assert-rack-test")
   gem.add_development_dependency('haml')

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -44,7 +44,7 @@ module Deas
     end
 
     def redirect(path, *halt_args)
-      RedirectArgs.new(path, halt_args)
+      throw(:halt, RedirectArgs.new(path, halt_args))
     end
 
     class RedirectArgs < Struct.new(:path, :halt_args)

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -52,7 +52,7 @@ class Deas::TestRunner
     end
 
     should "build redirect args if redirect is called" do
-      value = subject.redirect '/some/path'
+      value = catch(:halt){ subject.redirect '/some/path' }
       assert_kind_of RedirectArgs, value
       [:path, :halt_args].each do |meth|
         assert_respond_to meth, value


### PR DESCRIPTION
This updates the test runner to have its fake redirect also halt.
This more accurately fakes what a redirect does in live code.  If
a redirect is issued, then code execution should stop - similar to
issueing a `halt`.

@jcredding ready for review.
