### PR TITLE
add `compile` to the template engine render API

### DIFF
--- a/lib/deas/template_engine.rb
+++ b/lib/deas/template_engine.rb
@@ -25,6 +25,10 @@ module Deas
       raise NotImplementedError
     end
 
+    def compile(template_content, locals)
+      raise NotImplementedError
+    end
+
   end
 
   class NullTemplateEngine < TemplateEngine
@@ -43,6 +47,10 @@ module Deas
 
     def capture_partial(template_name, locals, &content)
       render(template_name, nil, locals)
+    end
+
+    def compile(template_content, locals)
+      template_content  # no-op, pass-thru - just return the given content
     end
 
   end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -20,7 +20,7 @@ class Deas::TemplateEngine
     subject{ @engine }
 
     should have_readers :source_path, :logger, :opts
-    should have_imeths :render, :partial, :capture_partial
+    should have_imeths :render, :partial, :capture_partial, :compile
 
     should "default its source path" do
       assert_equal Pathname.new(nil.to_s), subject.source_path
@@ -69,6 +69,12 @@ class Deas::TemplateEngine
       end
     end
 
+    should "raise NotImplementedError on `compile`" do
+      assert_raises NotImplementedError do
+        subject.compile(Factory.text, @locals)
+      end
+    end
+
   end
 
   class NullTemplateEngineTests < Assert::Context
@@ -114,6 +120,11 @@ class Deas::TemplateEngine
       assert_raises ArgumentError do
         subject.capture_partial(no_exists_file, @l, &@c)
       end
+    end
+
+    should "return any given content with its `compile` method" do
+      exp = Factory.string
+      assert_equal exp, subject.compile(exp, @l)
     end
 
   end


### PR DESCRIPTION
This method is given template content that must be rendered against
the given locals.  This will be used when rendering multiple engines
on the same template file.  The first engine will open the file and
do its render while subsequent engines will compile rendered content
from the upstream engines.

The default template engine is a no-op pass-thru.  This is so that
if there is no engine configured for an extension, it will be ignored.

Closes #154.
Related to #81.

@jcredding ready for review.
