### PR TITLE
route handling cleanups

### DIFF
--- a/lib/deas/redirect_proxy.rb
+++ b/lib/deas/redirect_proxy.rb
@@ -2,6 +2,7 @@ require 'deas/view_handler'
 require 'deas/url'
 
 module Deas
+
   class RedirectProxy
 
     attr_reader :handler_class_name, :handler_class
@@ -39,5 +40,8 @@ module Deas
       @handler_class_name = @handler_class.name
     end
 
+    def validate!; end
+
   end
+
 end

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -4,22 +4,23 @@ module Deas
 
   class Route
 
-    attr_reader :method, :path, :handler_proxy, :handler_class
+    attr_reader :method, :path, :route_proxy, :handler_class
 
-    def initialize(method, path, handler_proxy)
-      @method, @path, @handler_proxy = method, path, handler_proxy
+    def initialize(method, path, route_proxy)
+      @method, @path, @route_proxy = method, path, route_proxy
     end
 
     def validate!
-      @handler_class = @handler_proxy.handler_class
+      @route_proxy.validate!
+      @handler_class = @route_proxy.handler_class
     end
 
-    # TODO: unit test this??
     def run(sinatra_call)
       args = {
         :sinatra_call => sinatra_call
       }
       runner = Deas::SinatraRunner.new(self.handler_class, args)
+
       sinatra_call.request.env.tap do |env|
         env['deas.params'] = runner.params
         env['deas.handler_class_name'] = self.handler_class.name

--- a/lib/deas/route_proxy.rb
+++ b/lib/deas/route_proxy.rb
@@ -4,14 +4,14 @@ require 'deas/exceptions'
 module Deas
   class RouteProxy
 
-    attr_reader :handler_class_name
+    attr_reader :handler_class_name, :handler_class
 
     def initialize(handler_class_name)
       @handler_class_name = handler_class_name
     end
 
-    def handler_class
-      constantize(@handler_class_name).tap do |handler_class|
+    def validate!
+      @handler_class = constantize(@handler_class_name).tap do |handler_class|
         raise(NoHandlerClassError.new(@handler_class_name)) if !handler_class
       end
     end

--- a/test/unit/redirect_proxy_tests.rb
+++ b/test/unit/redirect_proxy_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
-require 'deas/test_helpers'
 require 'deas/redirect_proxy'
+
+require 'deas/test_helpers'
 
 class Deas::RedirectProxy
 
@@ -12,6 +13,7 @@ class Deas::RedirectProxy
     subject{ @proxy }
 
     should have_readers :handler_class_name, :handler_class
+    should have_imeths :validate!
 
     should "know its handler class name" do
       assert_equal subject.handler_class.name, subject.handler_class_name

--- a/test/unit/route_proxy_tests.rb
+++ b/test/unit/route_proxy_tests.rb
@@ -1,7 +1,8 @@
 require 'assert'
+require 'deas/route_proxy'
+
 require 'deas/test_helpers'
 require 'test/support/view_handlers'
-require 'deas/route_proxy'
 
 class Deas::RouteProxy
 
@@ -12,20 +13,23 @@ class Deas::RouteProxy
     end
     subject{ @proxy }
 
-    should have_reader :handler_class_name
-    should have_imeths :handler_class
+    should have_readers :handler_class_name, :handler_class
+    should have_imeths :validate!
 
     should "know its handler class name" do
       assert_equal 'EmptyViewHandler', subject.handler_class_name
     end
 
-    should "know its handler class" do
+    should "set its handler class on `validate!`" do
+      assert_nil subject.handler_class
+
+      assert_nothing_raised{ subject.validate! }
       assert_equal EmptyViewHandler, subject.handler_class
     end
 
     should "complain if there is no handler class with the given name" do
       assert_raises(Deas::NoHandlerClassError) do
-        Deas::RouteProxy.new('SomethingNotDefined').handler_class
+        Deas::RouteProxy.new('SomethingNotDefined').validate!
       end
     end
 

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -30,7 +30,7 @@ class Deas::Router
       assert_instance_of Deas::Route, route
       assert_equal :get,         route.method
       assert_equal '/things',    route.path
-      assert_equal 'ListThings', route.handler_proxy.handler_class_name
+      assert_equal 'ListThings', route.route_proxy.handler_class_name
     end
 
     should "add a POST route using #post" do
@@ -40,7 +40,7 @@ class Deas::Router
       assert_instance_of Deas::Route, route
       assert_equal :post,         route.method
       assert_equal '/things',     route.path
-      assert_equal 'CreateThing', route.handler_proxy.handler_class_name
+      assert_equal 'CreateThing', route.route_proxy.handler_class_name
     end
 
     should "add a PUT route using #put" do
@@ -50,7 +50,7 @@ class Deas::Router
       assert_instance_of Deas::Route, route
       assert_equal :put,          route.method
       assert_equal '/things/:id', route.path
-      assert_equal 'UpdateThing', route.handler_proxy.handler_class_name
+      assert_equal 'UpdateThing', route.route_proxy.handler_class_name
     end
 
     should "add a PATCH route using #patch" do
@@ -60,7 +60,7 @@ class Deas::Router
       assert_instance_of Deas::Route, route
       assert_equal :patch,        route.method
       assert_equal '/things/:id', route.path
-      assert_equal 'UpdateThing', route.handler_proxy.handler_class_name
+      assert_equal 'UpdateThing', route.route_proxy.handler_class_name
     end
 
     should "add a DELETE route using #delete" do
@@ -70,7 +70,7 @@ class Deas::Router
       assert_instance_of Deas::Route, route
       assert_equal :delete,       route.method
       assert_equal '/things/:id', route.path
-      assert_equal 'DeleteThing', route.handler_proxy.handler_class_name
+      assert_equal 'DeleteThing', route.route_proxy.handler_class_name
     end
 
     should "allow defining any kind of route using #route" do
@@ -80,7 +80,7 @@ class Deas::Router
       assert_instance_of Deas::Route, route
       assert_equal :options,    route.method
       assert_equal '/get_info', route.path
-      assert_equal 'GetInfo',   route.handler_proxy.handler_class_name
+      assert_equal 'GetInfo',   route.route_proxy.handler_class_name
     end
 
     should "set a view handler namespace and use it when defining routes" do
@@ -89,11 +89,11 @@ class Deas::Router
 
       # should use the ns
       route = subject.route(:get, '/ns_test', 'NsTest')
-      assert_equal 'MyStuff::NsTest', route.handler_proxy.handler_class_name
+      assert_equal 'MyStuff::NsTest', route.route_proxy.handler_class_name
 
       # should ignore the ns when the leading colons are present
       route = subject.route(:post, '/no_ns_test', '::NoNsTest')
-      assert_equal '::NoNsTest', route.handler_proxy.handler_class_name
+      assert_equal '::NoNsTest', route.route_proxy.handler_class_name
     end
 
     should "set a base url" do
@@ -130,7 +130,7 @@ class Deas::Router
       assert_instance_of Deas::Route, route
       assert_equal :get,       route.method
       assert_equal '/invalid', route.path
-      assert_equal 'Deas::RedirectHandler', route.handler_proxy.handler_class_name
+      assert_equal 'Deas::RedirectHandler', route.route_proxy.handler_class_name
 
       route.validate!
       assert_not_nil route.handler_class


### PR DESCRIPTION
This does some cleanups to the route handling code.  There are a
few different things happening here:
- properly name route proxy attr on the route object
- route proxy now uses a `validate!` method to contantize and
  error - not magically behind some handler class reader.
- redir proxy now also validates like the route proxy - no logic
  needed in this case - just for maintaining a consistent proxy api.
- properly unit test the route object's run behavior
- update the fake sinatra call to support new route run unit tests
- update route test requires to be up to convention

All this is prep for moving logic out of the sinatra runner.  I needed
to add more logic to the route run method but wanted to get it unit
tests first.  The other cleanups were just a side-effect of adding
in the route run unit tests.

@jcredding ready for review.
