### PR TITLE
runners: add a `DeasRunner` to eventually replace the sinatra runner

### DIFF
--- a/lib/deas/deas_runner.rb
+++ b/lib/deas/deas_runner.rb
@@ -1,0 +1,34 @@
+require 'deas/runner'
+
+module Deas
+
+  class DeasRunner < Runner
+
+    def initialize(handler_class, args = nil)
+      a = args || {}
+      runner_args = a.merge(:params => NormalizedParams.new(a[:params]).value)
+      super(handler_class, runner_args)
+    end
+
+    def run
+      run_callbacks @handler_class.before_callbacks
+      @handler.init
+      response_data = @handler.run
+      run_callbacks @handler_class.after_callbacks
+      response_data
+    end
+
+    private
+
+    def run_callbacks(callbacks)
+      callbacks.each{|proc| @handler.instance_eval(&proc) }
+    end
+
+    class NormalizedParams < Deas::Runner::NormalizedParams
+      def file_type?(value)
+        value.kind_of?(::Tempfile)
+      end
+    end
+
+  end
+end

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -1,9 +1,9 @@
-require 'deas/runner'
+require 'deas/deas_runner'
 require 'deas/template'
 
 module Deas
 
-  class SinatraRunner < Runner
+  class SinatraRunner < DeasRunner
 
     def initialize(handler_class, sinatra_call)
       @sinatra_call = sinatra_call
@@ -11,19 +11,11 @@ module Deas
       super(handler_class, {
         :request  => @sinatra_call.request,
         :response => @sinatra_call.response,
-        :params   => NormalizedParams.new(@sinatra_call.params).value,
+        :params   => @sinatra_call.params,
         :logger   => @sinatra_call.settings.logger,
         :router   => @sinatra_call.settings.router,
         :session  => @sinatra_call.session,
       })
-    end
-
-    def run
-      run_callbacks @handler_class.before_callbacks
-      @handler.init
-      response_data = @handler.run
-      run_callbacks @handler_class.after_callbacks
-      response_data
     end
 
     # Helpers
@@ -74,18 +66,8 @@ module Deas
 
     private
 
-    def run_callbacks(callbacks)
-      callbacks.each{|proc| @handler.instance_eval(&proc) }
-    end
-
     def get_content_type(template_name)
       File.extname(template_name)[1..-1] || 'html'
-    end
-
-    class NormalizedParams < Deas::Runner::NormalizedParams
-      def file_type?(value)
-        value.kind_of?(::Tempfile)
-      end
     end
 
   end

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -16,7 +16,7 @@ class TestRunnerViewHandler
 
 end
 
-class SinatraRunnerViewHandler
+class DeasRunnerViewHandler
   include Deas::ViewHandler
 
   attr_reader :before_called, :after_called

--- a/test/unit/deas_runner_tests.rb
+++ b/test/unit/deas_runner_tests.rb
@@ -1,0 +1,97 @@
+require 'assert'
+require 'deas/deas_runner'
+
+require 'deas/runner'
+require 'test/support/normalized_params_spy'
+require 'test/support/view_handlers'
+
+class Deas::DeasRunner
+
+  class UnitTests < Assert::Context
+    desc "Deas::DeasRunner"
+    setup do
+      @runner_class = Deas::DeasRunner
+    end
+    subject{ @runner_class }
+
+    should "be a `Runner`" do
+      assert subject < Deas::Runner
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @params = { 'value' => '1' }
+      @norm_params_spy = Deas::Runner::NormalizedParamsSpy.new
+      Assert.stub(NormalizedParams, :new){ |p| @norm_params_spy.new(p) }
+
+      @runner = @runner_class.new(DeasRunnerViewHandler, :params => @params)
+    end
+    subject{ @runner }
+
+    should have_imeths :run
+
+    should "super its params arg" do
+      assert_equal @params, subject.params
+    end
+
+    should "call to normalize its params" do
+      assert_equal @params, @norm_params_spy.params
+      assert_true @norm_params_spy.value_called
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @return_value = @runner.run
+      @handler = @runner.instance_variable_get("@handler")
+    end
+    subject{ @handler }
+
+    should "run the before and after hooks" do
+      assert_equal true, subject.before_called
+      assert_equal true, subject.after_called
+    end
+
+    should "run the handler's init and run" do
+      assert_equal true, subject.init_bang_called
+      assert_equal true, subject.run_bang_called
+    end
+
+    should "return the handler's run! return value" do
+      assert_equal true, @return_value
+    end
+
+  end
+
+  class NormalizedParamsTests < UnitTests
+    desc "NormalizedParams"
+    setup do
+      @norm_params_class = Deas::SinatraRunner::NormalizedParams
+    end
+
+    should "be a normalized params subclass" do
+      assert @norm_params_class < Deas::Runner::NormalizedParams
+    end
+
+    should "not convert Tempfile param values to strings" do
+      tempfile = Class.new(::Tempfile){ def initialize; end }.new
+      params = normalized({
+        'attachment' => { :tempfile => tempfile }
+      })
+      assert_kind_of ::Tempfile, params['attachment']['tempfile']
+    end
+
+    private
+
+    def normalized(params)
+      @norm_params_class.new(params).value
+    end
+
+  end
+
+end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -15,7 +15,7 @@ class Deas::TestRunner
     end
     subject{ @runner_class }
 
-    should "be a Runner" do
+    should "be a `Runner`" do
       assert subject < Deas::Runner
     end
 


### PR DESCRIPTION
This adds in a `DeasRunner`.  This runner will be the future live
runner and is intended to eventually replace the sinatra runner.
We are moving away from using Sinatra and this is part of that process.

Right now the deas runner is responsible for all live runner function
not involving the sinatra runner.  This includes the run and callback
behavior and live param normalization.  In future PRs we will begin
porting the sinatra specific runner logic to our new deas logic.

@jcredding ready for review.
