### PR TITLE
rework template source api for querying about configured engines

### DIFF
--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -37,8 +37,12 @@ module Deas
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
     end
 
-    def engine_for?(template_name)
-      @engines.keys.include?(get_template_ext(template_name))
+    def engine_for?(ext)
+      @engines.keys.include?(ext)
+    end
+
+    def engine_for_template?(template_name)
+      self.engine_for?(get_template_ext(template_name))
     end
 
     def render(template_name, view_handler, locals, &content)

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -26,7 +26,7 @@ class Deas::TemplateSource
     subject{ @source }
 
     should have_readers :path, :engines
-    should have_imeths :engine, :engine_for?
+    should have_imeths :engine, :engine_for?, :engine_for_template?
     should have_imeths :render, :partial
 
     should "know its path" do
@@ -92,10 +92,13 @@ class Deas::TemplateSource
 
     should "know if it has an engine registered for a given template name" do
       assert_false subject.engine_for?(Factory.string)
-      assert_false subject.engine_for?('test_template')
+      assert_false subject.engine_for?('test')
+      assert_false subject.engine_for_template?(Factory.string)
+      assert_false subject.engine_for_template?('test_template')
 
       subject.engine 'test', @test_engine
-      assert_true subject.engine_for?('test_template')
+      assert_true subject.engine_for?('test')
+      assert_true subject.engine_for_template?('test_template')
     end
 
   end


### PR DESCRIPTION
This reworks the `engine_for?` method to just take an extension
as an argument.  It then adds an `engine_for_template?` method that
works like the prev engine for method did.

The goal here is to be able to query whether an engine has been
configured when you already know the extension while keeping the
old ability to query when you don't know the extension but know the
template.

@jcredding ready for review.  I can across this need while updating our application configurations to use the latest deas and deas-erubis stuff.