### PR TITLE
pass the template source as a default option to the engines

### DIFF
--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -14,8 +14,9 @@ module Deas
     def initialize(path, logger = nil)
       @path = path.to_s
       @default_opts = {
-        'source_path' => @path,
-        'logger'      => logger || Deas::NullLogger.new
+        'source_path'          => @path,
+        'logger'               => logger || Deas::NullLogger.new,
+        'deas_template_source' => self
       }
       @engines = Hash.new{ |h,k| Deas::NullTemplateEngine.new(@default_opts) }
     end

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -50,30 +50,30 @@ class Deas::TemplateSource
     should "register with default options" do
       subject.engine 'test', @test_engine
       exp_opts = {
-        'source_path' => subject.path,
-        'logger'      => @logger
+        'source_path'          => subject.path,
+        'logger'               => @logger,
+        'deas_template_source' => subject
       }
       assert_equal exp_opts, subject.engines['test'].opts
 
-      source = Deas::TemplateSource.new(@source_path)
-      source.engine 'test', @test_engine
-      assert_kind_of Deas::NullLogger, source.engines['test'].opts['logger']
-
       subject.engine 'test', @test_engine, 'an' => 'opt'
       exp_opts = {
-        'source_path' => subject.path,
-        'logger'      => @logger,
-        'an'          => 'opt'
+        'source_path'          => subject.path,
+        'logger'               => @logger,
+        'deas_template_source' => subject,
+        'an'                   => 'opt'
       }
       assert_equal exp_opts, subject.engines['test'].opts
 
       subject.engine('test', @test_engine, {
-        'source_path' => 'something',
-        'logger'      => 'another'
+        'source_path'          => 'something',
+        'logger'               => 'another',
+        'deas_template_source' => 'tempsource'
       })
       exp_opts = {
-        'source_path' => 'something',
-        'logger'      => 'another'
+        'source_path'          => 'something',
+        'logger'               => 'another',
+        'deas_template_source' => 'tempsource'
       }
       assert_equal exp_opts, subject.engines['test'].opts
 


### PR DESCRIPTION
This allows the engines to make template helpers that can call
template source render API methods.  This allows rendering one
engine's partials from another engine's template.  This will also
be used to render partials that have multiple engine extensions.

Closes #153.

@jcredding ready for review.
