### PR TITLE
pass logger to tempalate source on init; set as engine default opt

### DIFF
--- a/lib/deas/template_engine.rb
+++ b/lib/deas/template_engine.rb
@@ -1,14 +1,16 @@
 require 'pathname'
+require 'deas/logger'
 
 module Deas
 
   class TemplateEngine
 
-    attr_reader :source_path, :opts
+    attr_reader :source_path, :logger, :opts
 
     def initialize(opts = nil)
       @opts = opts || {}
       @source_path = Pathname.new(@opts['source_path'].to_s)
+      @logger = @opts['logger'] || Deas::NullLogger.new
     end
 
     def render(path, view_handler, locals)

--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -1,3 +1,4 @@
+require 'deas/logger'
 require 'deas/template_engine'
 
 module Deas
@@ -10,9 +11,12 @@ module Deas
 
     attr_reader :path, :engines
 
-    def initialize(path)
+    def initialize(path, logger = nil)
       @path = path.to_s
-      @default_opts = { 'source_path' => @path }
+      @default_opts = {
+        'source_path' => @path,
+        'logger'      => logger || Deas::NullLogger.new
+      }
       @engines = Hash.new{ |h,k| Deas::NullTemplateEngine.new(@default_opts) }
     end
 

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'deas/template_engine'
 
 require 'pathname'
+require 'deas/logger'
 require 'test/support/factory'
 
 class Deas::TemplateEngine
@@ -17,7 +18,7 @@ class Deas::TemplateEngine
     end
     subject{ @engine }
 
-    should have_readers :source_path, :opts
+    should have_readers :source_path, :logger, :opts
     should have_imeths :render, :partial
 
     should "default its source path" do
@@ -27,6 +28,16 @@ class Deas::TemplateEngine
     should "allow custom source paths" do
       engine = Deas::TemplateEngine.new('source_path' => @source_path)
       assert_equal Pathname.new(@source_path.to_s), engine.source_path
+    end
+
+    should "default its logger" do
+      assert_instance_of Deas::NullLogger, subject.logger
+    end
+
+    should "allow custom source loggers" do
+      logger = 'a-logger'
+      engine = Deas::TemplateEngine.new('logger' => logger)
+      assert_equal logger, engine.logger
     end
 
     should "default the opts if none given" do

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -19,7 +19,8 @@ class Deas::TemplateSource
   class InitTests < Assert::Context
     setup do
       @source_path = ROOT.join('test/support').to_s
-      @source = Deas::TemplateSource.new(@source_path)
+      @logger = 'a-logger'
+      @source = Deas::TemplateSource.new(@source_path, @logger)
     end
     subject{ @source }
 
@@ -44,21 +45,35 @@ class Deas::TemplateSource
       assert_kind_of @test_engine, subject.engines['test']
     end
 
-    should "register with the source path as a default option" do
+    should "register with default options" do
       subject.engine 'test', @test_engine
-      exp_opts = { 'source_path' => subject.path }
+      exp_opts = {
+        'source_path' => subject.path,
+        'logger'      => @logger
+      }
       assert_equal exp_opts, subject.engines['test'].opts
 
       subject.engine 'test', @test_engine, 'an' => 'opt'
       exp_opts = {
         'source_path' => subject.path,
+        'logger'      => @logger,
         'an' => 'opt'
       }
       assert_equal exp_opts, subject.engines['test'].opts
 
-      subject.engine 'test', @test_engine, 'source_path' => 'something'
-      exp_opts = { 'source_path' => 'something' }
+      subject.engine('test', @test_engine, {
+        'source_path' => 'something',
+        'logger'      => 'another'
+      })
+      exp_opts = {
+        'source_path' => 'something',
+        'logger'      => 'another'
+      }
       assert_equal exp_opts, subject.engines['test'].opts
+
+      source = Deas::TemplateSource.new(@source_path)
+      source.engine('test', @test_engine)
+      assert_instance_of Deas::NullLogger, source.engines['test'].opts['logger']
     end
 
     should "complain if registering a disallowed temp" do


### PR DESCRIPTION
This allows engines to have access to any configured logger and make
use of it.  Right now it is passed in as a render local but we are
moving away from this with the new template engines render system.

The downsides to passing in as a local are it imposes this local
on the engine.  The engine may not need/want to give the templates
accss to the logger or they may want to expose it with a custom
local name or by some other means besides a local.  This gives the
engine the flexibility to choose how it handles the logger.

@jcredding ready for review.
