### PR TITLE
pass standard args in to the sinatra runner

### DIFF
--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -17,7 +17,13 @@ module Deas
 
     def run(sinatra_call)
       args = {
-        :sinatra_call => sinatra_call
+        :sinatra_call => sinatra_call,
+        :request      => sinatra_call.request,
+        :response     => sinatra_call.response,
+        :params       => sinatra_call.params,
+        :logger       => sinatra_call.settings.logger,
+        :router       => sinatra_call.settings.router,
+        :session      => sinatra_call.session
       }
       runner = Deas::SinatraRunner.new(self.handler_class, args)
 

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -6,17 +6,8 @@ module Deas
   class SinatraRunner < DeasRunner
 
     def initialize(handler_class, args = nil)
-      a = args || {}
-      @sinatra_call = a[:sinatra_call]
-
-      super(handler_class, {
-        :request  => @sinatra_call.request,
-        :response => @sinatra_call.response,
-        :params   => @sinatra_call.params,
-        :logger   => @sinatra_call.settings.logger,
-        :router   => @sinatra_call.settings.router,
-        :session  => @sinatra_call.session,
-      })
+      @sinatra_call = (args || {})[:sinatra_call]
+      super(handler_class, args)
     end
 
     # Helpers

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -59,7 +59,13 @@ class Deas::Route
       assert_equal subject.handler_class, @runner_spy.handler_class
 
       exp_args = {
-        :sinatra_call => @fake_sinatra_call
+        :sinatra_call => @fake_sinatra_call,
+        :request      => @fake_sinatra_call.request,
+        :response     => @fake_sinatra_call.response,
+        :params       => @fake_sinatra_call.params,
+        :logger       => @fake_sinatra_call.settings.logger,
+        :router       => @fake_sinatra_call.settings.router,
+        :session      => @fake_sinatra_call.session
       }
       assert_equal exp_args, @runner_spy.args
 
@@ -102,13 +108,12 @@ class Deas::Route
       @handler_class, @args = handler_class, args
 
       @sinatra_call = args[:sinatra_call]
-
-      @request  = @sinatra_call.request
-      @response = @sinatra_call.response
-      @params   = @sinatra_call.params
-      @logger   = @sinatra_call.logger
-      @router   = @sinatra_call.router
-      @session  = @sinatra_call.session
+      @request      = args[:request]
+      @response     = args[:response]
+      @params       = args[:params]
+      @logger       = args[:logger]
+      @router       = args[:router]
+      @session      = args[:session]
     end
 
     def run

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -33,15 +33,6 @@ class Deas::SinatraRunner
 
     should have_imeths :run
 
-    should "set its standard args from the sinatra call" do
-      assert_equal @fake_sinatra_call.request,         subject.request
-      assert_equal @fake_sinatra_call.response,        subject.response
-      assert_equal @fake_sinatra_call.params,          subject.params
-      assert_equal @fake_sinatra_call.settings.logger, subject.logger
-      assert_equal @fake_sinatra_call.settings.router, subject.router
-      assert_equal @fake_sinatra_call.session,         subject.session
-    end
-
     should "call the sinatra_call's halt with" do
       return_value = catch(:halt){ subject.halt('test') }
       assert_equal [ 'test' ], return_value


### PR DESCRIPTION
This removes auto setting standard args from the sinatra call in the
sinatra runner.  This 1) removes logic from the sinatra runner as
we are moving away from it and 2) allows for setting arguments (like
logger and router) without needing the sinatra call (again, moving
away from relying on sinatra).

This is all setup and work towards phasing out Sinatra and replacing
with native equivalent logic.

@jcredding ready for review.
