### PR TITLE
add `partial` method to template source/engine API

### DIFF
--- a/lib/deas/template_engine.rb
+++ b/lib/deas/template_engine.rb
@@ -15,6 +15,10 @@ module Deas
       raise NotImplementedError
     end
 
+    def partial(path, view_handler, locals)
+      raise NotImplementedError
+    end
+
   end
 
   class NullTemplateEngine < TemplateEngine
@@ -26,6 +30,8 @@ module Deas
       end
       File.read(template_file)
     end
+
+    alias_method :partial, :render
 
   end
 

--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -26,11 +26,18 @@ module Deas
     end
 
     def render(template_path, view_handler, locals)
-      engine = @engines[get_template_ext(template_path)]
-      engine.render(template_path, view_handler, locals)
+      get_engine(template_path).render(template_path, view_handler, locals)
+    end
+
+    def partial(template_path, view_handler, locals)
+      get_engine(template_path).partial(template_path, view_handler, locals)
     end
 
     private
+
+    def get_engine(template_path)
+      @engines[get_template_ext(template_path)]
+    end
 
     def get_template_ext(template_path)
       files = Dir.glob("#{File.join(@path, template_path.to_s)}.*")

--- a/test/support/template.erb
+++ b/test/support/template.erb
@@ -1,0 +1,1 @@
+ERB Template Message: <%= view.message %>

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -18,7 +18,7 @@ class Deas::TemplateEngine
     subject{ @engine }
 
     should have_readers :source_path, :opts
-    should have_imeths :render
+    should have_imeths :render, :partial
 
     should "default its source path" do
       assert_equal Pathname.new(nil.to_s), subject.source_path
@@ -45,6 +45,12 @@ class Deas::TemplateEngine
       end
     end
 
+    should "raise NotImplementedError on `partial`" do
+      assert_raises NotImplementedError do
+        subject.partial(@path, @view_handler, @locals)
+      end
+    end
+
   end
 
   class NullTemplateEngineTests < Assert::Context
@@ -58,16 +64,25 @@ class Deas::TemplateEngine
       assert_kind_of Deas::TemplateEngine, subject
     end
 
-    should "read and return the given path in its source path on `render" do
+    should "read and return the given path in its source path on `render`" do
       exists_file = 'test/support/template.json'
       exp = File.read(subject.source_path.join(exists_file).to_s)
       assert_equal exp, subject.render(exists_file, @view_handler, @locals)
+    end
+
+    should "alias `render` to implement its `partial` method" do
+      exists_file = 'test/support/template.json'
+      exp = subject.render(exists_file, @view_handler, @locals)
+      assert_equal exp, subject.partial(exists_file, @view_handler, @locals)
     end
 
     should "complain if given a path that does not exist in its source path" do
       no_exists_file = '/does/not/exists'
       assert_raises ArgumentError do
         subject.render(no_exists_file, @view_handler, @locals)
+      end
+      assert_raises ArgumentError do
+        subject.partial(no_exists_file, @view_handler, @locals)
       end
     end
 

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -24,7 +24,7 @@ class Deas::TemplateSource
     subject{ @source }
 
     should have_readers :path, :engines
-    should have_imeths :engine, :render
+    should have_imeths :engine, :render, :partial
 
     should "know its path" do
       assert_equal @source_path.to_s, subject.path
@@ -78,22 +78,44 @@ class Deas::TemplateSource
       @source.engine('json', JsonEngine)
     end
 
-    should "render a matching template using the configured engine" do
-      locals = { :something => Factory.string }
-      result = subject.render('test_template', TestServiceHandler, locals)
-      assert_equal 'test-engine', result
+    should "call `render` on the configured engine" do
+      result = subject.render('test_template', TestServiceHandler, {})
+      assert_equal 'render-test-engine', result
     end
 
     should "only try rendering template files its has engines for" do
       # there should be 2 files called "template" in `test/support` with diff
       # extensions
       result = subject.render('template', TestServiceHandler, {})
-      assert_equal 'json-engine', result
+      assert_equal 'render-json-engine', result
     end
 
     should "use the null template engine when an engine can't be found" do
       assert_raises(ArgumentError) do
         subject.render(Factory.string, TestServiceHandler, {})
+      end
+    end
+
+  end
+
+  class PartialTests < RenderTests
+    desc "using `partial`"
+
+    should "call `partial` on the configured engine" do
+      result = subject.partial('test_template', TestServiceHandler, {})
+      assert_equal 'partial-test-engine', result
+    end
+
+    should "only try rendering template files its has engines for" do
+      # there should be 2 files called "template" in `test/support` with diff
+      # extensions
+      result = subject.partial('template', TestServiceHandler, {})
+      assert_equal 'partial-json-engine', result
+    end
+
+    should "use the null template engine when an engine can't be found" do
+      assert_raises(ArgumentError) do
+        subject.partial(Factory.string, TestServiceHandler, {})
       end
     end
 
@@ -118,13 +140,19 @@ class Deas::TemplateSource
 
   class TestEngine < Deas::TemplateEngine
     def render(path, view_handler, locals)
-      'test-engine'
+      'render-test-engine'
+    end
+    def partial(path, view_handler, locals)
+      'partial-test-engine'
     end
   end
 
   class JsonEngine < Deas::TemplateEngine
     def render(path, view_handler, locals)
-      'json-engine'
+      'render-json-engine'
+    end
+    def partial(path, view_handler, locals)
+      'partial-json-engine'
     end
   end
 


### PR DESCRIPTION
This method will be used to help tell the engine whether to consider
layouts or not.  `render` means "consider any specified layouts the
view handler has when rendering".  `partial` means "explicitly ignore
any layouts the handler has and don't render with any layouts".

This is an effort to simplify the render calls.  Right now the runner
(`SinatraRunner`) has to do a fair bit of logic to consider layouts
and any specified layout option given on render calls.  This is
unfortunate b/c not all templates even support layouts.

This shifts the implementation and logic overhead down to the engines.
Engines now should implement both a render and partial method.  For
engines that don't render in layouts, the partial method should just
alias the render method and can be used interchangeably.  Any engines
supporting layouts will gather the layouts from the view handler
like the runner currently does.

@jcredding sorry for the take-partial-out-add-it-back-in on these Deas updates.  I was trying to implement the "sinatra engine" and found the stupid layout option frustrating to deal with.  Especially at the common engine level as it may not even apply to the template you are rendering.  Ultimately I decided layouts should be an engine level implementation detail.  The two methods give the engines an implicit `:layout` option now.  Make sense?  Ready for review.
