### PR TITLE
have `compile` render api expect the template name

### DIFF
--- a/lib/deas/template_engine.rb
+++ b/lib/deas/template_engine.rb
@@ -25,7 +25,7 @@ module Deas
       raise NotImplementedError
     end
 
-    def compile(template_content, locals)
+    def compile(template_name, compiled_content)
       raise NotImplementedError
     end
 
@@ -49,8 +49,8 @@ module Deas
       render(template_name, nil, locals)
     end
 
-    def compile(template_content, locals)
-      template_content  # no-op, pass-thru - just return the given content
+    def compile(template_name, compiled_content)
+      compiled_content  # no-op, pass-thru - just return the given content
     end
 
   end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -71,7 +71,7 @@ class Deas::TemplateEngine
 
     should "raise NotImplementedError on `compile`" do
       assert_raises NotImplementedError do
-        subject.compile(Factory.text, @locals)
+        subject.compile(@template_name, Factory.text)
       end
     end
 
@@ -124,7 +124,7 @@ class Deas::TemplateEngine
 
     should "return any given content with its `compile` method" do
       exp = Factory.string
-      assert_equal exp, subject.compile(exp, @l)
+      assert_equal exp, subject.compile(Factory.path, exp)
     end
 
   end


### PR DESCRIPTION
This is so you can provide meaningful backtraces and file information
even when rendering content that has already been rendered by another
engine.

This came up when attempting to implement `compile` for deas-erubis.
It is nice to give a file name so any exceptions get nice backtraces.

Note: this also removes locals from the expected API.  Locals are 
only needed at the top-level engine as all local handling should
be handled with that engine (ie Erb or other).  Compiling with
downstream engines should be about converting a more convenient
markup (ie writing markdown with erb) to the needed markup.

@jcredding ready for review.