### PR TITLE
view handler test cleanups

### DIFF
--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -1,6 +1,6 @@
 require 'deas/view_handler'
 
-class TestViewHandler
+class EmptyViewHandler
   include Deas::ViewHandler
 
 end
@@ -13,6 +13,22 @@ class TestRunnerViewHandler
   def run!
     'run has run'
   end
+
+end
+
+class SinatraRunnerViewHandler
+  include Deas::ViewHandler
+
+  attr_reader :before_called, :after_called
+  attr_reader :init_bang_called, :run_bang_called
+
+  layout 'web'
+
+  before{ @before_called = true }
+  after{  @after_called  = true }
+
+  def init!; @init_bang_called = true; end
+  def run!;  @run_bang_called  = true; end
 
 end
 
@@ -38,45 +54,6 @@ class SendFileViewHandler
   def run!
     send_file "my_file.txt", :some => :option
   end
-end
-
-class FlagViewHandler
-  include Deas::ViewHandler
-  before{ @before_hook_called = true }
-  after{  @after_hook_called  = true }
-  layout 'web'
-
-  attr_reader :before_init_called, :init_bang_called, :after_init_called
-  attr_reader :before_run_called, :run_bang_called, :after_run_called
-  attr_reader :before_hook_called, :after_hook_called, :second_before_init_called
-
-  before_init do
-    @before_init_called = true
-  end
-  before_init do
-    @second_before_init_called = true
-  end
-
-  def init!
-    @init_bang_called = true
-  end
-
-  after_init do
-    @after_init_called = true
-  end
-
-  before_run do
-    @before_run_called = true
-  end
-
-  def run!
-    @run_bang_called = true
-  end
-
-  after_run do
-    @after_run_called = true
-  end
-
 end
 
 class HaltViewHandler

--- a/test/unit/route_proxy_tests.rb
+++ b/test/unit/route_proxy_tests.rb
@@ -8,7 +8,7 @@ class Deas::RouteProxy
   class UnitTests < Assert::Context
     desc "Deas::RouteProxy"
     setup do
-      @proxy = Deas::RouteProxy.new('TestViewHandler')
+      @proxy = Deas::RouteProxy.new('EmptyViewHandler')
     end
     subject{ @proxy }
 
@@ -16,11 +16,11 @@ class Deas::RouteProxy
     should have_imeths :handler_class
 
     should "know its handler class name" do
-      assert_equal 'TestViewHandler', subject.handler_class_name
+      assert_equal 'EmptyViewHandler', subject.handler_class_name
     end
 
     should "know its handler class" do
-      assert_equal TestViewHandler, subject.handler_class
+      assert_equal EmptyViewHandler, subject.handler_class
     end
 
     should "complain if there is no handler class with the given name" do

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -8,7 +8,7 @@ class Deas::Route
   class UnitTests < Assert::Context
     desc "Deas::Route"
     setup do
-      @handler_proxy = Deas::RouteProxy.new('TestViewHandler')
+      @handler_proxy = Deas::RouteProxy.new('EmptyViewHandler')
       @route = Deas::Route.new(:get, '/test', @handler_proxy)
     end
     subject{ @route }
@@ -26,7 +26,7 @@ class Deas::Route
       assert_nil subject.handler_class
 
       assert_nothing_raised{ subject.validate! }
-      assert_equal TestViewHandler, subject.handler_class
+      assert_equal EmptyViewHandler, subject.handler_class
     end
 
     should "complain given an invalid handler class" do

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -8,7 +8,7 @@ class Deas::Runner
   class UnitTests < Assert::Context
     desc "Deas::Runner"
     setup do
-      @runner = Deas::Runner.new(TestViewHandler)
+      @runner = Deas::Runner.new(EmptyViewHandler)
     end
     subject{ @runner }
 
@@ -19,7 +19,7 @@ class Deas::Runner
     should have_imeths :render, :partial, :send_file
 
     should "know its handler and handler class" do
-      assert_equal TestViewHandler, subject.handler_class
+      assert_equal EmptyViewHandler, subject.handler_class
       assert_instance_of subject.handler_class, subject.handler
     end
 

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -96,7 +96,7 @@ class Deas::Server::Configuration
     setup do
       @initialized = false
       @other_initialized = false
-      proxy = Deas::RouteProxy.new('TestViewHandler')
+      proxy = Deas::RouteProxy.new('EmptyViewHandler')
       @route = Deas::Route.new(:get, '/something', proxy)
       @router = Deas::Router.new
       @router.routes = [ @route ]
@@ -132,7 +132,7 @@ class Deas::Server::Configuration
 
       subject.validate!
 
-      assert_equal TestViewHandler, @route.handler_class
+      assert_equal EmptyViewHandler, @route.handler_class
     end
 
     should "default the :erb :outvar setting in the SinatraApp it creates" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -12,7 +12,7 @@ module Deas::SinatraApp
   class UnitTests < Assert::Context
     desc "Deas::SinatraApp"
     setup do
-      proxy = Deas::RouteProxy.new('TestViewHandler')
+      proxy = Deas::RouteProxy.new('EmptyViewHandler')
       @route = Deas::Route.new(:get, '/something', proxy)
       @router = Deas::Router.new
       @router.routes = [ @route ]

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -30,7 +30,7 @@ class Deas::SinatraRunner
       Assert.stub(NormalizedParams, :new){ |p| @norm_params_spy.new(p) }
 
       @fake_sinatra_call = FakeSinatraCall.new
-      @runner = @runner_class.new(FlagViewHandler, @fake_sinatra_call)
+      @runner = @runner_class.new(SinatraRunnerViewHandler, @fake_sinatra_call)
     end
     subject{ @runner }
 
@@ -84,8 +84,8 @@ class Deas::SinatraRunner
     end
 
     should "render the template with :view/:logger locals and the handler layouts" do
-      exp_handler = FlagViewHandler.new(subject)
-      exp_layouts = FlagViewHandler.layouts
+      exp_handler = SinatraRunnerViewHandler.new(subject)
+      exp_layouts = SinatraRunnerViewHandler.layouts
       exp_result = Deas::Template.new(@fake_sinatra_call, 'index', {
         :locals => {
           :view => exp_handler,
@@ -124,8 +124,8 @@ class Deas::SinatraRunner
     subject{ @handler }
 
     should "run the before and after hooks" do
-      assert_equal true, subject.before_hook_called
-      assert_equal true, subject.after_hook_called
+      assert_equal true, subject.before_called
+      assert_equal true, subject.after_called
     end
 
     should "run the handler's init and run" do


### PR DESCRIPTION
These are some cleanups to the view handler tests.  There are two
main goals here:
- reduce coupling between tests by removing the `FlagViewHandler`
  and instead using a specific `SinatraRunnerViewHandler` and a
  local `TestViewHandler` (old test view handler renamed to
  `EmptyViewHandler`.
- rework the main view handler unit tests to our more modern conventions
  and flow.  No major changes here - tests just organized better and
  more consistently.

This is prep for some coming view handler changes related to native
template rendering.

@jcredding ready for review.
