### PR TITLE
render API: remove `capture_partial` method

### DIFF
--- a/lib/deas/template_engine.rb
+++ b/lib/deas/template_engine.rb
@@ -17,11 +17,7 @@ module Deas
       raise NotImplementedError
     end
 
-    def partial(template_name, locals)
-      raise NotImplementedError
-    end
-
-    def capture_partial(template_name, locals, &content)
+    def partial(template_name, locals, &content)
       raise NotImplementedError
     end
 
@@ -41,11 +37,7 @@ module Deas
       File.read(template_file)
     end
 
-    def partial(template_name, locals)
-      render(template_name, nil, locals)
-    end
-
-    def capture_partial(template_name, locals, &content)
+    def partial(template_name, locals, &content)
       render(template_name, nil, locals)
     end
 

--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -34,20 +34,16 @@ module Deas
       @engines.keys.include?(get_template_ext(template_name))
     end
 
-    def render(template_name, view_handler, locals)
+    def render(template_name, view_handler, locals, &content)
       [ view_handler.class.layouts,
         template_name
-      ].flatten.reverse.inject(proc{}) do |render_proc, name|
+      ].flatten.reverse.inject(content) do |render_proc, name|
         proc{ get_engine(name).render(name, view_handler, locals, &render_proc) }
       end.call
     end
 
-    def partial(template_name, locals)
-      get_engine(template_name).partial(template_name, locals)
-    end
-
-    def capture_partial(template_name, locals, &content)
-      get_engine(template_name).capture_partial(template_name, locals, &content)
+    def partial(template_name, locals, &content)
+      get_engine(template_name).partial(template_name, locals, &content)
     end
 
     private

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -20,7 +20,7 @@ class Deas::TemplateEngine
     subject{ @engine }
 
     should have_readers :source_path, :logger, :opts
-    should have_imeths :render, :partial, :capture_partial, :compile
+    should have_imeths :render, :partial, :compile
 
     should "default its source path" do
       assert_equal Pathname.new(nil.to_s), subject.source_path
@@ -63,12 +63,6 @@ class Deas::TemplateEngine
       end
     end
 
-    should "raise NotImplementedError on `capture_partial`" do
-      assert_raises NotImplementedError do
-        subject.capture_partial(@template_name, @locals, &@content)
-      end
-    end
-
     should "raise NotImplementedError on `compile`" do
       assert_raises NotImplementedError do
         subject.compile(@template_name, Factory.text)
@@ -103,12 +97,6 @@ class Deas::TemplateEngine
       assert_equal exp, subject.partial(exists_file, @l)
     end
 
-    should "call `render` to implement its `capture_partial` method" do
-      exists_file = 'test/support/template.json'
-      exp = subject.render(exists_file, nil, @l)
-      assert_equal exp, subject.capture_partial(exists_file, @l, &@c)
-    end
-
     should "complain if given a path that does not exist in its source path" do
       no_exists_file = '/does/not/exists'
       assert_raises ArgumentError do
@@ -116,9 +104,6 @@ class Deas::TemplateEngine
       end
       assert_raises ArgumentError do
         subject.partial(no_exists_file, @l)
-      end
-      assert_raises ArgumentError do
-        subject.capture_partial(no_exists_file, @l, &@c)
       end
     end
 

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -27,7 +27,7 @@ class Deas::TemplateSource
 
     should have_readers :path, :engines
     should have_imeths :engine, :engine_for?
-    should have_imeths :render, :partial, :capture_partial
+    should have_imeths :render, :partial
 
     should "know its path" do
       assert_equal @source_path.to_s, subject.path
@@ -153,7 +153,7 @@ class Deas::TemplateSource
     desc "when partial rendering a template"
 
     should "call `partial` on the configured engine" do
-      exp = 'partial-test-engine'
+      exp = "partial-test-engine\n"
       assert_equal exp, subject.partial('test_template', @l)
     end
 
@@ -167,29 +167,6 @@ class Deas::TemplateSource
     should "use the null template engine when an engine can't be found" do
       assert_raises(ArgumentError) do
         subject.partial(Factory.string, @l)
-      end
-    end
-
-  end
-
-  class CapturePartialTests < RenderOrPartialTests
-    desc "when capture partial rendering a template"
-
-    should "call `capture_partial` on the configured engine" do
-      exp = 'capture-partial-test-engine'
-      assert_equal exp, subject.capture_partial('test_template', @l, &@c)
-    end
-
-    should "only try rendering template files its has engines for" do
-      # there should be 2 files called "template" in `test/support` with diff
-      # extensions
-      exp = 'capture-partial-json-engine'
-      assert_equal exp, subject.capture_partial('template', @l, &@c)
-    end
-
-    should "use the null template engine when an engine can't be found" do
-      assert_raises(ArgumentError) do
-        subject.capture_partial(Factory.string, @l, &@c)
       end
     end
 
@@ -214,10 +191,11 @@ class Deas::TemplateSource
 
   class TestEngine < Deas::TemplateEngine
     def render(template_name, view_handler, locals, &content)
-      "render-test-engine on #{template_name}\n" + content.call.to_s
+      "render-test-engine on #{template_name}\n" +
+      (content || proc{}).call.to_s
     end
-    def partial(template_name, locals)
-      'partial-test-engine'
+    def partial(template_name, locals, &content)
+      "partial-test-engine\n" + (content || proc{}).call.to_s
     end
     def capture_partial(template_name, locals, &content)
       'capture-partial-test-engine'


### PR DESCRIPTION
This updates the render API to support sending a content block to
source/engine partial calls.  Doing this removes the need for a
dedicated capture partial method as it is just a partial call with
a content block.

This also cleans up the API to formally allow passing content blocks
to both the `render` and `partial` methods at the source level.  The
runner doesn't expose this to the view handler as it doesn't make
sense.  However, engines can use this in their template helpers.

This is all part of standardizing a rendering API that allows for
creating specific template engines that support rich rendering.
Deas::Erubis will specifically take advantage of these APIs to
allow rich partial rendering.

@jcredding like we discussed, I need this in place and need to roll a version to do the test cleanups we discussed in redding/deas-erubis#12.  Ready for review.