### PR TITLE
cleanups to the runner objs and their tests

### DIFF
--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -16,14 +16,14 @@ module Deas
     end
 
     def run(sinatra_call)
-      runner = Deas::SinatraRunner.new(self.handler_class, {
-        :sinatra_call    => sinatra_call,
-        :request         => sinatra_call.request,
-        :response        => sinatra_call.response,
-        :session         => sinatra_call.session,
-        :params          => sinatra_call.params,
-        :logger          => sinatra_call.settings.logger,
-        :router          => sinatra_call.settings.router,
+      runner = SinatraRunner.new(self.handler_class, {
+        :sinatra_call => sinatra_call,
+        :request      => sinatra_call.request,
+        :response     => sinatra_call.response,
+        :session      => sinatra_call.session,
+        :params       => sinatra_call.params,
+        :logger       => sinatra_call.settings.logger,
+        :router       => sinatra_call.settings.router,
         :template_source => sinatra_call.settings.template_source
       })
 

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -1,3 +1,8 @@
+# need to define class immediately b/c of circular requires:
+# - runner -> router -> route -> deas_runner -> runner
+module Deas; end
+class Deas::Runner; end
+
 require 'rack/utils'
 require 'deas/logger'
 require 'deas/router'

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -1,16 +1,23 @@
 require 'rack/multipart'
 require 'deas/router'
 require 'deas/runner'
+require 'deas/view_handler'
 
 module Deas
+
+  InvalidServiceHandlerError = Class.new(StandardError)
 
   class TestRunner < Runner
 
     attr_reader :return_value
 
     def initialize(handler_class, args = nil)
-      args = (args || {}).dup
+      if !handler_class.include?(Deas::ViewHandler)
+        raise InvalidServiceHandlerError, "#{handler_class.inspect} is not a"\
+                                          " Deas::ServiceHandler"
+      end
 
+      args = (args || {}).dup
       super(handler_class, {
         :request  => args.delete(:request),
         :response => args.delete(:response),

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -8,11 +8,13 @@ end
 class TestRunnerViewHandler
   include Deas::ViewHandler
 
+  attr_reader :before_called, :init_called
   attr_accessor :custom_value
 
-  def run!
-    'run has run'
-  end
+  before{ @before_called = true }
+
+  def init!; @init_called = true; end
+  def run!;  'run has run';       end
 
 end
 

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -59,13 +59,13 @@ class Deas::Route
       assert_equal subject.handler_class, @runner_spy.handler_class
 
       exp_args = {
-        :sinatra_call    => @fake_sinatra_call,
-        :request         => @fake_sinatra_call.request,
-        :response        => @fake_sinatra_call.response,
-        :session         => @fake_sinatra_call.session,
-        :params          => @fake_sinatra_call.params,
-        :logger          => @fake_sinatra_call.settings.logger,
-        :router          => @fake_sinatra_call.settings.router,
+        :sinatra_call => @fake_sinatra_call,
+        :request      => @fake_sinatra_call.request,
+        :response     => @fake_sinatra_call.response,
+        :session      => @fake_sinatra_call.session,
+        :params       => @fake_sinatra_call.params,
+        :logger       => @fake_sinatra_call.settings.logger,
+        :router       => @fake_sinatra_call.settings.router,
         :template_source => @fake_sinatra_call.settings.template_source
       }
       assert_equal exp_args, @runner_spy.args
@@ -98,8 +98,8 @@ class Deas::Route
     attr_reader :run_called
     attr_reader :handler_class, :args
     attr_reader :sinatra_call
-    attr_reader :request, :response, :params
-    attr_reader :logger, :router, :session
+    attr_reader :request, :response, :session, :params
+    attr_reader :logger, :router, :template_source
 
     def initialize
       @run_called = false
@@ -108,13 +108,13 @@ class Deas::Route
     def build(handler_class, args)
       @handler_class, @args = handler_class, args
 
-      @sinatra_call    = args[:sinatra_call]
-      @request         = args[:request]
-      @response        = args[:response]
-      @session         = args[:session]
-      @params          = args[:params]
-      @logger          = args[:logger]
-      @router          = args[:router]
+      @sinatra_call = args[:sinatra_call]
+      @request      = args[:request]
+      @response     = args[:response]
+      @session      = args[:session]
+      @params       = args[:params]
+      @logger       = args[:logger]
+      @router       = args[:router]
       @template_source = args[:template_source]
     end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -38,15 +38,10 @@ class Deas::Runner
       assert_nil subject.request
       assert_nil subject.response
       assert_nil subject.session
-      assert_kind_of ::Hash, subject.params
+      assert_equal ::Hash.new, subject.params
       assert_kind_of Deas::NullLogger, subject.logger
       assert_kind_of Deas::Router, subject.router
       assert_kind_of Deas::NullTemplateSource, subject.template_source
-    end
-
-    should "default its params" do
-      runner = @runner_class.new(TestRunnerViewHandler)
-      assert_equal ::Hash.new, runner.params
     end
 
     should "not implement any actions" do


### PR DESCRIPTION
These are some cleanups, mostly to tests, on the runner objects.  I
noticed these while updated the runner objs on Sanford to better match
how Deas passes an args hash to init them.  This adds some tests that
were missing and does some style cleanups.

The only behavior change is the test runner will now raise a hard
exception if it init without a valid view handler class.  This matches
how Sanford and Qs work.

@jcredding ready for review.
