### PR TITLE
test suite cleanups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"
 gem 'multi_json'
 gem 'yajl-ruby'
 gem 'rack-test'

--- a/deas.gemspec
+++ b/deas.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency("rack",       ["~> 1.5"])
   gem.add_dependency("sinatra",    ["~> 1.4"])
 
-  gem.add_development_dependency("assert", ["~> 2.8"])
-  gem.add_development_dependency("assert-mocha")
+  gem.add_development_dependency("assert", ["~> 2.12"])
   gem.add_development_dependency("assert-rack-test")
   gem.add_development_dependency('haml')
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,7 +9,8 @@ TEST_SUPPORT_ROOT = ROOT.join('test/support')
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
-require 'assert-mocha' if defined?(Assert)
+
+require 'test/support/factory'
 
 require 'fileutils'
 require 'logger'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -4,7 +4,7 @@ require 'deas/error_handler'
 
 class Deas::ErrorHandler
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::ErrorHandler"
     setup do
       @exception = RuntimeError.new
@@ -18,7 +18,7 @@ class Deas::ErrorHandler
 
   end
 
-  class RunTests < BaseTests
+  class RunTests < UnitTests
     desc "run"
     setup do
       @error_procs = [ proc do |exception|
@@ -40,7 +40,7 @@ class Deas::ErrorHandler
 
   end
 
-  class RunWithMultipleProcsTests < BaseTests
+  class RunWithMultipleProcsTests < UnitTests
     desc "run with multiple procs"
     setup do
       @error_procs = [
@@ -74,7 +74,7 @@ class Deas::ErrorHandler
 
   end
 
-  class RunWithProcsThatHaltTests < BaseTests
+  class RunWithProcsThatHaltTests < UnitTests
     desc "run with a proc that halts"
     setup do
       @error_procs = [

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -4,7 +4,7 @@ require 'deas/logging'
 
 module Deas::Logging
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::Logging"
     setup do
       @app = FakeSinatraCall.new
@@ -15,7 +15,7 @@ module Deas::Logging
 
   end
 
-  class VerboseLoggingTests < BaseTests
+  class VerboseLoggingTests < UnitTests
     desc "Deas::VerboseLogging"
     setup do
       @middleware = Deas::VerboseLogging.new(@app)
@@ -30,7 +30,7 @@ module Deas::Logging
 
   end
 
-  class SummaryLoggingTests < BaseTests
+  class SummaryLoggingTests < UnitTests
     desc "Deas::SummaryLogging"
     setup do
       @middleware = Deas::SummaryLogging.new(@app)
@@ -45,7 +45,7 @@ module Deas::Logging
 
   end
 
-  class SummaryLineTests < BaseTests
+  class SummaryLineTests < UnitTests
     desc "Deas::SummaryLine"
     subject{ Deas::SummaryLine }
 

--- a/test/unit/redirect_proxy_tests.rb
+++ b/test/unit/redirect_proxy_tests.rb
@@ -4,7 +4,7 @@ require 'deas/redirect_proxy'
 
 class Deas::RedirectProxy
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::RedirectProxy"
     setup do
       @proxy = Deas::RedirectProxy.new('/somewhere')
@@ -19,7 +19,7 @@ class Deas::RedirectProxy
 
   end
 
-  class HandlerClassTests < BaseTests
+  class HandlerClassTests < UnitTests
     include Deas::TestHelpers
 
     desc "redir handler class"

--- a/test/unit/route_proxy_tests.rb
+++ b/test/unit/route_proxy_tests.rb
@@ -5,7 +5,7 @@ require 'deas/route_proxy'
 
 class Deas::RouteProxy
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::RouteProxy"
     setup do
       @proxy = Deas::RouteProxy.new('TestViewHandler')

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -3,7 +3,7 @@ require 'deas/router'
 
 class Deas::Router
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::Router"
     setup do
       @router = Deas::Router.new
@@ -119,7 +119,7 @@ class Deas::Router
 
   end
 
-  class NamedUrlTests < BaseTests
+  class NamedUrlTests < UnitTests
     desc "when using named urls"
     setup do
       @router.url('get_info', '/info/:for')

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -8,7 +8,7 @@ require 'deas/router'
 
 class Deas::Server::Configuration
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::Server::Configuration"
     setup do
       @configuration = Deas::Server::Configuration.new
@@ -91,7 +91,7 @@ class Deas::Server::Configuration
 
   end
 
-  class ValidationTests < BaseTests
+  class ValidationTests < UnitTests
     desc "when successfully validated"
     setup do
       @initialized = false

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -6,7 +6,7 @@ require 'deas/router'
 
 module Deas::Server
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::Server"
     setup do
       @server_class = Class.new{ include Deas::Server }

--- a/test/unit/show_exceptions_tests.rb
+++ b/test/unit/show_exceptions_tests.rb
@@ -4,7 +4,7 @@ require 'deas/show_exceptions'
 
 class Deas::ShowExceptions
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::ShowExceptions"
     setup do
       exception = Sinatra::NotFound.new

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -8,7 +8,7 @@ require 'deas/sinatra_app'
 
 module Deas::SinatraApp
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Deas::SinatraApp"
     setup do
       proxy = Deas::RouteProxy.new('TestViewHandler')

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -5,7 +5,7 @@ require 'deas/view_handler'
 
 module Deas::ViewHandler
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     include Deas::TestHelpers
 
     desc "Deas::ViewHandler"
@@ -57,7 +57,7 @@ module Deas::ViewHandler
 
   end
 
-  class CallbackTests < BaseTests
+  class CallbackTests < UnitTests
     desc "callbacks"
     setup do
       @proc1 = proc{ '1' }
@@ -139,7 +139,7 @@ module Deas::ViewHandler
 
   end
 
-  class WithMethodFlagsTests < BaseTests
+  class WithMethodFlagsTests < UnitTests
     setup do
       @handler = test_handler(FlagViewHandler)
     end
@@ -167,7 +167,7 @@ module Deas::ViewHandler
 
   end
 
-  class HaltTests < BaseTests
+  class HaltTests < UnitTests
     desc "halt"
 
     should "return a response with the status code and the passed data" do
@@ -185,7 +185,7 @@ module Deas::ViewHandler
 
   end
 
-  class ContentTypeTests < BaseTests
+  class ContentTypeTests < UnitTests
     desc "content_type"
 
     should "should set the response content_type/charset" do
@@ -198,7 +198,7 @@ module Deas::ViewHandler
 
   end
 
-  class StatusTests < BaseTests
+  class StatusTests < UnitTests
     desc "status"
 
     should "should set the response status" do
@@ -210,7 +210,7 @@ module Deas::ViewHandler
 
   end
 
-  class HeadersTests < BaseTests
+  class HeadersTests < UnitTests
     desc "headers"
 
     should "should set the response status" do


### PR DESCRIPTION
This gets Deas on our latest testing conventions.  This includes:
- update to the latest Assert
- remove assert-mocha as the latest assert supports native stubbing
- add in a Factory class
- fully switch to our `UnitTests` base class convention

No behavior changes - just cleanups to the tests.

@jcredding ready for review.
