### PR TITLE
add capture render/partial methods to the template source/engine API

### DIFF
--- a/lib/deas/template_engine.rb
+++ b/lib/deas/template_engine.rb
@@ -13,11 +13,19 @@ module Deas
       @logger = @opts['logger'] || Deas::NullLogger.new
     end
 
-    def render(path, view_handler, locals)
+    def render(template_name, view_handler, locals)
       raise NotImplementedError
     end
 
-    def partial(path, view_handler, locals)
+    def partial(template_name, view_handler, locals)
+      raise NotImplementedError
+    end
+
+    def capture_render(template_name, view_handler, locals, &content)
+      raise NotImplementedError
+    end
+
+    def capture_partial(template_name, view_handler, locals, &content)
       raise NotImplementedError
     end
 
@@ -25,15 +33,17 @@ module Deas
 
   class NullTemplateEngine < TemplateEngine
 
-    def render(path, view_handler, locals)
-      template_file = self.source_path.join(path).to_s
+    def render(template_name, view_handler, locals)
+      template_file = self.source_path.join(template_name).to_s
       unless File.exists?(template_file)
         raise ArgumentError, "template file `#{template_file}` does not exist"
       end
       File.read(template_file)
     end
 
-    alias_method :partial, :render
+    alias_method :capture_render,  :render
+    alias_method :partial,         :render
+    alias_method :capture_partial, :render
 
   end
 

--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -29,28 +29,36 @@ module Deas
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
     end
 
-    def render(template_path, view_handler, locals)
-      get_engine(template_path).render(template_path, view_handler, locals)
+    def render(template_name, view_handler, locals)
+      get_engine(template_name).render(template_name, view_handler, locals)
     end
 
-    def partial(template_path, view_handler, locals)
-      get_engine(template_path).partial(template_path, view_handler, locals)
+    def partial(template_name, view_handler, locals)
+      get_engine(template_name).partial(template_name, view_handler, locals)
+    end
+
+    def capture_render(template_name, view_handler, locals)
+      get_engine(template_name).capture_render(template_name, view_handler, locals)
+    end
+
+    def capture_partial(template_name, view_handler, locals)
+      get_engine(template_name).capture_partial(template_name, view_handler, locals)
     end
 
     private
 
-    def get_engine(template_path)
-      @engines[get_template_ext(template_path)]
+    def get_engine(template_name)
+      @engines[get_template_ext(template_name)]
     end
 
-    def get_template_ext(template_path)
-      files = Dir.glob("#{File.join(@path, template_path.to_s)}.*")
+    def get_template_ext(template_name)
+      files = Dir.glob("#{File.join(@path, template_name.to_s)}.*")
       files = files.reject{ |p| !@engines.keys.include?(parse_ext(p)) }
       parse_ext(files.first.to_s || '')
     end
 
-    def parse_ext(template_path)
-      File.extname(template_path)[1..-1]
+    def parse_ext(template_name)
+      File.extname(template_name)[1..-1]
     end
 
   end


### PR DESCRIPTION
This adds capture methods to the template system API.  These methods
allow passing a content block to render calls.  They work like their
non-capture counterparts in terms of handling layouts.

These are intended for engines that allow content capturing when
rendering.  They are optional and should only be implemented where
appropriate.  They will not be exposed to the view handler or runner
and will only be called from template scopes.

Their main utility is for implementing template helper methods that
need to capture content.  A plugin can configure its source and then
provide helper methods that call these on its source.

This also cleans up how templates are referenced in these methods.
Everything now consistently refers to the template using the
`template_name` local var.

@jcredding like we discussed.  Ready for review.
