### PR TITLE
runners: remove `app_settings` reader from the runners

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -5,11 +5,8 @@ module Deas
 
   class SinatraRunner < Runner
 
-    attr_reader :app_settings
-
     def initialize(handler_class, sinatra_call)
       @sinatra_call = sinatra_call
-      @app_settings = @sinatra_call.settings
 
       super(handler_class, {
         :request  => @sinatra_call.request,

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'rack/multipart'
 require 'deas/router'
 require 'deas/runner'
@@ -7,11 +6,10 @@ module Deas
 
   class TestRunner < Runner
 
-    attr_reader :app_settings, :return_value
+    attr_reader :return_value
 
     def initialize(handler_class, args = nil)
       args = (args || {}).dup
-      @app_settings = OpenStruct.new(args.delete(:app_settings))
 
       super(handler_class, {
         :request  => args.delete(:request),

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -56,7 +56,6 @@ module Deas
     def render(*args, &block);    @deas_runner.render(*args, &block);    end
     def send_file(*args, &block); @deas_runner.send_file(*args, &block); end
 
-    def app_settings; @deas_runner.app_settings; end
     def logger;       @deas_runner.logger;       end
     def router;       @deas_runner.router;       end
     def request;      @deas_runner.request;      end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -227,7 +227,6 @@ class HandlerTestsHandler
 
   def init!
     @data = {}
-    set_data('app_settings_a_setting'){ self.app_settings.a_setting }
     set_data('logger_class_name'){ self.logger.class.name }
     set_data('request_method'){ self.request.request_method.to_s }
     set_data('response_firstheaderval'){ self.response.headers.sort.first.to_s }

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -151,7 +151,6 @@ module Deas
     end
 
     should "be able to access sinatra call data" do
-      assert_equal 'something',    @data['app_settings_a_setting']
       assert_equal 'Logger',       @data['logger_class_name']
       assert_equal 'GET',          @data['request_method']
       assert_equal 'Content-Type', @data['response_firstheaderval']

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -34,7 +34,6 @@ class Deas::SinatraRunner
     end
     subject{ @runner }
 
-    should have_readers :app_settings
     should have_imeths :run
 
     should "get its settings from the sinatra call" do

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -41,12 +41,8 @@ class Deas::TestRunner
     end
     subject{ @runner }
 
-    should have_readers :app_settings, :return_value
+    should have_readers :return_value
     should have_imeths :run
-
-    should "know its app_settings" do
-      assert_kind_of OpenStruct, subject.app_settings
-    end
 
     should "super its standard args" do
       assert_equal 'a-request',  subject.request


### PR DESCRIPTION
This is prep for moving away from the sinatra runner.  This is a
big fat coupling between sinatra and anything that uses the runner.
Not what we want going forward and can't be supported moving away
from Sinatra.

@jcredding ready for review.
