### PR TITLE
router: add `prepend_base_url`; remove handling from template scope

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -23,6 +23,10 @@ module Deas
       @base_url
     end
 
+    def prepend_base_url(url_path)
+      "#{base_url}#{url_path}"
+    end
+
     def url(name, path)
       if !path.kind_of?(::String)
         raise ArgumentError, "invalid path `#{path.inspect}` - "\
@@ -34,8 +38,7 @@ module Deas
     def url_for(name, *args)
       url = self.urls[name.to_sym]
       raise ArgumentError, "no route named `#{name.to_sym.inspect}`" unless url
-
-      "#{base_url}#{url.path_for(*args)}"
+      prepend_base_url(url.path_for(*args))
     end
 
     def get(path, handler_name);    self.route(:get,    path, handler_name); end
@@ -52,7 +55,7 @@ module Deas
 
       from_url = self.urls[from_path]
       from_url_path = from_url.path if from_url
-      add_route(http_method, "#{base_url}#{from_url_path || from_path}", proxy)
+      add_route(http_method, prepend_base_url(from_url_path || from_path), proxy)
     end
 
     def redirect(from_path, to_path = nil, &block)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -34,7 +34,6 @@ module Deas
         set :deas_error_procs,     server_config.error_procs
         set :deas_default_charset, server_config.default_charset
         set :logger,               server_config.logger
-        set :router,               server_config.router
 
         server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -65,14 +65,6 @@ module Deas
       end
       alias :u :escape_url
 
-      def router
-        @sinatra_call.settings.router
-      end
-
-      def url_for(url)
-        "#{self.router.base_url}#{url}"
-      end
-
       def ==(other_scope)
         self.sinatra_call == other_scope.sinatra_call
         self.class.included_modules == other_scope.class.included_modules

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -18,7 +18,6 @@ class FakeSinatraCall
     @settings = OpenStruct.new({
       :deas_template_scope => Deas::Template::Scope,
       :deas_default_charset => 'utf-8',
-      :router => Deas::Router.new,
       :logger => @logger
     }.merge(settings))
   end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -11,7 +11,7 @@ class Deas::Router
     subject{ @router }
 
     should have_accessors :urls, :routes
-    should have_imeths :view_handler_ns, :base_url
+    should have_imeths :view_handler_ns, :base_url, :prepend_base_url
     should have_imeths :url, :url_for
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :route, :redirect
@@ -103,12 +103,23 @@ class Deas::Router
       assert_equal url, subject.base_url
     end
 
-    should "use the base url when adding routes" do
+    should "prepend the base url to any url path" do
+      url_path = Factory.path
+      base_url = Factory.url
+
+      assert_equal url_path, subject.prepend_base_url(url_path)
+
+      subject.base_url base_url
+      assert_equal "#{base_url}#{url_path}", subject.prepend_base_url(url_path)
+    end
+
+    should "prepend the base url when adding routes" do
       url = Factory.url
       subject.base_url url
-      route = subject.get('/some-path', Object)
+      path = Factory.path
+      route = subject.get(path, Object)
 
-      exp_path = "#{url}/some-path"
+      exp_path = subject.prepend_base_url(path)
       assert_equal exp_path, route.path
     end
 
@@ -197,13 +208,14 @@ class Deas::Router
       assert_equal url.path, route.path
     end
 
-    should "use the base url when building named urls" do
+    should "prepend the base url when building named urls" do
       url = Factory.url
       subject.base_url url
-      subject.url('base_get_info', '/info/:for')
+      path = Factory.path
+      subject.url('base_get_info', path)
 
-      exp_path = "#{url}/info/now"
-      assert_equal exp_path, subject.url_for(:base_get_info, :for => 'now')
+      exp_path = subject.prepend_base_url(path)
+      assert_equal exp_path, subject.url_for(:base_get_info)
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -52,7 +52,6 @@ module Deas::SinatraApp
         assert_equal true,                       settings.static
         assert_equal true,                       settings.reload_templates
         assert_instance_of Deas::NullLogger,     settings.logger
-        assert_instance_of Deas::Router,         settings.router
 
         # settings that are set but can't be changed
         assert_equal false, settings.logging

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -83,7 +83,6 @@ class Deas::Template
 
     should have_reader :sinatra_call
     should have_imeths :render, :partial, :escape_html, :h, :escape_url, :u
-    should have_imeths :router, :url_for
 
     should "call the sinatra_call's erb method with #render" do
       render_args = subject.render('my_template', {
@@ -124,19 +123,6 @@ class Deas::Template
       exp_val = "%2Fpath%2Fto%2Fsomewhere"
       assert_equal exp_val, subject.escape_url("/path/to/somewhere")
       assert_equal exp_val, subject.u("/path/to/somewhere")
-    end
-
-    should "expose the sinatra call (and deas server) router" do
-      assert_equal @fake_sinatra_call.settings.router, subject.router
-    end
-
-    should "build urls with #url_for" do
-      base_url = Factory.url
-      url = Factory.url
-      @fake_sinatra_call.settings.router.base_url(base_url)
-
-      exp = "#{base_url}#{url}"
-      assert_equal exp, subject.url_for(url)
     end
 
   end


### PR DESCRIPTION
This updates the router to provide a method for manually prepending
the base url to any given url path.  This also switches the routers
internal handling to now use this method.

Also, the router handling is removed from the template scope.  With
the `prepend_base_url` method, there should be no need to expose
router logic directly in the scope.

This is all prep for moving away from Sinatra for template rendering.
Not all template engines will want to use a pre-defined scope so the
scope is being deprecated.

@jcredding ready for review.
