### PR TITLE
cleanup template source/engine rendering api

### DIFF
--- a/lib/deas/template_engine.rb
+++ b/lib/deas/template_engine.rb
@@ -17,15 +17,11 @@ module Deas
       raise NotImplementedError
     end
 
-    def partial(template_name, view_handler, locals)
+    def partial(template_name, locals)
       raise NotImplementedError
     end
 
-    def capture_render(template_name, view_handler, locals, &content)
-      raise NotImplementedError
-    end
-
-    def capture_partial(template_name, view_handler, locals, &content)
+    def capture_partial(template_name, locals, &content)
       raise NotImplementedError
     end
 
@@ -41,9 +37,13 @@ module Deas
       File.read(template_file)
     end
 
-    alias_method :capture_render,  :render
-    alias_method :partial,         :render
-    alias_method :capture_partial, :render
+    def partial(template_name, locals)
+      render(template_name, nil, locals)
+    end
+
+    def capture_partial(template_name, locals, &content)
+      render(template_name, nil, locals)
+    end
 
   end
 

--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -33,16 +33,12 @@ module Deas
       get_engine(template_name).render(template_name, view_handler, locals)
     end
 
-    def partial(template_name, view_handler, locals)
-      get_engine(template_name).partial(template_name, view_handler, locals)
+    def partial(template_name, locals)
+      get_engine(template_name).partial(template_name, locals)
     end
 
-    def capture_render(template_name, view_handler, locals)
-      get_engine(template_name).capture_render(template_name, view_handler, locals)
-    end
-
-    def capture_partial(template_name, view_handler, locals)
-      get_engine(template_name).capture_partial(template_name, view_handler, locals)
+    def capture_partial(template_name, locals, &content)
+      get_engine(template_name).capture_partial(template_name, locals, &content)
     end
 
     private

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -20,7 +20,7 @@ class Deas::TemplateEngine
     subject{ @engine }
 
     should have_readers :source_path, :logger, :opts
-    should have_imeths :render, :partial, :capture_render, :capture_partial
+    should have_imeths :render, :partial, :capture_partial
 
     should "default its source path" do
       assert_equal Pathname.new(nil.to_s), subject.source_path
@@ -59,19 +59,13 @@ class Deas::TemplateEngine
 
     should "raise NotImplementedError on `partial`" do
       assert_raises NotImplementedError do
-        subject.partial(@template_name, @view_handler, @locals)
-      end
-    end
-
-    should "raise NotImplementedError on `capture_render`" do
-      assert_raises NotImplementedError do
-        subject.capture_render(@template_name, @view_handler, @locals, &@content)
+        subject.partial(@template_name, @locals)
       end
     end
 
     should "raise NotImplementedError on `capture_partial`" do
       assert_raises NotImplementedError do
-        subject.capture_partial(@template_name, @view_handler, @locals, &@content)
+        subject.capture_partial(@template_name, @locals, &@content)
       end
     end
 
@@ -97,22 +91,16 @@ class Deas::TemplateEngine
       assert_equal exp, subject.render(exists_file, @v, @l)
     end
 
-    should "alias `render` to implement its `capture_render` method" do
+    should "call `render` to implement its `partial` method" do
       exists_file = 'test/support/template.json'
-      exp = subject.render(exists_file, @v, @l)
-      assert_equal exp, subject.capture_render(exists_file, @v, @l, &@c)
+      exp = subject.render(exists_file, nil, @l)
+      assert_equal exp, subject.partial(exists_file, @l)
     end
 
-    should "alias `render` to implement its `partial` method" do
+    should "call `render` to implement its `capture_partial` method" do
       exists_file = 'test/support/template.json'
-      exp = subject.render(exists_file, @v, @l)
-      assert_equal exp, subject.partial(exists_file, @v, @l)
-    end
-
-    should "alias `render` to implement its `capture_partial` method" do
-      exists_file = 'test/support/template.json'
-      exp = subject.render(exists_file, @v, @l)
-      assert_equal exp, subject.capture_partial(exists_file, @v, @l, &@c)
+      exp = subject.render(exists_file, nil, @l)
+      assert_equal exp, subject.capture_partial(exists_file, @l, &@c)
     end
 
     should "complain if given a path that does not exist in its source path" do
@@ -121,13 +109,10 @@ class Deas::TemplateEngine
         subject.render(no_exists_file, @v, @l)
       end
       assert_raises ArgumentError do
-        subject.capture_render(no_exists_file, @v, @l, &@c)
+        subject.partial(no_exists_file, @l)
       end
       assert_raises ArgumentError do
-        subject.partial(no_exists_file, @v, @l)
-      end
-      assert_raises ArgumentError do
-        subject.capture_partial(no_exists_file, @v, @l, &@c)
+        subject.capture_partial(no_exists_file, @l, &@c)
       end
     end
 

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -26,7 +26,7 @@ class Deas::TemplateSource
 
     should have_readers :path, :engines
     should have_imeths :engine
-    should have_imeths :render, :partial, :capture_render, :capture_partial
+    should have_imeths :render, :partial, :capture_partial
 
     should "know its path" do
       assert_equal @source_path.to_s, subject.path
@@ -122,47 +122,24 @@ class Deas::TemplateSource
 
   end
 
-  class CaptureRenderTests < RenderOrPartialTests
-    desc "when capture rendering a template"
-
-    should "call `capture_render` on the configured engine" do
-      result = subject.capture_render('test_template', @v, @l, &@c)
-      assert_equal 'capture-render-test-engine', result
-    end
-
-    should "only try rendering template files its has engines for" do
-      # there should be 2 files called "template" in `test/support` with diff
-      # extensions
-      result = subject.capture_render('template', @v, @l, &@c)
-      assert_equal 'capture-render-json-engine', result
-    end
-
-    should "use the null template engine when an engine can't be found" do
-      assert_raises(ArgumentError) do
-        subject.capture_render(Factory.string, @v, @l, &@c)
-      end
-    end
-
-  end
-
   class PartialTests < RenderTests
     desc "when partial rendering a template"
 
     should "call `partial` on the configured engine" do
-      result = subject.partial('test_template', @v, @l)
+      result = subject.partial('test_template', @l)
       assert_equal 'partial-test-engine', result
     end
 
     should "only try rendering template files its has engines for" do
       # there should be 2 files called "template" in `test/support` with diff
       # extensions
-      result = subject.partial('template', @v, @l)
+      result = subject.partial('template', @l)
       assert_equal 'partial-json-engine', result
     end
 
     should "use the null template engine when an engine can't be found" do
       assert_raises(ArgumentError) do
-        subject.partial(Factory.string, @v, @l)
+        subject.partial(Factory.string, @l)
       end
     end
 
@@ -172,20 +149,20 @@ class Deas::TemplateSource
     desc "when capture partial rendering a template"
 
     should "call `capture_partial` on the configured engine" do
-      result = subject.capture_partial('test_template', @v, @l, &@c)
+      result = subject.capture_partial('test_template', @l, &@c)
       assert_equal 'capture-partial-test-engine', result
     end
 
     should "only try rendering template files its has engines for" do
       # there should be 2 files called "template" in `test/support` with diff
       # extensions
-      result = subject.capture_partial('template', @v, @l, &@c)
+      result = subject.capture_partial('template', @l, &@c)
       assert_equal 'capture-partial-json-engine', result
     end
 
     should "use the null template engine when an engine can't be found" do
       assert_raises(ArgumentError) do
-        subject.capture_partial(Factory.string, @v, @l, &@c)
+        subject.capture_partial(Factory.string, @l, &@c)
       end
     end
 
@@ -212,13 +189,10 @@ class Deas::TemplateSource
     def render(template_name, view_handler, locals)
       'render-test-engine'
     end
-    def partial(template_name, view_handler, locals)
+    def partial(template_name, locals)
       'partial-test-engine'
     end
-    def capture_render(template_name, view_handler, locals, &content)
-      'capture-render-test-engine'
-    end
-    def capture_partial(template_name, view_handler, locals, &content)
+    def capture_partial(template_name, locals, &content)
       'capture-partial-test-engine'
     end
   end
@@ -227,13 +201,10 @@ class Deas::TemplateSource
     def render(template_name, view_handler, locals)
       'render-json-engine'
     end
-    def partial(template_name, view_handler, locals)
+    def partial(template_name, locals)
       'partial-json-engine'
     end
-    def capture_render(template_name, view_handler, locals, &content)
-      'capture-render-json-engine'
-    end
-    def capture_partial(template_name, view_handler, locals, &content)
+    def capture_partial(template_name, locals, &content)
       'capture-partial-json-engine'
     end
   end


### PR DESCRIPTION
This does a few cleanups to the template source/engine rendering
api.  This is all iterations to get the proper API in place for
developing custom engines.

There are 3 functions each engine can optionally implement:
- `render`: given a view handler, render the template considering
  handler layouts with the given locals
- `partial`: render the template with the given locals
- `capture_partial`: render the template with the given locals
  yielding to the given content block (capturing the given content).

Only `render` and `partial` will be exposed to the view handlers via the
runners as it isn't necessary to render with content blocks at the view
handler level.  Engines can choose to implement these methods in their
scopes as they see fit.

Anyway, all this is just another iteration to lock down the rendering
api for custom engines.

@jcredding ready for review.  Again, sorry for all the back n forth on the partial API while I'm figuring this stuff out.
