### PR TITLE
cache template name extensions at the template source

### DIFF
--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -91,6 +91,7 @@ class Deas::TemplateSource
     end
 
     should "know if it has an engine registered for a given template name" do
+      assert_false subject.engine_for?(Factory.string)
       assert_false subject.engine_for?('test_template')
 
       subject.engine 'test', @test_engine


### PR DESCRIPTION
This is a small render optimization.  The goal is to limit the
somewhat expensive logic of globing files on disk that match the
template name, rejecting out irrelevent ones and choosing the first
matching one just in order to lookup a files extension.

With this implementation, the expensive logic is only run once per
template (on the first lookup).  This will improve every render
call as this lookup is done both at engine-selection time but also
when querying to know if there is an engine available for the template.

Note: this also adds a test to make sure `engine_for?` returns false
on missing template names.  This was missing in the original tests
and is all about better coverage.

@jcredding ready for review.  This is all private level logic so it isn't really _explicitly_ tested.  Nothing tests that there is actually a cache in place.  I wasn't sure how to test this without exposing more that I wanted to.  Plus its private logic and we typically don't test that explicitly.  Let me know what you think.  I can certainly expose the cache and then test it more explicitly if you think it is important.