### PR TITLE
update test runner render args to conform to new render API

### DIFF
--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -75,15 +75,15 @@ module Deas
     end
     HeadersArgs = Struct.new(:value)
 
-    def render(template_name, options = nil, &block)
-      RenderArgs.new(template_name, options, block)
+    def render(template_name, locals = nil)
+      RenderArgs.new(template_name, locals)
     end
-    RenderArgs = Struct.new(:template_name, :options, :block)
+    RenderArgs = Struct.new(:template_name, :locals)
 
     def partial(template_name, locals = nil)
       PartialArgs.new(template_name, locals)
     end
-    PartialArgs = Struct.new(:template_name, :locals)
+    PartialArgs = RenderArgs
 
     def send_file(file_path, options = nil, &block)
       SendFileArgs.new(file_path, options, block)

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -40,16 +40,6 @@ class FakeSinatraCall
   def status(*args);       args; end
   def headers(*args);      args; end
 
-  # return the template name for each nested calls
-  def erb(template_name, opts, &block)
-    if block
-      RenderArgs.new(template_name, opts, block.call)
-    else
-      RenderArgs.new(template_name, opts, nil)
-    end
-  end
-  RenderArgs = Struct.new(:template_name, :opts, :block_call_result)
-
   def send_file(file_path, opts, &block)
     if block
       SendFileArgs.new(file_path, opts, block.call)

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -38,7 +38,7 @@ class RenderViewHandler
   include Deas::ViewHandler
 
   def run!
-    render "my_template", :some => :option
+    render "my_template", :some => 'local'
   end
 end
 
@@ -46,7 +46,7 @@ class PartialViewHandler
   include Deas::ViewHandler
 
   def run!
-    partial "my_partial", :some => 'locals'
+    partial "my_partial", :some => 'local'
   end
 end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -133,31 +133,40 @@ class Deas::TestRunner
     end
 
     should "build render args if render is called" do
-      value = subject.render 'some/template'
-      assert_kind_of RenderArgs, value
-      [:template_name, :options, :block].each do |meth|
-        assert_respond_to meth, value
+      template_name = Factory.path
+      locals = { Factory.string => Factory.string }
+      args = subject.render template_name, locals
+
+      assert_kind_of RenderArgs, args
+      [:template_name, :locals].each do |meth|
+        assert_respond_to meth, args
       end
-      assert_equal 'some/template', value.template_name
+      assert_equal template_name, args.template_name
+      assert_equal locals,        args.locals
     end
 
     should "build partial args if partial is called" do
-      value = subject.partial 'some/partial', :some => 'locals'
-      assert_kind_of PartialArgs, value
+      template_name = Factory.path
+      locals = { Factory.string => Factory.string }
+      args = subject.partial template_name, locals
+
+      assert_kind_of PartialArgs, args
       [:template_name, :locals].each do |meth|
-        assert_respond_to meth, value
+        assert_respond_to meth, args
       end
-      assert_equal 'some/partial', value.template_name
-      assert_equal({:some => 'locals'}, value.locals)
+      assert_equal template_name, args.template_name
+      assert_equal locals,        args.locals
     end
 
     should "build send file args if send file is called" do
-      value = subject.send_file 'some/file/path'
-      assert_kind_of SendFileArgs, value
+      path = Factory.path
+      args = subject.send_file path
+
+      assert_kind_of SendFileArgs, args
       [:file_path, :options, :block].each do |meth|
-        assert_respond_to meth, value
+        assert_respond_to meth, args
       end
-      assert_equal 'some/file/path', value.file_path
+      assert_equal path, args.file_path
     end
 
   end

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -73,20 +73,20 @@ module Deas::ViewHandler
 
     should "render templates" do
       render_args = test_runner(RenderViewHandler).run
-      assert_equal "my_template",        render_args.template_name
-      assert_equal({ :some => :option }, render_args.options)
+      assert_equal "my_template",      render_args.template_name
+      assert_equal({:some => 'local'}, render_args.locals)
     end
 
     should "render partial templates" do
       partial_args = test_runner(PartialViewHandler).run
-      assert_equal "my_partial",        partial_args.template_name
-      assert_equal({:some => 'locals'}, partial_args.locals)
+      assert_equal "my_partial",       partial_args.template_name
+      assert_equal({:some => 'local'}, partial_args.locals)
     end
 
     should "send files" do
       send_file_args = test_runner(SendFileViewHandler).run
-      assert_equal "my_file.txt",        send_file_args.file_path
-      assert_equal({ :some => :option }, send_file_args.options)
+      assert_equal "my_file.txt",      send_file_args.file_path
+      assert_equal({:some => :option}, send_file_args.options)
     end
 
   end


### PR DESCRIPTION
This is part of switching to the new render API.  This gets the
render args API inline with the actual api.  This also updates the
tests to be more to our conventions with using factory data.

@jcredding ready for review.