### PR TITLE
template source: rename `default_template_source` engine option

### DIFF
--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -13,12 +13,12 @@ module Deas
 
     def initialize(path, logger = nil)
       @path = path.to_s
-      @default_opts = {
-        'source_path'          => @path,
-        'logger'               => logger || Deas::NullLogger.new,
-        'deas_template_source' => self
+      @default_engine_opts = {
+        'source_path'             => @path,
+        'logger'                  => logger || Deas::NullLogger.new,
+        'default_template_source' => self
       }
-      @engines = Hash.new{ |h, k| Deas::NullTemplateEngine.new(@default_opts) }
+      @engines = Hash.new{ |h, k| Deas::NullTemplateEngine.new(@default_engine_opts) }
       @ext_cache = Hash.new do |hash, template_name|
         paths = Dir.glob("#{File.join(@path, template_name.to_s)}.*")
         paths = paths.reject{ |p| !@engines.keys.include?(parse_ext(p)) }
@@ -33,7 +33,7 @@ module Deas
         raise DisallowedEngineExtError, "`#{input_ext}` is disallowed as an"\
                                         " engine extension."
       end
-      engine_opts = @default_opts.merge(registered_opts || {})
+      engine_opts = @default_engine_opts.merge(registered_opts || {})
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
     end
 

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -50,30 +50,30 @@ class Deas::TemplateSource
     should "register with default options" do
       subject.engine 'test', @test_engine
       exp_opts = {
-        'source_path'          => subject.path,
-        'logger'               => @logger,
-        'deas_template_source' => subject
+        'source_path'             => subject.path,
+        'logger'                  => @logger,
+        'default_template_source' => subject
       }
       assert_equal exp_opts, subject.engines['test'].opts
 
       subject.engine 'test', @test_engine, 'an' => 'opt'
       exp_opts = {
-        'source_path'          => subject.path,
-        'logger'               => @logger,
-        'deas_template_source' => subject,
-        'an'                   => 'opt'
+        'source_path'             => subject.path,
+        'logger'                  => @logger,
+        'default_template_source' => subject,
+        'an'                      => 'opt'
       }
       assert_equal exp_opts, subject.engines['test'].opts
 
       subject.engine('test', @test_engine, {
-        'source_path'          => 'something',
-        'logger'               => 'another',
-        'deas_template_source' => 'tempsource'
+        'source_path'             => 'something',
+        'logger'                  => 'another',
+        'default_template_source' => 'tempsource'
       })
       exp_opts = {
-        'source_path'          => 'something',
-        'logger'               => 'another',
-        'deas_template_source' => 'tempsource'
+        'source_path'             => 'something',
+        'logger'                  => 'another',
+        'default_template_source' => 'tempsource'
       }
       assert_equal exp_opts, subject.engines['test'].opts
 


### PR DESCRIPTION
This is a simple rename.  This name better describes the intent and
purpose of this option.  It is the source that will be used to
render if no specific source is specified.

This is useful if configuring 3rd-party template sources.  You may
want to configure their sources to use your app's template source
by default so that any generic renders done within 3rd-party templates
behave the same as if they were done within your app.  A case for
this would be if a 3rd-party template needs to render app-specific
partials.

@jcredding this came up while testing the new render API on our apps.  This has no behavior changes - just renames to better communicate the purpose of the option.