### PR TITLE
configure template source on the server; pipe down to the runner

### DIFF
--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -16,16 +16,16 @@ module Deas
     end
 
     def run(sinatra_call)
-      args = {
-        :sinatra_call => sinatra_call,
-        :request      => sinatra_call.request,
-        :response     => sinatra_call.response,
-        :params       => sinatra_call.params,
-        :logger       => sinatra_call.settings.logger,
-        :router       => sinatra_call.settings.router,
-        :session      => sinatra_call.session
-      }
-      runner = Deas::SinatraRunner.new(self.handler_class, args)
+      runner = Deas::SinatraRunner.new(self.handler_class, {
+        :sinatra_call    => sinatra_call,
+        :request         => sinatra_call.request,
+        :response        => sinatra_call.response,
+        :session         => sinatra_call.session,
+        :params          => sinatra_call.params,
+        :logger          => sinatra_call.settings.logger,
+        :router          => sinatra_call.settings.router,
+        :template_source => sinatra_call.settings.template_source
+      })
 
       sinatra_call.request.env.tap do |env|
         env['deas.params'] = runner.params

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -1,25 +1,27 @@
 require 'rack/utils'
 require 'deas/router'
+require 'deas/template_source'
 
 module Deas
 
   class Runner
 
     attr_reader :handler_class, :handler
-    attr_reader :request, :response, :params
-    attr_reader :logger, :router, :session
+    attr_reader :request, :response, :session
+    attr_reader :params, :logger, :router, :template_source
 
     def initialize(handler_class, args = nil)
       @handler_class = handler_class
       @handler = @handler_class.new(self)
 
       a = args || {}
-      @request  = a[:request]
-      @response = a[:response]
-      @params   = a[:params] || {}
-      @logger   = a[:logger] || Deas::NullLogger.new
-      @router   = a[:router] || Deas::Router.new
-      @session  = a[:session]
+      @request         = a[:request]
+      @response        = a[:response]
+      @session         = a[:session]
+      @params          = a[:params] || {}
+      @logger          = a[:logger] || Deas::NullLogger.new
+      @router          = a[:router] || Deas::Router.new
+      @template_source = a[:template_source] || Deas::NullTemplateSource.new
     end
 
     def halt(*args);         raise NotImplementedError; end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -7,6 +7,7 @@ require 'deas/logging'
 require 'deas/show_exceptions'
 require 'deas/router'
 require 'deas/sinatra_app'
+require 'deas/template_source'
 
 module Deas; end
 module Deas::Server
@@ -34,6 +35,7 @@ module Deas::Server
 
     option :verbose_logging, NsOptions::Boolean, :default => true
     option :logger,                              :default => proc{ Deas::NullLogger.new }
+    option :template_source,                     :default => proc{ Deas::NullTemplateSource.new }
 
     attr_accessor :settings, :error_procs, :init_procs, :template_helpers
     attr_accessor :middlewares, :router
@@ -196,6 +198,10 @@ module Deas::Server
 
     def default_charset(*args)
       self.configuration.default_charset *args
+    end
+
+    def template_source(*args)
+      self.configuration.template_source *args
     end
 
     # router handling

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -35,6 +35,7 @@ module Deas
         set :deas_default_charset, server_config.default_charset
         set :logger,               server_config.logger
         set :router,               server_config.router
+        set :template_source,      server_config.template_source
 
         server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -14,10 +14,11 @@ module Deas
       super(handler_class, {
         :request  => args.delete(:request),
         :response => args.delete(:response),
+        :session  => args.delete(:session),
         :params   => NormalizedParams.new(args.delete(:params) || {}).value,
         :logger   => args.delete(:logger),
         :router   => args.delete(:router),
-        :session  => args.delete(:session)
+        :template_source => args.delete(:template_source)
       })
       args.each{|key, value| self.handler.send("#{key}=", value) }
 

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -1,6 +1,7 @@
 require 'ostruct'
 require 'deas'
 require 'deas/router'
+require 'deas/template_source'
 
 class FakeSinatraCall
 
@@ -10,19 +11,21 @@ class FakeSinatraCall
   attr_accessor :request, :response, :params, :logger, :router, :session
   attr_accessor :settings
 
-  def initialize(settings={})
-    @request  = FakeRequest.new('GET','/something', {}, OpenStruct.new)
-    @response = FakeResponse.new
-    @params   = @request.params
-    @logger   = Deas::NullLogger.new
-    @router   = Deas::Router.new
-    @session  = @request.session
+  def initialize(settings = {})
+    @request         = FakeRequest.new('GET','/something', {}, OpenStruct.new)
+    @response        = FakeResponse.new
+    @session         = @request.session
+    @params          = @request.params
+    @logger          = Deas::NullLogger.new
+    @router          = Deas::Router.new
+    @template_source = Deas::NullTemplateSource.new
 
     @settings = OpenStruct.new({
       :deas_template_scope => Deas::Template::Scope,
       :deas_default_charset => 'utf-8',
-      :router => Deas::Router.new,
-      :logger => @logger
+      :logger => @logger,
+      :router => @router,
+      :template_source => @template_source
     }.merge(settings))
   end
 

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -59,13 +59,14 @@ class Deas::Route
       assert_equal subject.handler_class, @runner_spy.handler_class
 
       exp_args = {
-        :sinatra_call => @fake_sinatra_call,
-        :request      => @fake_sinatra_call.request,
-        :response     => @fake_sinatra_call.response,
-        :params       => @fake_sinatra_call.params,
-        :logger       => @fake_sinatra_call.settings.logger,
-        :router       => @fake_sinatra_call.settings.router,
-        :session      => @fake_sinatra_call.session
+        :sinatra_call    => @fake_sinatra_call,
+        :request         => @fake_sinatra_call.request,
+        :response        => @fake_sinatra_call.response,
+        :session         => @fake_sinatra_call.session,
+        :params          => @fake_sinatra_call.params,
+        :logger          => @fake_sinatra_call.settings.logger,
+        :router          => @fake_sinatra_call.settings.router,
+        :template_source => @fake_sinatra_call.settings.template_source
       }
       assert_equal exp_args, @runner_spy.args
 
@@ -107,13 +108,14 @@ class Deas::Route
     def build(handler_class, args)
       @handler_class, @args = handler_class, args
 
-      @sinatra_call = args[:sinatra_call]
-      @request      = args[:request]
-      @response     = args[:response]
-      @params       = args[:params]
-      @logger       = args[:logger]
-      @router       = args[:router]
-      @session      = args[:session]
+      @sinatra_call    = args[:sinatra_call]
+      @request         = args[:request]
+      @response        = args[:response]
+      @session         = args[:session]
+      @params          = args[:params]
+      @logger          = args[:logger]
+      @router          = args[:router]
+      @template_source = args[:template_source]
     end
 
     def run

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -23,8 +23,8 @@ class Deas::Runner
     subject{ @runner }
 
     should have_readers :handler_class, :handler
-    should have_readers :request, :response, :params
-    should have_readers :logger, :router, :session
+    should have_readers :request, :response, :session
+    should have_readers :params, :logger, :router, :template_source
     should have_imeths :halt, :redirect, :content_type, :status, :headers
     should have_imeths :render, :send_file
 
@@ -36,10 +36,11 @@ class Deas::Runner
     should "default its settings" do
       assert_nil subject.request
       assert_nil subject.response
+      assert_nil subject.session
       assert_kind_of ::Hash, subject.params
       assert_kind_of Deas::NullLogger, subject.logger
       assert_kind_of Deas::Router, subject.router
-      assert_nil subject.session
+      assert_kind_of Deas::NullTemplateSource, subject.template_source
     end
 
     should "default its params" do

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -1,10 +1,11 @@
 require 'assert'
 require 'deas/server'
 
-require 'test/support/view_handlers'
 require 'deas/exceptions'
-require 'deas/template'
 require 'deas/router'
+require 'deas/template'
+require 'deas/template_source'
+require 'test/support/view_handlers'
 
 class Deas::Server::Configuration
 
@@ -24,7 +25,7 @@ class Deas::Server::Configuration
 
     # server handling options
 
-    should have_imeths :verbose_logging, :logger
+    should have_imeths :verbose_logging, :logger, :template_source
 
     should have_accessors :settings, :error_procs, :init_procs, :template_helpers
     should have_accessors :middlewares, :router
@@ -49,8 +50,9 @@ class Deas::Server::Configuration
     end
 
     should "default the handling options" do
-      assert_instance_of Deas::NullLogger, subject.logger
       assert_equal true, subject.verbose_logging
+      assert_instance_of Deas::NullLogger, subject.logger
+      assert_instance_of Deas::NullTemplateSource, subject.template_source
     end
 
     should "default its stored configuration" do

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -3,6 +3,7 @@ require 'deas/server'
 
 require 'logger'
 require 'deas/router'
+require 'deas/template_source'
 
 module Deas::Server
 
@@ -22,7 +23,7 @@ module Deas::Server
 
     # DSL for server handling settings
     should have_imeths :init, :error, :template_helpers, :template_helper?
-    should have_imeths :use, :set, :verbose_logging, :logger
+    should have_imeths :use, :set, :verbose_logging, :logger, :template_source
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :redirect, :route, :url, :url_for
 
@@ -86,6 +87,10 @@ module Deas::Server
       stdout_logger = Logger.new(STDOUT)
       subject.logger stdout_logger
       assert_equal stdout_logger, config.logger
+
+      a_source = Deas::TemplateSource.new(Factory.path)
+      subject.template_source a_source
+      assert_equal a_source, config.template_source
 
       subject.default_charset 'latin1'
       assert_equal 'latin1', config.default_charset

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -42,17 +42,18 @@ module Deas::SinatraApp
 
     should "have it's configuration set based on the server configuration" do
       subject.settings.tap do |settings|
-        assert_equal 'staging',                  settings.environment
-        assert_equal 'path/to/somewhere',        settings.root.to_s
-        assert_equal 'path/to/somewhere/public', settings.public_folder.to_s
-        assert_equal 'path/to/somewhere/views',  settings.views.to_s
-        assert_equal true,                       settings.dump_errors
-        assert_equal false,                      settings.method_override
-        assert_equal false,                      settings.sessions
-        assert_equal true,                       settings.static
-        assert_equal true,                       settings.reload_templates
-        assert_instance_of Deas::NullLogger,     settings.logger
-        assert_instance_of Deas::Router,         settings.router
+        assert_equal 'staging',                      settings.environment
+        assert_equal 'path/to/somewhere',            settings.root.to_s
+        assert_equal 'path/to/somewhere/public',     settings.public_folder.to_s
+        assert_equal 'path/to/somewhere/views',      settings.views.to_s
+        assert_equal true,                           settings.dump_errors
+        assert_equal false,                          settings.method_override
+        assert_equal false,                          settings.sessions
+        assert_equal true,                           settings.static
+        assert_equal true,                           settings.reload_templates
+        assert_instance_of Deas::NullLogger,         settings.logger
+        assert_instance_of Deas::Router,             settings.router
+        assert_instance_of Deas::NullTemplateSource, settings.template_source
 
         # settings that are set but can't be changed
         assert_equal false, settings.logging

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -26,12 +26,13 @@ class Deas::TestRunner
     setup do
       @params = { 'value' => '1' }
       @args = {
-        :request  => 'a-request',
-        :response => 'a-response',
-        :params   => @params,
-        :logger   => 'a-logger',
-        :router   => 'a-router',
-        :session  => 'a-session'
+        :request         => 'a-request',
+        :response        => 'a-response',
+        :session         => 'a-session',
+        :params          => @params,
+        :logger          => 'a-logger',
+        :router          => 'a-router',
+        :template_source => 'a-source'
       }
 
       @norm_params_spy = Deas::Runner::NormalizedParamsSpy.new
@@ -47,10 +48,11 @@ class Deas::TestRunner
     should "super its standard args" do
       assert_equal 'a-request',  subject.request
       assert_equal 'a-response', subject.response
+      assert_equal 'a-session',  subject.session
       assert_equal @params,      subject.params
       assert_equal 'a-logger',   subject.logger
       assert_equal 'a-router',   subject.router
-      assert_equal 'a-session',  subject.session
+      assert_equal 'a-source',   subject.template_source
     end
 
     should "call to normalize its params" do


### PR DESCRIPTION
This adds a `template_source` config to the server and the necessary
piping to get that configured source to the runner.  This includes
setting it on the sinatra app and passing it in the route run method.

This only adds the config API and plumbing right now.  Nothing uses
this value (yet) so it doesn't need to be configured (yet).  This is
part of building out the template rendering system and moving away
from relying on sinatra/tilt for rendering.

@jcredding a config and a bunch of piping.  Sucks that I still have to pass these custom settings through the sinatra app but I'm not ready to redo that logic just yet.  Ready for review.
