### PR TITLE
router `base_url`

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -18,6 +18,11 @@ module Deas
       @view_handler_ns
     end
 
+    def base_url(value = nil)
+      @base_url = value if !value.nil?
+      @base_url
+    end
+
     def url(name, path)
       if !path.kind_of?(::String)
         raise ArgumentError, "invalid path `#{path.inspect}` - "\
@@ -30,7 +35,7 @@ module Deas
       url = self.urls[name.to_sym]
       raise ArgumentError, "no route named `#{name.to_sym.inspect}`" unless url
 
-      url.path_for(*args)
+      "#{base_url}#{url.path_for(*args)}"
     end
 
     def get(path, handler_name);    self.route(:get,    path, handler_name); end
@@ -47,7 +52,7 @@ module Deas
 
       from_url = self.urls[from_path]
       from_url_path = from_url.path if from_url
-      add_route(http_method, from_url_path || from_path, proxy)
+      add_route(http_method, "#{base_url}#{from_url_path || from_path}", proxy)
     end
 
     def redirect(from_path, to_path = nil, &block)

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -38,7 +38,7 @@ module Deas::Server
     attr_accessor :settings, :error_procs, :init_procs, :template_helpers
     attr_accessor :middlewares, :router
 
-    def initialize(values=nil)
+    def initialize(values = nil)
       # these are defaulted here because we want to use the Configuration
       # instance `root`. If we define a proc above, we will be using the
       # Configuration class `root`, which will not update these options as
@@ -206,6 +206,7 @@ module Deas::Server
     end
 
     def view_handler_ns(*args); self.router.view_handler_ns(*args); end
+    def base_url(*args);        self.router.base_url(*args);        end
 
     def url(*args, &block);     self.router.url(*args, &block);     end
     def url_for(*args, &block); self.router.url_for(*args, &block); end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -34,6 +34,7 @@ module Deas
         set :deas_error_procs,     server_config.error_procs
         set :deas_default_charset, server_config.default_charset
         set :logger,               server_config.logger
+        set :router,               server_config.router
 
         server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -66,7 +66,15 @@ module Deas
       alias :u :escape_url
 
       def logger
-        @sinatra_call.logger
+        @sinatra_call.settings.logger
+      end
+
+      def router
+        @sinatra_call.settings.router
+      end
+
+      def url_for(url)
+        "#{self.router.base_url}#{url}"
       end
 
       def ==(other_scope)

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -9,16 +9,17 @@ class FakeSinatraCall
   attr_accessor :request, :response, :params, :settings, :session, :logger
 
   def initialize(settings={})
-    @settings = OpenStruct.new(settings.merge({
-      :deas_template_scope => Deas::Template::Scope,
-      :deas_default_charset => 'utf-8'
-    }))
-
     @request = FakeRequest.new('GET','/something', {}, OpenStruct.new)
     @response = FakeResponse.new
     @params   = @request.params
     @logger   = Deas::NullLogger.new
     @session  = @request.session
+
+    @settings = OpenStruct.new({
+      :deas_template_scope => Deas::Template::Scope,
+      :deas_default_charset => 'utf-8',
+      :router => Deas::Router.new
+    }.merge(settings))
   end
 
   def halt(*args)

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -11,13 +11,14 @@ class Deas::Router
     subject{ @router }
 
     should have_accessors :urls, :routes
-    should have_imeths :view_handler_ns
+    should have_imeths :view_handler_ns, :base_url
     should have_imeths :url, :url_for
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :route, :redirect
 
-    should "have no view_handler_ns, urls, or routes by default" do
+    should "have no view_handler_ns, base_url, urls, or routes by default" do
       assert_nil subject.view_handler_ns
+      assert_nil subject.base_url
       assert_empty subject.urls
       assert_empty subject.routes
     end
@@ -93,6 +94,22 @@ class Deas::Router
       # should ignore the ns when the leading colons are present
       route = subject.route(:post, '/no_ns_test', '::NoNsTest')
       assert_equal '::NoNsTest', route.handler_proxy.handler_class_name
+    end
+
+    should "set a base url" do
+      url = Factory.url
+      subject.base_url url
+
+      assert_equal url, subject.base_url
+    end
+
+    should "use the base url when adding routes" do
+      url = Factory.url
+      subject.base_url url
+      route = subject.get('/some-path', Object)
+
+      exp_path = "#{url}/some-path"
+      assert_equal exp_path, route.path
     end
 
     should "add a redirect route using #redirect" do
@@ -178,6 +195,15 @@ class Deas::Router
       route = subject.routes.last
 
       assert_equal url.path, route.path
+    end
+
+    should "use the base url when building named urls" do
+      url = Factory.url
+      subject.base_url url
+      subject.url('base_get_info', '/info/:for')
+
+      exp_path = "#{url}/info/now"
+      assert_equal exp_path, subject.url_for(:base_get_info, :for => 'now')
     end
 
   end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -22,12 +22,12 @@ module Deas::Server
 
     # DSL for server handling settings
     should have_imeths :init, :error, :template_helpers, :template_helper?
-    should have_imeths :use, :set, :view_handler_ns, :verbose_logging, :logger
+    should have_imeths :use, :set, :verbose_logging, :logger
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :redirect, :route, :url, :url_for
 
     # DSL for server routing settings
-    should have_imeths :router, :view_handler_ns
+    should have_imeths :router, :view_handler_ns, :base_url
     should have_imeths :url, :url_for
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :route, :redirect
@@ -98,6 +98,8 @@ module Deas::Server
 
     should "have a router by default and allow overriding it" do
       assert_kind_of Deas::Router, subject.router
+      assert_equal subject.router.view_handler_ns, subject.view_handler_ns
+      assert_equal subject.router.base_url, subject.base_url
 
       new_router = Deas::Router.new
       subject.router new_router

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -3,6 +3,7 @@ require 'sinatra/base'
 require 'test/support/view_handlers'
 require 'deas/route_proxy'
 require 'deas/route'
+require 'deas/router'
 require 'deas/server'
 require 'deas/sinatra_app'
 
@@ -51,6 +52,7 @@ module Deas::SinatraApp
         assert_equal true,                       settings.static
         assert_equal true,                       settings.reload_templates
         assert_instance_of Deas::NullLogger,     settings.logger
+        assert_instance_of Deas::Router,         settings.router
 
         # settings that are set but can't be changed
         assert_equal false, settings.logging

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -83,7 +83,7 @@ class Deas::Template
 
     should have_reader :sinatra_call
     should have_imeths :render, :partial, :escape_html, :h, :escape_url, :u
-    should have_imeths :logger
+    should have_imeths :logger, :router, :url_for
 
     should "call the sinatra_call's erb method with #render" do
       render_args = subject.render('my_template', {
@@ -127,7 +127,20 @@ class Deas::Template
     end
 
     should "expose the sinatra call (and deas server) logger" do
-      assert_equal @fake_sinatra_call.logger, subject.logger
+      assert_equal @fake_sinatra_call.settings.logger, subject.logger
+    end
+
+    should "expose the sinatra call (and deas server) router" do
+      assert_equal @fake_sinatra_call.settings.router, subject.router
+    end
+
+    should "build urls with #url_for" do
+      base_url = Factory.url
+      url = Factory.url
+      @fake_sinatra_call.settings.router.base_url(base_url)
+
+      exp = "#{base_url}#{url}"
+      assert_equal exp, subject.url_for(url)
     end
 
   end


### PR DESCRIPTION
This adds a new router setting: `base_url`.  Use this to define a
global base url value for the router and any server using the
router.  Values should be in the form: `/my-url`.

Using this value, all urls defined in the router will be hosted
relative to the base url.  Conversly, any urls generated from a
named url will have the base url prepended to them.

In addition, the template scope now exposes the `router` to the
templates.  It also adds a method, `url_for`, for generating
urls that honor any base url setting.  This should be used when
there is no named url to generate from.

All this allows you to host and reference your views with a common
relative url.

@jcredding ready for review.
