### PR TITLE
sinatra runner: pass the logger as a template local; remove from scope

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -60,7 +60,10 @@ module Deas
 
     def render(template_name, options = nil, &block)
       options ||= {}
-      options[:locals] = { :view => @handler }.merge(options[:locals] || {})
+      options[:locals] = {
+        :view => @handler,
+        :logger => @logger
+      }.merge(options[:locals] || {})
       options[:layout] ||= @handler_class.layouts
 
       self.content_type(get_content_type(template_name)) if self.content_type.nil?

--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -65,10 +65,6 @@ module Deas
       end
       alias :u :escape_url
 
-      def logger
-        @sinatra_call.settings.logger
-      end
-
       def router
         @sinatra_call.settings.router
       end

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -18,7 +18,8 @@ class FakeSinatraCall
     @settings = OpenStruct.new({
       :deas_template_scope => Deas::Template::Scope,
       :deas_default_charset => 'utf-8',
-      :router => Deas::Router.new
+      :router => Deas::Router.new,
+      :logger => @logger
     }.merge(settings))
   end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -4,6 +4,7 @@ require 'deas/sinatra_runner'
 require 'deas/runner'
 require 'deas/template'
 require 'test/support/fake_sinatra_call'
+require 'test/support/normalized_params_spy'
 require 'test/support/view_handlers'
 
 class Deas::SinatraRunner
@@ -40,7 +41,7 @@ class Deas::SinatraRunner
       assert_equal @fake_sinatra_call.request, subject.request
       assert_equal @fake_sinatra_call.response, subject.response
       assert_equal @fake_sinatra_call.params, subject.params
-      assert_equal @fake_sinatra_call.settings.deas_logger, subject.logger
+      assert_equal @fake_sinatra_call.settings.logger, subject.logger
       assert_equal @fake_sinatra_call.session, subject.session
     end
 
@@ -81,11 +82,14 @@ class Deas::SinatraRunner
       assert_equal [exp_headers], subject.headers(exp_headers)
     end
 
-    should "render the template with a :view local and the handler layouts" do
+    should "render the template with :view/:logger locals and the handler layouts" do
       exp_handler = FlagViewHandler.new(subject)
       exp_layouts = FlagViewHandler.layouts
       exp_result = Deas::Template.new(@fake_sinatra_call, 'index', {
-        :locals => { :view => exp_handler },
+        :locals => {
+          :view => exp_handler,
+          :logger => @runner.logger
+        },
         :layout => exp_layouts
       }).render
 

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -83,7 +83,7 @@ class Deas::Template
 
     should have_reader :sinatra_call
     should have_imeths :render, :partial, :escape_html, :h, :escape_url, :u
-    should have_imeths :logger, :router, :url_for
+    should have_imeths :router, :url_for
 
     should "call the sinatra_call's erb method with #render" do
       render_args = subject.render('my_template', {
@@ -124,10 +124,6 @@ class Deas::Template
       exp_val = "%2Fpath%2Fto%2Fsomewhere"
       assert_equal exp_val, subject.escape_url("/path/to/somewhere")
       assert_equal exp_val, subject.u("/path/to/somewhere")
-    end
-
-    should "expose the sinatra call (and deas server) logger" do
-      assert_equal @fake_sinatra_call.settings.logger, subject.logger
     end
 
     should "expose the sinatra call (and deas server) router" do


### PR DESCRIPTION
This removes the `logger` method from the template scope and switches
to exposing it to the template as a local.  This is prep for moving
away from Sinatra for template rendering.  Not all template engines
will want to use a pre-defined scope so the scope is being deprecated.

@jcredding ready for review.
