### PR TITLE
sinatra runner: render with template source if there is an engine

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -40,23 +40,29 @@ module Deas
       @sinatra_call.headers(*args)
     end
 
-    def render(template_name, opts = nil, &block)
+    def render(template_name, opts = nil)
       self.content_type(get_content_type(template_name)) if self.content_type.nil?
 
-      # TODO: move to DeasRunner, don't pass sinatra call to create template
-      # def render(template_name, *args, &block)
-      #   super(template_name, *args, &block)
       options = opts || {}
       options[:locals] = {
         :view => self.handler,
         :logger => self.logger
       }.merge(options[:locals] || {})
       options[:layout] = self.handler_class.layouts if !options.key?(:layout)
-      Deas::Template.new(@sinatra_call, template_name, options).render(&block)
+
+      if self.template_source.engine_for?(template_name)
+        self.template_source.render(template_name, self.handler, options[:locals])
+      else
+        Deas::Template.new(@sinatra_call, template_name, options).render
+      end
     end
 
     def partial(template_name, locals = nil)
-      Deas::Template::Partial.new(@sinatra_call, template_name, locals).render
+      if self.template_source.engine_for?(template_name)
+        self.template_source.partial(template_name, locals || {})
+      else
+        Deas::Template::Partial.new(@sinatra_call, template_name, locals).render
+      end
     end
 
     def send_file(*args, &block)

--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -29,6 +29,10 @@ module Deas
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
     end
 
+    def engine_for?(template_name)
+      @engines.keys.include?(get_template_ext(template_name))
+    end
+
     def render(template_name, view_handler, locals)
       get_engine(template_name).render(template_name, view_handler, locals)
     end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -33,7 +33,6 @@ class DeasTestServer
   get  '/session',  'UseSessionHandler'
 
   get  '/with_layout',           'WithLayoutHandler'
-  get  '/alt_with_layout',       'AlternateWithLayoutHandler'
   get  '/haml_with_layout',      'HamlWithLayoutHandler'
   get  '/with_haml_layout',      'WithHamlLayoutHandler'
   get  '/haml_with_haml_layout', 'HamlWithHamlLayoutHandler'
@@ -146,21 +145,6 @@ class WithLayoutHandler
 
   def run!
     render 'with_layout'
-  end
-
-end
-
-class AlternateWithLayoutHandler
-  include Deas::ViewHandler
-
-  def run!
-    render 'layout1' do
-      render 'layout2' do
-        render 'layout3' do
-          render 'with_layout'
-        end
-      end
-    end
   end
 
 end

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -72,11 +72,6 @@ module Deas
       expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layouts View: WithLayoutHandler\n"
       assert_equal 200,           last_response.status
       assert_equal expected_body, last_response.body
-
-      get '/alt_with_layout'
-      expected_body = "Layout 1\nLayout 2\nLayout 3\nWith Layouts View: AlternateWithLayoutHandler\n"
-      assert_equal 200,           last_response.status
-      assert_equal expected_body, last_response.body
     end
 
     should "render mixed (erb and other) templates using layouts" do

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -112,4 +112,44 @@ class Deas::SinatraRunner
 
   end
 
+  class InitWithEngineTests < UnitTests
+    desc "when init with a template source and matching engine"
+    setup do
+      @fake_sinatra_call = FakeSinatraCall.new
+      @runner = @runner_class.new(DeasRunnerViewHandler, {
+        :sinatra_call => @fake_sinatra_call,
+        :template_source => FakeTemplateSource.new
+      })
+    end
+    subject{ @runner }
+
+    should "render templates using the source" do
+      exp_handler = DeasRunnerViewHandler.new(subject)
+      exp_locals = {
+        :view => exp_handler,
+        :logger => @runner.logger,
+        :some => 'locals'
+      }
+      exp = ['render', 'info', @runner.handler, exp_locals]
+      assert_equal exp, subject.render('info', :locals => {
+        :some => 'locals'
+      })
+    end
+
+    should "render partials using the source" do
+      exp = ['partial', 'info', { :some => 'locals' }]
+      assert_equal exp, subject.partial('info', { :some => 'locals' })
+    end
+
+  end
+
+  class FakeTemplateSource
+    def engine_for?(template_name)
+      true
+    end
+
+    def render(*args);  ['render',  *args]; end
+    def partial(*args); ['partial', *args]; end
+  end
+
 end

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -25,7 +25,7 @@ class Deas::TemplateSource
     subject{ @source }
 
     should have_readers :path, :engines
-    should have_imeths :engine
+    should have_imeths :engine, :engine_for?
     should have_imeths :render, :partial, :capture_partial
 
     should "know its path" do
@@ -83,6 +83,13 @@ class Deas::TemplateSource
         subject.engine 'rb', @test_engine
       end
       assert_kind_of Deas::NullTemplateEngine, subject.engines['rb']
+    end
+
+    should "know if it has an engine registered for a given template name" do
+      assert_false subject.engine_for?('test_template')
+
+      subject.engine 'test', @test_engine
+      assert_true subject.engine_for?('test_template')
     end
 
   end


### PR DESCRIPTION
This updates the sinatra runner to prefer to render using a matching
engine on the template source if one has been configured.  If not
it falls back to rendering with Sinatra as before.

This is a temporary patch to allow transitioning off sinatra and
on to engines.  This is part of moving away from Sinatra for rendering.

Note too that I removed the alt layout render system tests b/c we
are no longer supporting calling `render` with a block in the view
handlers.

@jcredding ready for review.  I chose not to add a system test for this and the tests will be dramatically changing once I remove all the sinatra rendering logic out of here.  I'll address any necessary system tests for template source rendering then.
