### PR TITLE
set render layout opt only if it is missing from given opts

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -40,18 +40,18 @@ module Deas
       @sinatra_call.headers(*args)
     end
 
-    def render(template_name, options = nil, &block)
+    def render(template_name, opts = nil, &block)
       self.content_type(get_content_type(template_name)) if self.content_type.nil?
 
       # TODO: move to DeasRunner, don't pass sinatra call to create template
       # def render(template_name, *args, &block)
       #   super(template_name, *args, &block)
-      options ||= {}
+      options = opts || {}
       options[:locals] = {
         :view => self.handler,
         :logger => self.logger
       }.merge(options[:locals] || {})
-      options[:layout] ||= self.handler_class.layouts
+      options[:layout] = self.handler_class.layouts if !options.key?(:layout)
       Deas::Template.new(@sinatra_call, template_name, options).render(&block)
     end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -75,8 +75,23 @@ class Deas::SinatraRunner
         },
         :layout => exp_layouts
       }).render
-
       assert_equal exp_result, subject.render('index')
+
+      exp_result = Deas::Template.new(@fake_sinatra_call, 'index', {
+        :locals => {
+          :view => 'a-view',
+          :some => 'thing',
+          :logger => @runner.logger
+        },
+        :layout => false
+      }).render
+      assert_equal exp_result, subject.render('index', {
+        :layout => false,
+        :locals => {
+          :view => 'a-view',
+          :some => 'thing'
+        }
+      })
     end
 
     should "call the sinatra_call's send_file to set the send files" do


### PR DESCRIPTION
This updates how render options are defaulted.  Now the layout opt
will only be defaulted if it is missing.  Previously, the `:layout`
opt was set using `||=` so if you wanted to manually set it to
`false` you couldn't.

This also updates the tests to validate the "deep merge" behavior
on render locals.  This test was missing and a previous attempt
at this PR broke that behavior unknowingly.

This is all prep for reworking how rendering works and moving away
from Sinatra.

@jcredding another issue that came up porting an app - ready for review.
