### PR TITLE
runners: have base runner take args and set its readers

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -1,4 +1,5 @@
 require 'rack/utils'
+require 'deas/router'
 
 module Deas
 
@@ -8,9 +9,17 @@ module Deas
     attr_reader :request, :response, :params
     attr_reader :logger, :router, :session
 
-    def initialize(handler_class)
+    def initialize(handler_class, args = nil)
       @handler_class = handler_class
       @handler = @handler_class.new(self)
+
+      a = args || {}
+      @request  = a[:request]
+      @response = a[:response]
+      @params   = a[:params] || {}
+      @logger   = a[:logger] || Deas::NullLogger.new
+      @router   = a[:router] || Deas::Router.new
+      @session  = a[:session]
     end
 
     def halt(*args);         raise NotImplementedError; end

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -8,17 +8,17 @@ module Deas
     attr_reader :app_settings
 
     def initialize(handler_class, sinatra_call)
-      @sinatra_call  = sinatra_call
-      @app_settings  = @sinatra_call.settings
+      @sinatra_call = sinatra_call
+      @app_settings = @sinatra_call.settings
 
-      @request  = @sinatra_call.request
-      @response = @sinatra_call.response
-      @params   = NormalizedParams.new(@sinatra_call.params).value
-      @logger   = @sinatra_call.settings.logger
-      @router   = @sinatra_call.settings.router
-      @session  = @sinatra_call.session
-
-      super(handler_class)
+      super(handler_class, {
+        :request  => @sinatra_call.request,
+        :response => @sinatra_call.response,
+        :params   => NormalizedParams.new(@sinatra_call.params).value,
+        :logger   => @sinatra_call.settings.logger,
+        :router   => @sinatra_call.settings.router,
+        :session  => @sinatra_call.session,
+      })
     end
 
     def run

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -13,14 +13,14 @@ module Deas
       args = (args || {}).dup
       @app_settings = OpenStruct.new(args.delete(:app_settings))
 
-      @request  = args.delete(:request)
-      @response = args.delete(:response)
-      @params   = NormalizedParams.new(args.delete(:params) || {}).value
-      @logger   = args.delete(:logger) || Deas::NullLogger.new
-      @router   = args.delete(:router) || Deas::Router.new
-      @session  = args.delete(:session)
-
-      super(handler_class)
+      super(handler_class, {
+        :request  => args.delete(:request),
+        :response => args.delete(:response),
+        :params   => NormalizedParams.new(args.delete(:params) || {}).value,
+        :logger   => args.delete(:logger),
+        :router   => args.delete(:router),
+        :session  => args.delete(:session)
+      })
       args.each{|key, value| @handler.send("#{key}=", value) }
 
       @return_value = catch(:halt){ @handler.init; nil }

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'deas/runner'
 
+require 'deas/router'
 require 'test/support/view_handlers'
 
 class Deas::Runner
@@ -8,7 +9,16 @@ class Deas::Runner
   class UnitTests < Assert::Context
     desc "Deas::Runner"
     setup do
-      @runner = Deas::Runner.new(EmptyViewHandler)
+      @runner_class = Deas::Runner
+    end
+    subject{ @runner_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner = @runner_class.new(EmptyViewHandler)
     end
     subject{ @runner }
 
@@ -23,13 +33,18 @@ class Deas::Runner
       assert_instance_of subject.handler_class, subject.handler
     end
 
-    should "not set any settings" do
+    should "default its settings" do
       assert_nil subject.request
       assert_nil subject.response
-      assert_nil subject.params
-      assert_nil subject.logger
-      assert_nil subject.router
+      assert_kind_of ::Hash, subject.params
+      assert_kind_of Deas::NullLogger, subject.logger
+      assert_kind_of Deas::Router, subject.router
       assert_nil subject.session
+    end
+
+    should "default its params" do
+      runner = @runner_class.new(TestRunnerViewHandler)
+      assert_equal ::Hash.new, runner.params
     end
 
     should "not implement any actions" do

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -38,12 +38,12 @@ class Deas::SinatraRunner
     should have_imeths :run
 
     should "get its settings from the sinatra call" do
-      assert_equal @fake_sinatra_call.request, subject.request
-      assert_equal @fake_sinatra_call.response, subject.response
-      assert_equal @fake_sinatra_call.params, subject.params
+      assert_equal @fake_sinatra_call.request,         subject.request
+      assert_equal @fake_sinatra_call.response,        subject.response
+      assert_equal @fake_sinatra_call.params,          subject.params
       assert_equal @fake_sinatra_call.settings.logger, subject.logger
       assert_equal @fake_sinatra_call.settings.router, subject.router
-      assert_equal @fake_sinatra_call.session, subject.session
+      assert_equal @fake_sinatra_call.session,         subject.session
     end
 
     should "call to normalize its params" do


### PR DESCRIPTION
This reworks how the runners set the necessary base runner attributes.
This makes for a more uniform API across the runners.

This is also prep for adding in a `DeasRunner` that takes args in
this manner.  The `DeasRunner` is the future counterpart to the
test runner and will be added to transition off of using sinatra
at the runner level.  The sinatra runner will subclass the deas
runner and then we can start porting logic out of the sinatra
runner and into the deas runner.

This is the first step towards that setup.

@jcredding ready for review.
