### PR TITLE
render partials from the view handlers

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -16,6 +16,7 @@ module Deas
     def status(*args);       raise NotImplementedError; end
     def headers(*args);      raise NotImplementedError; end
     def render(*args);       raise NotImplementedError; end
+    def partial(*args);      raise NotImplementedError; end
     def send_file(*args);    raise NotImplementedError; end
 
   end

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -71,6 +71,10 @@ module Deas
       Deas::Template.new(@sinatra_call, template_name, options).render(&block)
     end
 
+    def partial(partial_name, locals = nil)
+      Deas::Template::Partial.new(@sinatra_call, partial_name, locals).render
+    end
+
     def send_file(*args, &block)
       @sinatra_call.send_file(*args, &block)
     end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -72,6 +72,11 @@ module Deas
     end
     RenderArgs = Struct.new(:template_name, :options, :block)
 
+    def partial(partial_name, locals = nil)
+      PartialArgs.new(partial_name, locals)
+    end
+    PartialArgs = Struct.new(:partial_name, :locals)
+
     def send_file(file_path, options = nil, &block)
       SendFileArgs.new(file_path, options, block)
     end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -54,6 +54,7 @@ module Deas
     def headers(*args);      @deas_runner.headers(*args);      end
 
     def render(*args, &block);    @deas_runner.render(*args, &block);    end
+    def partial(*args, &block);   @deas_runner.partial(*args, &block);   end
     def send_file(*args, &block); @deas_runner.send_file(*args, &block); end
 
     def app_settings; @deas_runner.app_settings; end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -37,6 +37,7 @@ class DeasTestServer
   get  '/haml_with_layout',      'HamlWithLayoutHandler'
   get  '/with_haml_layout',      'WithHamlLayoutHandler'
   get  '/haml_with_haml_layout', 'HamlWithHamlLayoutHandler'
+  get  '/partial.html',          'PartialHandler'
 
   get '/handler/tests.json', 'HandlerTestsHandler'
 
@@ -191,6 +192,13 @@ class HamlWithHamlLayoutHandler
   def run!
     render 'haml_with_layout'
   end
+
+end
+
+class PartialHandler
+  include Deas::ViewHandler
+
+  def run!; partial 'info', :info => 'some-info'; end
 
 end
 

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -24,6 +24,14 @@ class RenderViewHandler
   end
 end
 
+class PartialViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    partial "my_partial", :some => 'locals'
+  end
+end
+
 class SendFileViewHandler
   include Deas::ViewHandler
 

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -96,6 +96,13 @@ module Deas
       assert_equal expected_body, last_response.body
     end
 
+    should "render partial templates" do
+      get '/partial.html'
+      expected_body = "Stuff: some-info\n"
+      assert_equal 200,           last_response.status
+      assert_equal expected_body, last_response.body
+    end
+
     should "return a 302 redirecting to the expected locations" do
       get '/redirect'
       expected_location = 'http://google.com'

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -15,7 +15,7 @@ class Deas::Runner
     should have_readers :handler_class, :handler
     should have_readers :request, :response, :params, :logger, :session
     should have_imeths :halt, :redirect, :content_type, :status, :headers
-    should have_imeths :render, :send_file
+    should have_imeths :render, :partial, :send_file
 
     should "know its handler and handler class" do
       assert_equal TestViewHandler, subject.handler_class
@@ -37,6 +37,7 @@ class Deas::Runner
       assert_raises(NotImplementedError){ subject.status }
       assert_raises(NotImplementedError){ subject.headers }
       assert_raises(NotImplementedError){ subject.render }
+      assert_raises(NotImplementedError){ subject.partial }
       assert_raises(NotImplementedError){ subject.send_file }
     end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -69,6 +69,14 @@ class Deas::SinatraRunner
       assert_equal exp_result, subject.render('index')
     end
 
+    should "render partials with locals" do
+      exp_result = Deas::Template::Partial.new(@fake_sinatra_call, 'info', {
+        :some => 'locals'
+      }).render
+
+      assert_equal exp_result, subject.partial('info', :some => 'locals')
+    end
+
     should "call the sinatra_call's send_file to set the send files" do
       block_called = false
       args = subject.send_file('a/file', {:some => 'opts'}, &proc{ block_called = true })

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -99,6 +99,16 @@ class Deas::TestRunner
       assert_equal 'some/template', value.template_name
     end
 
+    should "build partial args if partial is called" do
+      value = subject.partial 'some/partial', :some => 'locals'
+      assert_kind_of PartialArgs, value
+      [:partial_name, :locals].each do |meth|
+        assert_respond_to meth, value
+      end
+      assert_equal 'some/partial', value.partial_name
+      assert_equal({:some => 'locals'}, value.locals)
+    end
+
     should "build send file args if send file is called" do
       value = subject.send_file 'some/file/path'
       assert_kind_of SendFileArgs, value

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -23,17 +23,23 @@ module Deas::ViewHandler
     should have_cmeths :before_run,  :prepend_before_run,  :before_run_callbacks
     should have_cmeths :after_run,   :prepend_after_run,   :after_run_callbacks
 
-    should "raise a NotImplementedError if run! is not overwritten" do
+    should "complain if run! is not overwritten" do
       assert_raises(NotImplementedError){ subject.run! }
     end
 
-    should "be able to render templates" do
+    should "render templates" do
       render_args = test_runner(RenderViewHandler).run
       assert_equal "my_template",        render_args.template_name
       assert_equal({ :some => :option }, render_args.options)
     end
 
-    should "be able to send files" do
+    should "render partial templates" do
+      partial_args = test_runner(PartialViewHandler).run
+      assert_equal "my_partial",        partial_args.partial_name
+      assert_equal({:some => 'locals'}, partial_args.locals)
+    end
+
+    should "send files" do
       send_file_args = test_runner(SendFileViewHandler).run
       assert_equal "my_file.txt",        send_file_args.file_path
       assert_equal({ :some => :option }, send_file_args.options)


### PR DESCRIPTION
This adds the ability to render partials from the view handlers.
This follows the pattern of the runners implementing the specific
behavior and the view handler demetering to its runner.

This overarching goal here is to render partial html content to
expose as view handler attrs and include in things like JSON data
responses.

@jcredding ready for review.
