### PR TITLE
default rack settings when building test runners

### DIFF
--- a/lib/deas/test_helpers.rb
+++ b/lib/deas/test_helpers.rb
@@ -1,12 +1,16 @@
+require 'rack/request'
+require 'rack/response'
 require 'deas/test_runner'
 
 module Deas
 
   module TestHelpers
 
-    module_function
-
     def test_runner(handler_class, args = nil)
+      args ||= {}
+      args[:request]  ||= Rack::Request.new({})
+      args[:response] ||= Rack::Response.new
+      args[:session]  ||= args[:request].session
       TestRunner.new(handler_class, args)
     end
 

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -1,0 +1,53 @@
+require 'assert'
+require 'deas/test_helpers'
+
+require 'rack/request'
+require 'rack/response'
+require 'deas/view_handler'
+
+module Deas::TestHelpers
+
+  class UnitTests < Assert::Context
+    desc "Deas::TestHelpers"
+    setup do
+      @test_helpers = Deas::TestHelpers
+    end
+    subject{ @test_helpers }
+
+  end
+
+  class MixinTests < UnitTests
+    desc "as a mixin"
+    setup do
+      context_class = Class.new{ include Deas::TestHelpers }
+      @context = context_class.new
+    end
+    subject{ @context }
+
+    should have_imeths :test_runner, :test_handler
+
+  end
+
+  class HandlerTestRunnerTests < MixinTests
+    desc "for handler testing"
+    setup do
+      @handler_class = Class.new{ include Deas::ViewHandler }
+      @runner  = @context.test_runner(@handler_class)
+      @handler = @context.test_handler(@handler_class)
+    end
+
+    should "build a test runner for a given handler" do
+      assert_kind_of ::Deas::TestRunner, @runner
+      assert_kind_of Rack::Request,  @runner.request
+      assert_kind_of Rack::Response, @runner.response
+      assert_equal @runner.request.session, @runner.session
+    end
+
+    should "return an initialized handler instance" do
+      assert_kind_of @handler_class, @handler
+      assert_equal @runner.handler, @handler
+    end
+
+  end
+
+end


### PR DESCRIPTION
This formally defaults the rack request/response/session when building
test runners using the test helpers.  Now that templates are rendered
in tests, deas should provide sane defaults for these as templates
may rely on their values.  Also, users shouldn't have to fake this
if their views rely on them being in place.

This also formally tests the test helpers.  Before we were just
implicitly testing them as they were used in the test suite itself.

@jcredding this came up when rendering templates in the test suites of our apps.  Ready for review.