### PR TITLE
runners: update sinatra runner to take args

### DIFF
--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -16,7 +16,10 @@ module Deas
 
     # TODO: unit test this??
     def run(sinatra_call)
-      runner = Deas::SinatraRunner.new(self.handler_class, sinatra_call)
+      args = {
+        :sinatra_call => sinatra_call
+      }
+      runner = Deas::SinatraRunner.new(self.handler_class, args)
       sinatra_call.request.env.tap do |env|
         env['deas.params'] = runner.params
         env['deas.handler_class_name'] = self.handler_class.name

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -5,8 +5,9 @@ module Deas
 
   class SinatraRunner < DeasRunner
 
-    def initialize(handler_class, sinatra_call)
-      @sinatra_call = sinatra_call
+    def initialize(handler_class, args = nil)
+      a = args || {}
+      @sinatra_call = a[:sinatra_call]
 
       super(handler_class, {
         :request  => @sinatra_call.request,

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -25,13 +25,15 @@ class Deas::SinatraRunner
     desc "when init"
     setup do
       @fake_sinatra_call = FakeSinatraCall.new
-      @runner = @runner_class.new(DeasRunnerViewHandler, @fake_sinatra_call)
+      @runner = @runner_class.new(DeasRunnerViewHandler, {
+        :sinatra_call => @fake_sinatra_call
+      })
     end
     subject{ @runner }
 
     should have_imeths :run
 
-    should "get its settings from the sinatra call" do
+    should "set its standard args from the sinatra call" do
       assert_equal @fake_sinatra_call.request,         subject.request
       assert_equal @fake_sinatra_call.response,        subject.response
       assert_equal @fake_sinatra_call.params,          subject.params


### PR DESCRIPTION
This makes for a consistent runner api between all the runner
variants.  The sinatra call is now passed in as an arg and the
other standard args are still built from the sinatra call.

This is more prep for switching off the sinatra runner.  In a coming
PR, I'll switch it so that the runner is built by passing in the
args instead of relying on them being set to sinatra call values.

@jcredding another tiny one repositioning things.  I'm breaking up small so they don't all run together.  Ready for review.
