### PR TITLE
add source render/partial methods to the view handler and runners

### DIFF
--- a/lib/deas/deas_runner.rb
+++ b/lib/deas/deas_runner.rb
@@ -19,11 +19,19 @@ module Deas
     end
 
     def render(template_name, locals = nil)
-      self.template_source.render(template_name, self.handler, locals || {})
+      source_render(self.template_source, template_name, locals)
+    end
+
+    def source_render(source, template_name, locals = nil)
+      source.render(template_name, self.handler, locals || {})
     end
 
     def partial(template_name, locals = nil)
-      self.template_source.partial(template_name, locals || {})
+      source_partial(self.template_source, template_name, locals)
+    end
+
+    def source_partial(source, template_name, locals = nil)
+      source.partial(template_name, locals || {})
     end
 
     private

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -30,14 +30,16 @@ module Deas
       @template_source = a[:template_source] || Deas::NullTemplateSource.new
     end
 
-    def halt(*args);         raise NotImplementedError; end
-    def redirect(*args);     raise NotImplementedError; end
-    def content_type(*args); raise NotImplementedError; end
-    def status(*args);       raise NotImplementedError; end
-    def headers(*args);      raise NotImplementedError; end
-    def render(*args);       raise NotImplementedError; end
-    def partial(*args);      raise NotImplementedError; end
-    def send_file(*args);    raise NotImplementedError; end
+    def halt(*args);           raise NotImplementedError; end
+    def redirect(*args);       raise NotImplementedError; end
+    def content_type(*args);   raise NotImplementedError; end
+    def status(*args);         raise NotImplementedError; end
+    def headers(*args);        raise NotImplementedError; end
+    def render(*args);         raise NotImplementedError; end
+    def source_render(*args);  raise NotImplementedError; end
+    def partial(*args);        raise NotImplementedError; end
+    def source_partial(*args); raise NotImplementedError; end
+    def send_file(*args);      raise NotImplementedError; end
 
     class NormalizedParams
 

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -39,7 +39,7 @@ module Deas
       @sinatra_call.headers(*args)
     end
 
-    def render(template_name, locals = nil)
+    def source_render(source, template_name, locals = nil)
       self.content_type(get_content_type(template_name)) if self.content_type.nil?
       super
     end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -80,10 +80,20 @@ module Deas
     end
     RenderArgs = Struct.new(:template_name, :locals)
 
+    def source_render(source, template_name, locals = nil)
+      SourceRenderArgs.new(source, template_name, locals)
+    end
+    SourceRenderArgs = Struct.new(:source, :template_name, :locals)
+
     def partial(template_name, locals = nil)
       PartialArgs.new(template_name, locals)
     end
     PartialArgs = RenderArgs
+
+    def source_partial(source, template_name, locals = nil)
+      SourcePartialArgs.new(source, template_name, locals)
+    end
+    SourcePartialArgs = SourceRenderArgs
 
     def send_file(file_path, options = nil, &block)
       SendFileArgs.new(file_path, options, block)

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -14,7 +14,7 @@ module Deas
     module InstanceMethods
 
       def initialize(runner)
-        @deas_runner = runner
+        @runner = runner
       end
 
       def init
@@ -50,22 +50,24 @@ module Deas
 
       # Helpers
 
-      def halt(*args);         @deas_runner.halt(*args);         end
-      def redirect(*args);     @deas_runner.redirect(*args);     end
-      def content_type(*args); @deas_runner.content_type(*args); end
-      def status(*args);       @deas_runner.status(*args);       end
-      def headers(*args);      @deas_runner.headers(*args);      end
+      def halt(*args);         @runner.halt(*args);         end
+      def redirect(*args);     @runner.redirect(*args);     end
+      def content_type(*args); @runner.content_type(*args); end
+      def status(*args);       @runner.status(*args);       end
+      def headers(*args);      @runner.headers(*args);      end
 
-      def render(*args, &block);    @deas_runner.render(*args, &block);    end
-      def partial(*args, &block);   @deas_runner.partial(*args, &block);   end
-      def send_file(*args, &block); @deas_runner.send_file(*args, &block); end
+      def render(*args, &block);         @runner.render(*args, &block);         end
+      def source_render(*args, &block);  @runner.source_render(*args, &block);  end
+      def partial(*args, &block);        @runner.partial(*args, &block);        end
+      def source_partial(*args, &block); @runner.source_partial(*args, &block); end
+      def send_file(*args, &block);      @runner.send_file(*args, &block);      end
 
-      def logger;   @deas_runner.logger;   end
-      def router;   @deas_runner.router;   end
-      def request;  @deas_runner.request;  end
-      def response; @deas_runner.response; end
-      def params;   @deas_runner.params;   end
-      def session;  @deas_runner.session;  end
+      def logger;   @runner.logger;   end
+      def router;   @runner.router;   end
+      def request;  @runner.request;  end
+      def response; @runner.response; end
+      def params;   @runner.params;   end
+      def session;  @runner.session;  end
 
       def run_callback(callback)
         (self.class.send("#{callback}_callbacks") || []).each do |callback|

--- a/test/support/view_handlers.rb
+++ b/test/support/view_handlers.rb
@@ -1,3 +1,4 @@
+require 'deas/template_source'
 require 'deas/view_handler'
 
 class EmptyViewHandler
@@ -42,11 +43,29 @@ class RenderViewHandler
   end
 end
 
+class SourceRenderViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    source = Deas::TemplateSource.new(Factory.path)
+    source_render source, "my_template", :some => 'local'
+  end
+end
+
 class PartialViewHandler
   include Deas::ViewHandler
 
   def run!
     partial "my_partial", :some => 'local'
+  end
+end
+
+class SourcePartialViewHandler
+  include Deas::ViewHandler
+
+  def run!
+    source = Deas::TemplateSource.new(Factory.path)
+    source_partial source, "my_partial", :some => 'local'
   end
 end
 

--- a/test/unit/deas_runner_tests.rb
+++ b/test/unit/deas_runner_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'deas/deas_runner'
 
 require 'deas/runner'
+require 'deas/template_source'
 require 'test/support/normalized_params_spy'
 require 'test/support/view_handlers'
 
@@ -121,6 +122,26 @@ class Deas::DeasRunner
 
   end
 
+  class SourceRenderTests < RenderSetupTests
+    desc "source render method"
+    setup do
+      @source_render_args = nil
+      @source = Deas::TemplateSource.new(Factory.path)
+      Assert.stub(@source, :render){ |*args| @source_render_args = args }
+    end
+
+    should "call to the given source's render method" do
+      subject.source_render(@source, @template_name, @locals)
+      exp = [@template_name, subject.handler, @locals]
+      assert_equal exp, @source_render_args
+
+      subject.source_render(@source, @template_name)
+      exp = [@template_name, subject.handler, {}]
+      assert_equal exp, @source_render_args
+    end
+
+  end
+
   class PartialTests < RenderSetupTests
     desc "partial method"
     setup do
@@ -136,6 +157,26 @@ class Deas::DeasRunner
       subject.partial(@template_name)
       exp = [@template_name, {}]
       assert_equal exp, @partial_args
+    end
+
+  end
+
+  class SourcePartialTests < RenderSetupTests
+    desc "source partial method"
+    setup do
+      @source_partial_args = nil
+      @source = Deas::TemplateSource.new(Factory.path)
+      Assert.stub(@source, :partial){ |*args| @source_partial_args = args }
+    end
+
+    should "call to the given source's partial method" do
+      subject.source_partial(@source, @template_name, @locals)
+      exp = [@template_name, @locals]
+      assert_equal exp, @source_partial_args
+
+      subject.source_partial(@source, @template_name)
+      exp = [@template_name, {}]
+      assert_equal exp, @source_partial_args
     end
 
   end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -27,7 +27,8 @@ class Deas::Runner
     should have_readers :request, :response, :session
     should have_readers :params, :logger, :router, :template_source
     should have_imeths :halt, :redirect, :content_type, :status, :headers
-    should have_imeths :render, :partial, :send_file
+    should have_imeths :render, :source_render, :partial, :source_partial
+    should have_imeths :send_file
 
     should "know its handler and handler class" do
       assert_equal EmptyViewHandler, subject.handler_class
@@ -51,7 +52,9 @@ class Deas::Runner
       assert_raises(NotImplementedError){ subject.status }
       assert_raises(NotImplementedError){ subject.headers }
       assert_raises(NotImplementedError){ subject.render }
+      assert_raises(NotImplementedError){ subject.source_render }
       assert_raises(NotImplementedError){ subject.partial }
+      assert_raises(NotImplementedError){ subject.source_partial }
       assert_raises(NotImplementedError){ subject.send_file }
     end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -3,6 +3,7 @@ require 'deas/test_runner'
 
 require 'rack/test'
 require 'deas/runner'
+require 'deas/template_source'
 require 'test/support/normalized_params_spy'
 require 'test/support/view_handlers'
 
@@ -145,6 +146,21 @@ class Deas::TestRunner
       assert_equal locals,        args.locals
     end
 
+    should "build source render args if source source render is called" do
+      source = Deas::TemplateSource.new(Factory.path)
+      template_name = Factory.path
+      locals = { Factory.string => Factory.string }
+      args = subject.source_render source, template_name, locals
+
+      assert_kind_of SourceRenderArgs, args
+      [:source, :template_name, :locals].each do |meth|
+        assert_respond_to meth, args
+      end
+      assert_equal source,        args.source
+      assert_equal template_name, args.template_name
+      assert_equal locals,        args.locals
+    end
+
     should "build partial args if partial is called" do
       template_name = Factory.path
       locals = { Factory.string => Factory.string }
@@ -154,6 +170,21 @@ class Deas::TestRunner
       [:template_name, :locals].each do |meth|
         assert_respond_to meth, args
       end
+      assert_equal template_name, args.template_name
+      assert_equal locals,        args.locals
+    end
+
+    should "build source partial args if source partial is called" do
+      source = Deas::TemplateSource.new(Factory.path)
+      template_name = Factory.path
+      locals = { Factory.string => Factory.string }
+      args = subject.source_partial source, template_name, locals
+
+      assert_kind_of SourcePartialArgs, args
+      [:source, :template_name, :locals].each do |meth|
+        assert_respond_to meth, args
+      end
+      assert_equal source,        args.source
       assert_equal template_name, args.template_name
       assert_equal locals,        args.locals
     end

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'deas/view_handler'
 
 require 'deas/test_helpers'
+require 'deas/template_source'
 require 'test/support/view_handlers'
 
 module Deas::ViewHandler
@@ -77,8 +78,22 @@ module Deas::ViewHandler
       assert_equal({:some => 'local'}, render_args.locals)
     end
 
+    should "render templates on a given source" do
+      render_args = test_runner(SourceRenderViewHandler).run
+      assert_kind_of Deas::TemplateSource, render_args.source
+      assert_equal "my_template",      render_args.template_name
+      assert_equal({:some => 'local'}, render_args.locals)
+    end
+
     should "render partial templates" do
       partial_args = test_runner(PartialViewHandler).run
+      assert_equal "my_partial",       partial_args.template_name
+      assert_equal({:some => 'local'}, partial_args.locals)
+    end
+
+    should "render partial templates on a given source" do
+      partial_args = test_runner(SourcePartialViewHandler).run
+      assert_kind_of Deas::TemplateSource, partial_args.source
       assert_equal "my_partial",       partial_args.template_name
       assert_equal({:some => 'local'}, partial_args.locals)
     end


### PR DESCRIPTION
This expands the render API to allow rendering templates on given
sources (ie from 3rd party sources).  This allows third party tools
to provide handler mixins that render their own templates from their
own sources under special circumstances.

This is part of switching off of Sinatra/Tilt for rendering.

@jcredding ready for review.