### PR TITLE
remove `partial` method from view handlers and runners

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -19,7 +19,6 @@ module Deas
     def status(*args);       raise NotImplementedError; end
     def headers(*args);      raise NotImplementedError; end
     def render(*args);       raise NotImplementedError; end
-    def partial(*args);      raise NotImplementedError; end
     def send_file(*args);    raise NotImplementedError; end
 
     class NormalizedParams

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -71,10 +71,6 @@ module Deas
       Deas::Template.new(@sinatra_call, template_name, options).render(&block)
     end
 
-    def partial(partial_name, locals = nil)
-      Deas::Template::Partial.new(@sinatra_call, partial_name, locals).render
-    end
-
     def send_file(*args, &block)
       @sinatra_call.send_file(*args, &block)
     end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -74,11 +74,6 @@ module Deas
     end
     RenderArgs = Struct.new(:template_name, :options, :block)
 
-    def partial(partial_name, locals = nil)
-      PartialArgs.new(partial_name, locals)
-    end
-    PartialArgs = Struct.new(:partial_name, :locals)
-
     def send_file(file_path, options = nil, &block)
       SendFileArgs.new(file_path, options, block)
     end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -54,7 +54,6 @@ module Deas
     def headers(*args);      @deas_runner.headers(*args);      end
 
     def render(*args, &block);    @deas_runner.render(*args, &block);    end
-    def partial(*args, &block);   @deas_runner.partial(*args, &block);   end
     def send_file(*args, &block); @deas_runner.send_file(*args, &block); end
 
     def app_settings; @deas_runner.app_settings; end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -37,7 +37,6 @@ class DeasTestServer
   get  '/haml_with_layout',      'HamlWithLayoutHandler'
   get  '/with_haml_layout',      'WithHamlLayoutHandler'
   get  '/haml_with_haml_layout', 'HamlWithHamlLayoutHandler'
-  get  '/partial.html',          'PartialHandler'
 
   get '/handler/tests.json', 'HandlerTestsHandler'
 
@@ -192,13 +191,6 @@ class HamlWithHamlLayoutHandler
   def run!
     render 'haml_with_layout'
   end
-
-end
-
-class PartialHandler
-  include Deas::ViewHandler
-
-  def run!; partial 'info', :info => 'some-info'; end
 
 end
 

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -40,14 +40,6 @@ class RenderViewHandler
   end
 end
 
-class PartialViewHandler
-  include Deas::ViewHandler
-
-  def run!
-    partial "my_partial", :some => 'locals'
-  end
-end
-
 class SendFileViewHandler
   include Deas::ViewHandler
 

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -96,13 +96,6 @@ module Deas
       assert_equal expected_body, last_response.body
     end
 
-    should "render partial templates" do
-      get '/partial.html'
-      expected_body = "Stuff: some-info\n"
-      assert_equal 200,           last_response.status
-      assert_equal expected_body, last_response.body
-    end
-
     should "return a 302 redirecting to the expected locations" do
       get '/redirect'
       expected_location = 'http://google.com'

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -16,7 +16,7 @@ class Deas::Runner
     should have_readers :request, :response, :params
     should have_readers :logger, :router, :session
     should have_imeths :halt, :redirect, :content_type, :status, :headers
-    should have_imeths :render, :partial, :send_file
+    should have_imeths :render, :send_file
 
     should "know its handler and handler class" do
       assert_equal EmptyViewHandler, subject.handler_class
@@ -39,7 +39,6 @@ class Deas::Runner
       assert_raises(NotImplementedError){ subject.status }
       assert_raises(NotImplementedError){ subject.headers }
       assert_raises(NotImplementedError){ subject.render }
-      assert_raises(NotImplementedError){ subject.partial }
       assert_raises(NotImplementedError){ subject.send_file }
     end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -97,14 +97,6 @@ class Deas::SinatraRunner
       assert_equal exp_result, subject.render('index')
     end
 
-    should "render partials with locals" do
-      exp_result = Deas::Template::Partial.new(@fake_sinatra_call, 'info', {
-        :some => 'locals'
-      }).render
-
-      assert_equal exp_result, subject.partial('info', :some => 'locals')
-    end
-
     should "call the sinatra_call's send_file to set the send files" do
       block_called = false
       args = subject.send_file('a/file', {:some => 'opts'}, &proc{ block_called = true })

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -124,16 +124,6 @@ class Deas::TestRunner
       assert_equal 'some/template', value.template_name
     end
 
-    should "build partial args if partial is called" do
-      value = subject.partial 'some/partial', :some => 'locals'
-      assert_kind_of PartialArgs, value
-      [:partial_name, :locals].each do |meth|
-        assert_respond_to meth, value
-      end
-      assert_equal 'some/partial', value.partial_name
-      assert_equal({:some => 'locals'}, value.locals)
-    end
-
     should "build send file args if send file is called" do
       value = subject.send_file 'some/file/path'
       assert_kind_of SendFileArgs, value

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -76,12 +76,6 @@ module Deas::ViewHandler
       assert_equal({ :some => :option }, render_args.options)
     end
 
-    should "render partial templates" do
-      partial_args = test_runner(PartialViewHandler).run
-      assert_equal "my_partial",        partial_args.partial_name
-      assert_equal({:some => 'locals'}, partial_args.locals)
-    end
-
     should "send files" do
       send_file_args = test_runner(SendFileViewHandler).run
       assert_equal "my_file.txt",        send_file_args.file_path


### PR DESCRIPTION
This isn't a universal capability across template engines so it
shouldn't be available at the view handler level.  Template engines
should be the ones to provide this function if they choose to.

This was really just a macro for a special `render` call anyway so
we aren't really losing any capabilities.

In a future PR, the `partial` method and `Partial` template subclass
will need to be removed from "general" deas and into an erb template
engine gem (once the API for template engines is ready).  Again,
this isn't a global template engine capability so it shouldn't be
exposed as one.

This is all prep for building a template rendering API and not
relying on Tilt/Sinatra.

@jcredding ready for review
