### PR TITLE
don't add an underscore to a partial's basename if has one already

### DIFF
--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -76,9 +76,9 @@ module Deas
 
       def initialize(sinatra_call, name, locals = nil)
         options = { :locals => (locals || {}) }
-        name = begin
-          basename = File.basename(name.to_s)
-          name.to_s.sub(/#{basename}\Z/, "_#{basename}")
+        name = name.to_s.tap do |n|
+          basename = File.basename(n)
+          n.sub!(/#{basename}\Z/, "_#{basename}") unless basename[0] == '_'[0]
         end
         super sinatra_call, name, options
       end

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -144,6 +144,11 @@ class Deas::Template
       assert_equal :"users/index/_listing", subject.name
     end
 
+    should "not add an underscore to it's template's basename if one already exists" do
+      partial = Deas::Template::Partial.new(@fake_sinatra_call, 'users/index/_listing')
+      assert_equal :"users/index/_listing", partial.name
+    end
+
     should "set it's locals option" do
       assert_equal({ :user => 'Joe Test' }, subject.options[:locals])
     end


### PR DESCRIPTION
This is so you can easily call render or partial on a path that
includes the underscore and it will work.  This is necessary to
port legacy `partial` commands in handlers to `render` commands and
still have them reuse a common path with template `partial` commands.

@jcredding this came up while porting an app to this new Deas api.  ready for review.
