### PR TITLE
view handler: expose the router as a protected helper method

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -5,7 +5,8 @@ module Deas
   class Runner
 
     attr_reader :handler_class, :handler
-    attr_reader :request, :response, :params, :logger, :session
+    attr_reader :request, :response, :params
+    attr_reader :logger, :router, :session
 
     def initialize(handler_class)
       @handler_class = handler_class

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -34,6 +34,7 @@ module Deas
         set :deas_error_procs,     server_config.error_procs
         set :deas_default_charset, server_config.default_charset
         set :logger,               server_config.logger
+        set :router,               server_config.router
 
         server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -15,6 +15,7 @@ module Deas
       @response = @sinatra_call.response
       @params   = NormalizedParams.new(@sinatra_call.params).value
       @logger   = @sinatra_call.settings.logger
+      @router   = @sinatra_call.settings.router
       @session  = @sinatra_call.session
 
       super(handler_class)

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -1,5 +1,6 @@
 require 'ostruct'
 require 'rack/multipart'
+require 'deas/router'
 require 'deas/runner'
 
 module Deas
@@ -16,6 +17,7 @@ module Deas
       @response = args.delete(:response)
       @params   = NormalizedParams.new(args.delete(:params) || {}).value
       @logger   = args.delete(:logger) || Deas::NullLogger.new
+      @router   = args.delete(:router) || Deas::Router.new
       @session  = args.delete(:session)
 
       super(handler_class)

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -59,6 +59,7 @@ module Deas
 
     def app_settings; @deas_runner.app_settings; end
     def logger;       @deas_runner.logger;       end
+    def router;       @deas_runner.router;       end
     def request;      @deas_runner.request;      end
     def response;     @deas_runner.response;     end
     def params;       @deas_runner.params;       end

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -18,6 +18,7 @@ class FakeSinatraCall
     @settings = OpenStruct.new({
       :deas_template_scope => Deas::Template::Scope,
       :deas_default_charset => 'utf-8',
+      :router => Deas::Router.new,
       :logger => @logger
     }.merge(settings))
   end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -13,7 +13,8 @@ class Deas::Runner
     subject{ @runner }
 
     should have_readers :handler_class, :handler
-    should have_readers :request, :response, :params, :logger, :session
+    should have_readers :request, :response, :params
+    should have_readers :logger, :router, :session
     should have_imeths :halt, :redirect, :content_type, :status, :headers
     should have_imeths :render, :partial, :send_file
 
@@ -27,6 +28,7 @@ class Deas::Runner
       assert_nil subject.response
       assert_nil subject.params
       assert_nil subject.logger
+      assert_nil subject.router
       assert_nil subject.session
     end
 

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -52,6 +52,7 @@ module Deas::SinatraApp
         assert_equal true,                       settings.static
         assert_equal true,                       settings.reload_templates
         assert_instance_of Deas::NullLogger,     settings.logger
+        assert_instance_of Deas::Router,         settings.router
 
         # settings that are set but can't be changed
         assert_equal false, settings.logging

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -42,6 +42,7 @@ class Deas::SinatraRunner
       assert_equal @fake_sinatra_call.response, subject.response
       assert_equal @fake_sinatra_call.params, subject.params
       assert_equal @fake_sinatra_call.settings.logger, subject.logger
+      assert_equal @fake_sinatra_call.settings.router, subject.router
       assert_equal @fake_sinatra_call.session, subject.session
     end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'deas/test_runner'
 
 require 'rack/test'
+require 'deas/router'
 require 'deas/runner'
 require 'test/support/normalized_params_spy'
 require 'test/support/view_handlers'
@@ -43,6 +44,7 @@ class Deas::TestRunner
       assert_nil subject.response
       assert_kind_of ::Hash, subject.params
       assert_kind_of Deas::NullLogger, subject.logger
+      assert_kind_of Deas::Router, subject.router
       assert_nil subject.session
     end
 


### PR DESCRIPTION
This updates the view handler to have the router exposed as a
protected helper method.  This follows the pattern of other helpers
like the logger method.  The goal here is to allow plugins to do
things with the router.  To do this the router needs to be provided
in a generic, programmable way.

To accomplish this, we add the router to the sinatra call and pipe
it to the view handler via the runners.

@jcredding ready for review.
