### PR TITLE
normalize param values in test and sinatra runners

### DIFF
--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -102,7 +102,7 @@ module Deas
         'method'  => request.request_method,
         'path'    => request.path,
         'handler' => env['deas.handler_class_name'],
-        'params'  => env['sinatra.params'],
+        'params'  => env['deas.params'],
         'time'    => env['deas.time_taken'],
         'status'  => status
       }

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -1,6 +1,7 @@
 require 'deas/sinatra_runner'
 
 module Deas
+
   class Route
 
     attr_reader :method, :path, :handler_proxy, :handler_class
@@ -15,14 +16,16 @@ module Deas
 
     # TODO: unit test this??
     def run(sinatra_call)
+      runner = Deas::SinatraRunner.new(self.handler_class, sinatra_call)
       sinatra_call.request.env.tap do |env|
-        env['sinatra.params']          = sinatra_call.params
+        env['deas.params'] = runner.params
         env['deas.handler_class_name'] = self.handler_class.name
         env['deas.logging'].call "  Handler: #{env['deas.handler_class_name']}"
-        env['deas.logging'].call "  Params:  #{env['sinatra.params'].inspect}"
+        env['deas.logging'].call "  Params:  #{env['deas.params'].inspect}"
       end
-      Deas::SinatraRunner.run(self.handler_class, sinatra_call)
+      runner.run
     end
 
   end
+
 end

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -1,3 +1,5 @@
+require 'rack/utils'
+
 module Deas
 
   class Runner
@@ -18,6 +20,28 @@ module Deas
     def render(*args);       raise NotImplementedError; end
     def partial(*args);      raise NotImplementedError; end
     def send_file(*args);    raise NotImplementedError; end
+
+    class NormalizedParams
+
+      attr_reader :value
+
+      def initialize(value)
+        @value = if value.is_a?(::Array)
+          value.map{ |i| self.class.new(i).value }
+        elsif Rack::Utils.params_hash_type?(value)
+          value.inject({}){ |h, (k, v)| h[k.to_s] = self.class.new(v).value; h }
+        elsif self.file_type?(value)
+          value
+        else
+          value.to_s
+        end
+      end
+
+      def file_type?(value)
+        raise NotImplementedError
+      end
+
+    end
 
   end
 

--- a/test/support/normalized_params_spy.rb
+++ b/test/support/normalized_params_spy.rb
@@ -1,0 +1,24 @@
+module Deas; end
+class Deas::Runner
+
+  class NormalizedParamsSpy
+    attr_reader :params, :value_called
+
+    def initialize
+      @params = nil
+      @value_called = false
+    end
+
+    def new(params)
+      @params = params
+      self
+    end
+
+    def value
+      @value_called = true
+      @params
+    end
+
+  end
+
+end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -5,7 +5,7 @@ require 'deas/route'
 
 class Deas::Route
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::Route"
     setup do
       @handler_proxy = Deas::RouteProxy.new('TestViewHandler')

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -5,7 +5,7 @@ require 'test/support/view_handlers'
 
 class Deas::Runner
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::Runner"
     setup do
       @runner = Deas::Runner.new(TestViewHandler)
@@ -39,6 +39,71 @@ class Deas::Runner
       assert_raises(NotImplementedError){ subject.render }
       assert_raises(NotImplementedError){ subject.partial }
       assert_raises(NotImplementedError){ subject.send_file }
+    end
+
+  end
+
+  class NormalizedParamsTests < UnitTests
+    desc "NormalizedParams"
+
+    should "convert any non-Array or non-Hash values to strings" do
+      exp_params = {
+        'nil' => '',
+        'int' => '42',
+        'str' => 'string'
+      }
+      assert_equal exp_params, normalized({
+        'nil' => nil,
+        'int' => 42,
+        'str' => 'string'
+      })
+    end
+
+    should "recursively convert array values to strings" do
+      exp_params = {
+        'array' => ['', '42', 'string']
+      }
+      assert_equal exp_params, normalized({
+        'array' => [nil, 42, 'string']
+      })
+    end
+
+    should "recursively convert hash values to strings" do
+      exp_params = {
+        'values' => {
+          'nil' => '',
+          'int' => '42',
+          'str' => 'string'
+        }
+      }
+      assert_equal exp_params, normalized({
+        'values' => {
+          'nil' => nil,
+          'int' => 42,
+          'str' => 'string'
+        }
+      })
+    end
+
+    should "convert any non-string hash keys to string keys" do
+      exp_params = {
+        'nil' => '',
+        'vals' => { '42' => 'int', 'str' => 'string' }
+      }
+      assert_equal exp_params, normalized({
+        'nil' => '',
+        :vals => { 42 => :int, 'str' => 'string' }
+      })
+    end
+
+    private
+
+    def normalized(params)
+      TestNormalizedParams.new(params).value
+    end
+
+    class TestNormalizedParams < Deas::Runner::NormalizedParams
+      def file_type?(value); false; end
     end
 
   end


### PR DESCRIPTION
We want to normalize the param values so we can make some assumptions
about the params that are coming in:
- they will have string keys
- they will not have `nil` values
- any value that is not an array, hash, or file will be a string

The test runner has been normalizing like this for a while, however
the sinatra runner has not been.  This updates the sinatra runner
to normalize like the test runner.

The sinatra runner was already normalizing to string keys, but not
accounting for param values.  Particularly, crafted requests could
cause `nil` param values.  This in turn causes "not defined for
NilClass" exceptions in our app b/c we are not expecting the browser
to send `nil` values - only `""` values.  This fixes that issue.

Note: I also updated how the route builds and run the runner.  I
now want to log normalized params but to do that I have to build
them before logging.  This meant I needed to build the runner first,
set its params value to the env, then do the logging, and then
running the runner.  This removed the `run` class method from use
(it wasn't even tested anyway).

@jcredding ready for review.
