### PR TITLE
partial: remove magic-underscoring of partial template names

### DIFF
--- a/lib/deas/template.rb
+++ b/lib/deas/template.rb
@@ -76,10 +76,6 @@ module Deas
 
       def initialize(sinatra_call, name, locals = nil)
         options = { :locals => (locals || {}) }
-        name = name.to_s.tap do |n|
-          basename = File.basename(n)
-          n.sub!(/#{basename}\Z/, "_#{basename}") unless basename[0] == '_'[0]
-        end
         super sinatra_call, name, options
       end
 

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -198,7 +198,7 @@ end
 class PartialHandler
   include Deas::ViewHandler
 
-  def run!; partial 'info', :info => 'some-info'; end
+  def run!; partial '_info', :info => 'some-info'; end
 
 end
 

--- a/test/support/views/show.erb
+++ b/test/support/views/show.erb
@@ -1,2 +1,2 @@
 show page: <%= view.message %>
-<%= partial "info", :info => 'Show Info' %>
+<%= partial "_info", :info => 'Show Info' %>

--- a/test/unit/template_tests.rb
+++ b/test/unit/template_tests.rb
@@ -100,7 +100,7 @@ class Deas::Template
     end
 
     should "call the sinatra_call's erb method with #partial" do
-      render_args = subject.partial('part', {
+      render_args = subject.partial('_part', {
         :something => true
       }, &Proc.new{ '#partial called this proc' })
 
@@ -130,7 +130,7 @@ class Deas::Template
   class PartialTests < UnitTests
     desc "Partial"
     setup do
-      @partial = Deas::Template::Partial.new(@fake_sinatra_call, 'users/index/listing', {
+      @partial = Deas::Template::Partial.new(@fake_sinatra_call, 'users/index/_listing', {
         :user => 'Joe Test'
       })
     end
@@ -138,15 +138,6 @@ class Deas::Template
 
     should "be a kind of Deas::Template" do
       assert_kind_of Deas::Template, subject
-    end
-
-    should "add an underscore to it's template's basename" do
-      assert_equal :"users/index/_listing", subject.name
-    end
-
-    should "not add an underscore to it's template's basename if one already exists" do
-      partial = Deas::Template::Partial.new(@fake_sinatra_call, 'users/index/_listing')
-      assert_equal :"users/index/_listing", partial.name
     end
 
     should "set it's locals option" do


### PR DESCRIPTION
This logic has proven to be unnecessarily complex.  The partial
should be about rendering with just locals and no layouts - not
the extra wrinkle of expecting underscored template names.

Doing this greatly simplifies the rendering API needed.  Also it
makes template referencing more straightforward and less magical.
You can keep using the underscored-named-partial convention - just
do it manually.

@jcredding like we discussed earlier today - ready for review.
