### PR TITLE
router: api to route same meth/path to diff handlers based on request

### DIFF
--- a/lib/deas/exceptions.rb
+++ b/lib/deas/exceptions.rb
@@ -16,4 +16,6 @@ module Deas
     end
   end
 
+  HandlerProxyNotFound = Class.new(Error)
+
 end

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -1,0 +1,41 @@
+require 'deas/exceptions'
+require 'deas/sinatra_runner'
+
+module Deas
+
+  class HandlerProxy
+
+    attr_reader :handler_class_name, :handler_class
+
+    def initialize(handler_class_name)
+      @handler_class_name = handler_class_name
+    end
+
+    def validate!
+      raise NotImplementedError
+    end
+
+    def run(sinatra_call)
+      runner = SinatraRunner.new(self.handler_class, {
+        :sinatra_call => sinatra_call,
+        :request      => sinatra_call.request,
+        :response     => sinatra_call.response,
+        :session      => sinatra_call.session,
+        :params       => sinatra_call.params,
+        :logger       => sinatra_call.settings.logger,
+        :router       => sinatra_call.settings.router,
+        :template_source => sinatra_call.settings.template_source
+      })
+
+      sinatra_call.request.env.tap do |env|
+        env['deas.params'] = runner.params
+        env['deas.handler_class_name'] = self.handler_class.name
+        env['deas.logging'].call "  Handler: #{env['deas.handler_class_name']}"
+        env['deas.logging'].call "  Params:  #{env['deas.params'].inspect}"
+      end
+      runner.run
+    end
+
+  end
+
+end

--- a/lib/deas/redirect_proxy.rb
+++ b/lib/deas/redirect_proxy.rb
@@ -1,9 +1,10 @@
+require 'deas/handler_proxy'
 require 'deas/url'
 require 'deas/view_handler'
 
 module Deas
 
-  class RedirectProxy
+  class RedirectProxy < HandlerProxy
 
     attr_reader :handler_class_name, :handler_class
 

--- a/lib/deas/route_proxy.rb
+++ b/lib/deas/route_proxy.rb
@@ -1,18 +1,22 @@
 require 'deas/exceptions'
-require 'deas/view_handler'
+require 'deas/handler_proxy'
 
 module Deas
-  class RouteProxy
 
-    attr_reader :handler_class_name, :handler_class
+  class RouteProxy < HandlerProxy
 
-    def initialize(handler_class_name)
-      @handler_class_name = handler_class_name
+    def initialize(handler_class_name, view_handler_ns = nil)
+      raise(NoHandlerClassError.new(handler_class_name)) if handler_class_name.nil?
+
+      if view_handler_ns && !(handler_class_name =~ /^::/)
+        handler_class_name = "#{view_handler_ns}::#{handler_class_name}"
+      end
+      super(handler_class_name)
     end
 
     def validate!
-      @handler_class = constantize(@handler_class_name).tap do |handler_class|
-        raise(NoHandlerClassError.new(@handler_class_name)) if !handler_class
+      @handler_class = constantize(self.handler_class_name).tap do |handler_class|
+        raise(NoHandlerClassError.new(self.handler_class_name)) if !handler_class
       end
     end
 
@@ -27,4 +31,5 @@ module Deas
     end
 
   end
+
 end

--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -1,15 +1,21 @@
+require 'deas/exceptions'
 require 'deas/redirect_proxy'
 require 'deas/route'
 require 'deas/route_proxy'
 require 'deas/url'
 
 module Deas
+
   class Router
 
-    attr_accessor :urls, :routes
+    DEFAULT_REQUEST_TYPE_NAME = 'default'
+
+    attr_reader :request_types, :urls, :routes
 
     def initialize(&block)
+      @request_types = []
       @urls, @routes = {}, []
+      default_request_type_name(DEFAULT_REQUEST_TYPE_NAME)
       self.instance_eval(&block) if !block.nil?
     end
 
@@ -41,21 +47,42 @@ module Deas
       prepend_base_url(url.path_for(*args))
     end
 
-    def get(path, handler_name);    self.route(:get,    path, handler_name); end
-    def post(path, handler_name);   self.route(:post,   path, handler_name); end
-    def put(path, handler_name);    self.route(:put,    path, handler_name); end
-    def patch(path, handler_name);  self.route(:patch,  path, handler_name); end
-    def delete(path, handler_name); self.route(:delete, path, handler_name); end
+    def default_request_type_name(value = nil)
+      @default_request_type = RequestType.new(value) if !value.nil?
+      @default_request_type.name
+    end
 
-    def route(http_method, from_path, handler_class_name)
-      if self.view_handler_ns && !(handler_class_name =~ /^::/)
-        handler_class_name = "#{self.view_handler_ns}::#{handler_class_name}"
+    def add_request_type(name, &proc)
+      @request_types << RequestType.new(name, proc)
+    end
+
+    # ideally someday the request should just *know* its request type
+    def request_type_name(request)
+      (self.request_types.detect{ |rt| rt.proc.call(request) } || @default_request_type).name
+    end
+
+    def get(path, *args);    self.route(:get,    path, *args); end
+    def post(path, *args);   self.route(:post,   path, *args); end
+    def put(path, *args);    self.route(:put,    path, *args); end
+    def patch(path, *args);  self.route(:patch,  path, *args); end
+    def delete(path, *args); self.route(:delete, path, *args); end
+
+    def route(http_method, from_path, *args)
+      handler_names        = args.last.kind_of?(::Hash) ? args.pop : {}
+      default_handler_name = args.last
+      if !handler_names.key?(self.default_request_type_name) && default_handler_name
+        handler_names[self.default_request_type_name] = default_handler_name
       end
-      proxy = Deas::RouteProxy.new(handler_class_name)
+
+      proxies = handler_names.inject({}) do |proxies, (req_type_name, handler_name)|
+        proxies[req_type_name] = Deas::RouteProxy.new(handler_name, self.view_handler_ns)
+        proxies
+      end
 
       from_url = self.urls[from_path]
       from_url_path = from_url.path if from_url
-      add_route(http_method, prepend_base_url(from_url_path || from_path), proxy)
+
+      add_route(http_method, prepend_base_url(from_url_path || from_path), proxies)
     end
 
     def redirect(from_path, to_path = nil, &block)
@@ -63,11 +90,15 @@ module Deas
       if to_path.kind_of?(::Symbol) && to_url.nil?
         raise ArgumentError, "no url named `#{to_path.inspect}`"
       end
+
       proxy = Deas::RedirectProxy.new(to_url || to_path, &block)
+      proxies = { self.default_request_type_name => proxy }
 
       from_url = self.urls[from_path]
       from_url_path = from_url.path if from_url
-      add_route(:get, from_url_path || from_path, proxy)
+
+      # TODO: prepend base url
+      add_route(:get, from_url_path || from_path, proxies)
     end
 
     private
@@ -76,9 +107,35 @@ module Deas
       self.urls[name] = Deas::Url.new(name, path)
     end
 
-    def add_route(http_method, path, proxy)
-      Deas::Route.new(http_method, path, proxy).tap{ |r| self.routes.push(r) }
+    def add_route(http_method, path, proxies)
+      proxies = HandlerProxies.new(proxies, self.default_request_type_name)
+      Deas::Route.new(http_method, path, proxies).tap{ |r| self.routes.push(r) }
     end
+
+    class HandlerProxies
+
+      attr_reader :default_type
+
+      def initialize(proxies, default_name)
+        @proxies = proxies
+        @default_type = default_name
+      end
+
+      def [](type)
+        @proxies[type] || @proxies[@default_type] || raise(HandlerProxyNotFound)
+      end
+
+      def each(&block)
+        @proxies.each(&block)
+      end
+
+      def empty?
+        @proxies.empty?
+      end
+
+    end
+
+    RequestType = Struct.new(:name, :proc)
 
   end
 

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -211,6 +211,10 @@ module Deas::Server
     def url(*args, &block);     self.router.url(*args, &block);     end
     def url_for(*args, &block); self.router.url_for(*args, &block); end
 
+    def default_request_type_name(*args); self.router.default_request_type_name(*args); end
+    def add_request_type(*args, &block);  self.router.add_request_type(*args, &block);  end
+    def request_type_name(*args);         self.router.request_type_name(*args);         end
+
     def get(*args, &block);    self.router.get(*args, &block);    end
     def post(*args, &block);   self.router.post(*args, &block);   end
     def put(*args, &block);    self.router.put(*args, &block);    end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -19,12 +19,19 @@ class DeasTestServer
     end
   end
 
+  default_request_type_name 'desktop'
+  add_request_type('regular'){ |r| r.path_info =~ /regular/ }
+  add_request_type('mobile'){ |r| r.path_info =~ /mobile/ }
+
   get  '/show',              'ShowHandler'
   get  '/show.html',         'ShowHtmlHandler'
   get  '/show.json',         'ShowJsonHandler'
   get  '/show-latin1-json',  'ShowLatinJsonHandler'
   get  '/show-text',         'ShowTextHandler'
   get  '/show-headers-text', 'ShowHeadersTextHandler'
+
+  get '/req-type-show/:type', 'regular' => 'ShowHandler',
+                              'mobile'  => 'ShowMobileHandler'
 
   get  '/halt',     'HaltHandler'
   get  '/error',    'ErrorHandler'
@@ -63,6 +70,21 @@ class ShowHandler
 
   def init!
     @message = params['message']
+  end
+
+  def run!
+    @message
+  end
+
+end
+
+class ShowMobileHandler
+  include Deas::ViewHandler
+
+  attr_reader :message
+
+  def init!
+    @message = "[MOBILE] #{params['message']}"
   end
 
   def run!

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
-require 'assert-rack-test'
 require 'deas'
+
+require 'assert-rack-test'
 
 module Deas
 
@@ -20,8 +21,7 @@ module Deas
       get '/show', 'message' => 'this is a test'
 
       assert_equal 200, last_response.status
-      exp = "this is a test"
-      assert_equal exp, last_response.body
+      assert_equal "this is a test", last_response.body
     end
 
     should "set the content type appropriately" do
@@ -42,6 +42,19 @@ module Deas
 
       get '/show-headers-text'
       assert_equal 'text/plain', last_response.headers['Content-Type']
+    end
+
+    should "render different handlers for the same meth/path based on the type" do
+      get '/req-type-show/regular', 'message' => 'this is a test request'
+      assert_equal 200, last_response.status
+      assert_equal "this is a test request", last_response.body
+
+      get '/req-type-show/mobile', 'message' => 'this is a test request'
+      assert_equal 200, last_response.status
+      assert_equal "[MOBILE] this is a test request", last_response.body
+
+      get '/req-type-show/other', 'message' => 'this is a test request'
+      assert_equal 404, last_response.status
     end
 
     should "allow halting with a custom response" do
@@ -115,7 +128,6 @@ module Deas
     desc "handler"
     setup do
       get 'handler/tests?a-param=something'
-
       @data_inspect = last_response.body
     end
 

--- a/test/unit/exceptions_tests.rb
+++ b/test/unit/exceptions_tests.rb
@@ -11,7 +11,7 @@ module Deas
       assert_kind_of RuntimeError, Deas::Error.new
     end
 
-    should "provide a no handler class exception that subclasses `Error`" do
+    should "provide a no handler class exception" do
       assert Deas::NoHandlerClassError
 
       handler_class_name = 'AHandlerClass'
@@ -23,17 +23,22 @@ module Deas
       assert_equal exp_msg, e.message
     end
 
-    should "provide a server exception that subclasses `Error`" do
+    should "provide a server exception" do
       assert Deas::ServerError
       assert_kind_of Deas::Error, Deas::ServerError.new
     end
 
-    should "provide a server root exception that subclasses `ServerError`" do
+    should "provide a server root exception" do
       assert Deas::ServerRootError
 
       e = Deas::ServerRootError.new
       assert_kind_of Deas::ServerError, e
       assert_equal "server `root` not set but required", e.message
+    end
+
+    should "provide a handler proxy not found exception" do
+      assert Deas::HandlerProxyNotFound
+      assert_kind_of Deas::Error, Deas::HandlerProxyNotFound.new
     end
 
   end

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -1,0 +1,115 @@
+require 'assert'
+require 'deas/handler_proxy'
+
+require 'deas/exceptions'
+require 'deas/sinatra_runner'
+require 'test/support/fake_sinatra_call'
+require 'test/support/view_handlers'
+
+class Deas::HandlerProxy
+
+  class UnitTests < Assert::Context
+    desc "Deas::HandlerProxy"
+    setup do
+      @proxy = Deas::HandlerProxy.new('EmptyViewHandler')
+    end
+    subject{ @proxy }
+
+    should have_readers :handler_class_name, :handler_class
+    should have_imeths :validate!, :run
+
+    should "know its handler class name" do
+      assert_equal 'EmptyViewHandler', subject.handler_class_name
+    end
+
+    should "not implement its validate! method" do
+      assert_raises(NotImplementedError){ subject.validate! }
+    end
+
+  end
+
+  class RunTests < UnitTests
+    desc "when run"
+    setup do
+      @runner_spy = SinatraRunnerSpy.new
+      Assert.stub(Deas::SinatraRunner, :new) do |*args|
+        @runner_spy.build(*args)
+        @runner_spy
+      end
+
+      Assert.stub(@proxy, :handler_class){ EmptyViewHandler }
+
+      @fake_sinatra_call = FakeSinatraCall.new
+      @proxy.run(@fake_sinatra_call)
+    end
+
+    should "build and run a sinatra runner" do
+      assert_equal subject.handler_class, @runner_spy.handler_class
+
+      exp_args = {
+        :sinatra_call => @fake_sinatra_call,
+        :request      => @fake_sinatra_call.request,
+        :response     => @fake_sinatra_call.response,
+        :session      => @fake_sinatra_call.session,
+        :params       => @fake_sinatra_call.params,
+        :logger       => @fake_sinatra_call.settings.logger,
+        :router       => @fake_sinatra_call.settings.router,
+        :template_source => @fake_sinatra_call.settings.template_source
+      }
+      assert_equal exp_args, @runner_spy.args
+
+      assert_true @runner_spy.run_called
+    end
+
+    should "add the runner params to the request env" do
+      exp = @runner_spy.params
+      assert_equal exp, @fake_sinatra_call.request.env['deas.params']
+    end
+
+    should "add the handler class name to the request env" do
+      exp = subject.handler_class.name
+      assert_equal exp, @fake_sinatra_call.request.env['deas.handler_class_name']
+    end
+
+    should "log the handler and params" do
+      exp_msgs = [
+        "  Handler: #{subject.handler_class}",
+        "  Params:  #{@runner_spy.params.inspect}"
+      ]
+      assert_equal exp_msgs, @fake_sinatra_call.request.logging_msgs
+    end
+
+  end
+
+  class SinatraRunnerSpy
+
+    attr_reader :run_called
+    attr_reader :handler_class, :args
+    attr_reader :sinatra_call
+    attr_reader :request, :response, :session, :params
+    attr_reader :logger, :router, :template_source
+
+    def initialize
+      @run_called = false
+    end
+
+    def build(handler_class, args)
+      @handler_class, @args = handler_class, args
+
+      @sinatra_call = args[:sinatra_call]
+      @request      = args[:request]
+      @response     = args[:response]
+      @session      = args[:session]
+      @params       = args[:params]
+      @logger       = args[:logger]
+      @router       = args[:router]
+      @template_source = args[:template_source]
+    end
+
+    def run
+      @run_called = true
+    end
+
+  end
+
+end

--- a/test/unit/redirect_proxy_tests.rb
+++ b/test/unit/redirect_proxy_tests.rb
@@ -1,7 +1,10 @@
 require 'assert'
 require 'deas/redirect_proxy'
 
+require 'deas/handler_proxy'
 require 'deas/test_helpers'
+require 'deas/url'
+require 'deas/view_handler'
 
 class Deas::RedirectProxy
 
@@ -12,11 +15,8 @@ class Deas::RedirectProxy
     end
     subject{ @proxy }
 
-    should have_readers :handler_class_name, :handler_class
-    should have_imeths :validate!
-
-    should "know its handler class name" do
-      assert_equal subject.handler_class.name, subject.handler_class_name
+    should "be a HandlerProxy" do
+      assert_kind_of Deas::HandlerProxy, subject
     end
 
   end
@@ -24,7 +24,7 @@ class Deas::RedirectProxy
   class HandlerClassTests < UnitTests
     include Deas::TestHelpers
 
-    desc "redir handler class"
+    desc "handler class"
     setup do
       @handler_class = @proxy.handler_class
     end
@@ -58,7 +58,7 @@ class Deas::RedirectProxy
   end
 
   class HandlerTests < HandlerClassTests
-    desc "redir handler instance"
+    desc "handler instance"
     setup do
       @handler = test_handler(@handler_class)
     end

--- a/test/unit/route_proxy_tests.rb
+++ b/test/unit/route_proxy_tests.rb
@@ -1,7 +1,8 @@
 require 'assert'
 require 'deas/route_proxy'
 
-require 'deas/test_helpers'
+require 'deas/exceptions'
+require 'deas/handler_proxy'
 require 'test/support/view_handlers'
 
 class Deas::RouteProxy
@@ -13,11 +14,28 @@ class Deas::RouteProxy
     end
     subject{ @proxy }
 
-    should have_readers :handler_class_name, :handler_class
-    should have_imeths :validate!
+    should "be a HandlerProxy" do
+      assert_kind_of Deas::HandlerProxy, subject
+    end
 
-    should "know its handler class name" do
+    should "complain if given a nil handler class name" do
+      assert_raises(Deas::NoHandlerClassError) do
+        Deas::RouteProxy.new(nil)
+      end
+    end
+
+    should "apply no view handler ns if none given" do
       assert_equal 'EmptyViewHandler', subject.handler_class_name
+    end
+
+    should "apply an optional view handler ns if it is given" do
+      proxy = Deas::RouteProxy.new('NsTest', 'MyStuff')
+      assert_equal 'MyStuff::NsTest', proxy.handler_class_name
+    end
+
+    should "ignore the ns when given a class name with leading colons" do
+      proxy = Deas::RouteProxy.new('::NoNsTest', 'MyStuff')
+      assert_equal '::NoNsTest', proxy.handler_class_name
     end
 
     should "set its handler class on `validate!`" do

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'deas/route'
 
-require 'deas/sinatra_runner'
+require 'deas/exceptions'
 require 'deas/route_proxy'
 require 'test/support/fake_sinatra_call'
 require 'test/support/view_handlers'
@@ -11,32 +11,29 @@ class Deas::Route
   class UnitTests < Assert::Context
     desc "Deas::Route"
     setup do
-      @route_proxy = Deas::RouteProxy.new('EmptyViewHandler')
-      @route = Deas::Route.new(:get, '/test', @route_proxy)
+      @req_type_name = Factory.string
+      @proxy = HandlerProxySpy.new
+      @handler_proxies = Hash.new{ |h, k| raise(Deas::HandlerProxyNotFound) }.tap do |h|
+        h[@req_type_name] = @proxy
+      end
+
+      @route = Deas::Route.new(:get, '/test', @handler_proxies)
     end
     subject{ @route }
 
-    should have_readers :method, :path, :route_proxy, :handler_class
+    should have_readers :method, :path
     should have_imeths :validate!, :run
 
-    should "know its method, path and route proxy" do
+    should "know its method and path" do
       assert_equal :get, subject.method
       assert_equal '/test', subject.path
-      assert_equal @route_proxy, subject.route_proxy
     end
 
-    should "set its handler class on `validate!`" do
-      assert_nil subject.handler_class
+    should "validate its proxies on validate" do
+      assert_false @proxy.validate_called
 
       assert_nothing_raised{ subject.validate! }
-      assert_equal EmptyViewHandler, subject.handler_class
-    end
-
-    should "complain given an invalid handler class" do
-      proxy = Deas::RouteProxy.new('SomethingNotDefined')
-      assert_raises(Deas::NoHandlerClassError) do
-        Deas::Route.new(:get, '/test', proxy).validate!
-      end
+      assert_true @proxy.validate_called
     end
 
   end
@@ -45,81 +42,43 @@ class Deas::Route
     desc "when run"
     setup do
       @fake_sinatra_call = FakeSinatraCall.new
-      @runner_spy = SinatraRunnerSpy.new
-      Assert.stub(Deas::SinatraRunner, :new) do |*args|
-        @runner_spy.build(*args)
-        @runner_spy
-      end
+    end
 
-      @route.validate!
+    should "run the proxy for the given request type name" do
+      Assert.stub(@fake_sinatra_call.settings.router, :request_type_name).with(
+        @fake_sinatra_call.request
+      ){ @req_type_name }
+
       @route.run(@fake_sinatra_call)
+      assert_true @proxy.run_called
     end
 
-    should "build and run a sinatra runner" do
-      assert_equal subject.handler_class, @runner_spy.handler_class
-
-      exp_args = {
-        :sinatra_call => @fake_sinatra_call,
-        :request      => @fake_sinatra_call.request,
-        :response     => @fake_sinatra_call.response,
-        :session      => @fake_sinatra_call.session,
-        :params       => @fake_sinatra_call.params,
-        :logger       => @fake_sinatra_call.settings.logger,
-        :router       => @fake_sinatra_call.settings.router,
-        :template_source => @fake_sinatra_call.settings.template_source
-      }
-      assert_equal exp_args, @runner_spy.args
-
-      assert_true @runner_spy.run_called
-    end
-
-    should "add the runner params to the request env" do
-      exp = @runner_spy.params
-      assert_equal exp, @fake_sinatra_call.request.env['deas.params']
-    end
-
-    should "add the handler class name to the request env" do
-      exp = subject.handler_class.name
-      assert_equal exp, @fake_sinatra_call.request.env['deas.handler_class_name']
-    end
-
-    should "log the handler and params" do
-      exp_msgs = [
-        "  Handler: #{subject.handler_class}",
-        "  Params:  #{@runner_spy.params.inspect}"
-      ]
-      assert_equal exp_msgs, @fake_sinatra_call.request.logging_msgs
+    should "halt 404 if it can't find a proxy for the given request type name" do
+      halt_value = catch(:halt) do
+        @route.run(@fake_sinatra_call)
+      end
+      assert_equal [404], halt_value
     end
 
   end
 
-  class SinatraRunnerSpy
+  class HandlerProxySpy
 
-    attr_reader :run_called
-    attr_reader :handler_class, :args
-    attr_reader :sinatra_call
-    attr_reader :request, :response, :session, :params
-    attr_reader :logger, :router, :template_source
+    attr_reader :validate_called, :run_called, :sinatra_call
 
     def initialize
-      @run_called = false
+      @run_called      = false
+      @validate_called = false
+      @sinatra_call    = nil
     end
 
-    def build(handler_class, args)
-      @handler_class, @args = handler_class, args
-
-      @sinatra_call = args[:sinatra_call]
-      @request      = args[:request]
-      @response     = args[:response]
-      @session      = args[:session]
-      @params       = args[:params]
-      @logger       = args[:logger]
-      @router       = args[:router]
-      @template_source = args[:template_source]
+    def validate!
+      @validate_called = true
     end
 
-    def run
-      @run_called = true
+    def run(sinatra_call)
+      @sinatra_call = sinatra_call
+      @run_called   = true
     end
 
   end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -1,106 +1,60 @@
 require 'assert'
 require 'deas/router'
 
+require 'deas/exceptions'
+require 'deas/route'
+require 'test/support/view_handlers'
+
 class Deas::Router
 
   class UnitTests < Assert::Context
     desc "Deas::Router"
     setup do
-      @router = Deas::Router.new
+      @router_class = Deas::Router
+    end
+    subject{ @router_class }
+
+    should "know its default request type name" do
+      assert_equal 'default', subject::DEFAULT_REQUEST_TYPE_NAME
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @router = @router_class.new
     end
     subject{ @router }
 
-    should have_accessors :urls, :routes
+    should have_readers :request_types, :urls, :routes
+
     should have_imeths :view_handler_ns, :base_url, :prepend_base_url
     should have_imeths :url, :url_for
+    should have_imeths :default_request_type_name, :add_request_type
+    should have_imeths :request_type_name
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :route, :redirect
 
-    should "have no view_handler_ns, base_url, urls, or routes by default" do
+    should "default its settings" do
       assert_nil subject.view_handler_ns
       assert_nil subject.base_url
+      assert_empty subject.request_types
       assert_empty subject.urls
       assert_empty subject.routes
+
+      exp = @router_class::DEFAULT_REQUEST_TYPE_NAME
+      assert_equal exp, subject.default_request_type_name
     end
 
-    should "add a GET route using #get" do
-      subject.get('/things', 'ListThings')
-
-      route = subject.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :get,         route.method
-      assert_equal '/things',    route.path
-      assert_equal 'ListThings', route.route_proxy.handler_class_name
-    end
-
-    should "add a POST route using #post" do
-      subject.post('/things', 'CreateThing')
-
-      route = subject.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :post,         route.method
-      assert_equal '/things',     route.path
-      assert_equal 'CreateThing', route.route_proxy.handler_class_name
-    end
-
-    should "add a PUT route using #put" do
-      subject.put('/things/:id', 'UpdateThing')
-
-      route = subject.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :put,          route.method
-      assert_equal '/things/:id', route.path
-      assert_equal 'UpdateThing', route.route_proxy.handler_class_name
-    end
-
-    should "add a PATCH route using #patch" do
-      subject.patch('/things/:id', 'UpdateThing')
-
-      route = subject.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :patch,        route.method
-      assert_equal '/things/:id', route.path
-      assert_equal 'UpdateThing', route.route_proxy.handler_class_name
-    end
-
-    should "add a DELETE route using #delete" do
-      subject.delete('/things/:id', 'DeleteThing')
-
-      route = subject.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :delete,       route.method
-      assert_equal '/things/:id', route.path
-      assert_equal 'DeleteThing', route.route_proxy.handler_class_name
-    end
-
-    should "allow defining any kind of route using #route" do
-      subject.route(:options, '/get_info', 'GetInfo')
-
-      route = subject.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :options,    route.method
-      assert_equal '/get_info', route.path
-      assert_equal 'GetInfo',   route.route_proxy.handler_class_name
-    end
-
-    should "set a view handler namespace and use it when defining routes" do
-      subject.view_handler_ns 'MyStuff'
-      assert_equal 'MyStuff', subject.view_handler_ns
-
-      # should use the ns
-      route = subject.route(:get, '/ns_test', 'NsTest')
-      assert_equal 'MyStuff::NsTest', route.route_proxy.handler_class_name
-
-      # should ignore the ns when the leading colons are present
-      route = subject.route(:post, '/no_ns_test', '::NoNsTest')
-      assert_equal '::NoNsTest', route.route_proxy.handler_class_name
+    should "set a view handler namespace" do
+      subject.view_handler_ns(exp = Factory.string)
+      assert_equal exp, subject.view_handler_ns
     end
 
     should "set a base url" do
-      url = Factory.url
-      subject.base_url url
-
-      assert_equal url, subject.base_url
+      subject.base_url(exp = Factory.url)
+      assert_equal exp, subject.base_url
     end
 
     should "prepend the base url to any url path" do
@@ -123,32 +77,136 @@ class Deas::Router
       assert_equal exp_path, route.path
     end
 
-    should "add a redirect route using #redirect" do
-      subject.redirect('/invalid', '/assets')
+    should "set a default request type name" do
+      subject.default_request_type_name(exp = Factory.string)
+      assert_equal exp, subject.default_request_type_name
+    end
 
-      route = subject.routes[0]
-      assert_instance_of Deas::Route, route
-      assert_equal :get,       route.method
-      assert_equal '/invalid', route.path
-      assert_equal 'Deas::RedirectHandler', route.route_proxy.handler_class_name
+    should "add request types" do
+      assert_empty subject.request_types
 
-      route.validate!
-      assert_not_nil route.handler_class
+      name, proc = Factory.string, Proc.new{}
+      subject.add_request_type(name, &proc)
+      assert_not_empty subject.request_types
+
+      rt = subject.request_types.last
+      assert_equal name, rt.name
+      assert_equal proc, rt.proc
+    end
+
+    should "lookup request type names" do
+      request = Factory.string
+      name = Factory.string
+      proc = Proc.new{ |r| r == request }
+      subject.add_request_type(name, &proc)
+      subject.add_request_type(Factory.string, &proc)
+
+      exp = name
+      assert_equal exp, subject.request_type_name(request)
+
+      exp = subject.default_request_type_name
+      assert_equal exp, subject.request_type_name(Factory.string)
+    end
+
+    should "add get, post, put, patch and delete routes" do
+      Assert.stub(subject, :route){ |*args| RouteSpy.new(*args) }
+      path = Factory.path
+      args = [Factory.string]
+
+      [:get, :post, :put, :patch, :delete].each do |meth|
+        route = subject.send(meth, path, *args)
+        assert_equal meth, route.method
+        assert_equal path, route.path
+        assert_equal args, route.args
+      end
     end
 
     should "instance eval any given block" do
+      ns = Factory.string
       router = Deas::Router.new do
-        get('/things', 'ListThings')
+        view_handler_ns ns
       end
 
-      assert_equal 1, router.routes.size
-      assert_instance_of Deas::Route, router.routes.first
+      assert_equal ns, router.view_handler_ns
     end
 
   end
 
-  class NamedUrlTests < UnitTests
-    desc "when using named urls"
+  class RouteTests < InitTests
+    setup do
+      @method = Factory.string
+      @path1  = Factory.path
+      @path2  = Factory.path
+      @handler_class_name1 = Factory.string
+      @handler_class_name2 = Factory.string
+    end
+
+    should "add a Route with the given method and path" do
+      assert_empty subject.routes
+
+      subject.route(@method, @path1)
+      assert_not_empty subject.routes
+
+      route = subject.routes.last
+      assert_instance_of Deas::Route, route
+      assert_equal @method, route.method
+      assert_equal @path1,  route.path
+
+      proxies = route.handler_proxies
+      assert_kind_of HandlerProxies, proxies
+      assert_empty proxies
+      assert_equal subject.default_request_type_name, proxies.default_type
+    end
+
+    should "proxy any handler class given for the default request type" do
+      subject.route(@method, @path1, @handler_class_name1)
+      route = subject.routes.last
+      proxy = route.handler_proxies[subject.default_request_type_name]
+      assert_kind_of Deas::RouteProxy, proxy
+      assert_equal @handler_class_name1, proxy.handler_class_name
+
+      subject.route(@method, @path1, @handler_class_name1, {
+        subject.default_request_type_name => @handler_class_name2
+      })
+      route = subject.routes.last
+      proxy = route.handler_proxies[subject.default_request_type_name]
+      assert_kind_of Deas::RouteProxy, proxy
+      assert_not_nil proxy
+      assert_equal @handler_class_name2, proxy.handler_class_name
+    end
+
+    should "proxy handler classes for their specified request types" do
+      subject.route(@method, @path1, {
+        '1' => @handler_class_name1,
+        '2' => @handler_class_name2,
+      })
+      route = subject.routes.last
+
+      proxy = route.handler_proxies['1']
+      assert_kind_of Deas::RouteProxy, proxy
+      assert_equal @handler_class_name1, proxy.handler_class_name
+
+      proxy = route.handler_proxies['2']
+      assert_kind_of Deas::RouteProxy, proxy
+      assert_equal @handler_class_name2, proxy.handler_class_name
+    end
+
+    should "add redirect routes" do
+      subject.redirect(@path1, @path2)
+
+      route = subject.routes.last
+      assert_instance_of Deas::Route, route
+      assert_equal :get,   route.method
+      assert_equal @path1, route.path
+
+      proxy = route.handler_proxies[subject.default_request_type_name]
+      assert_kind_of Deas::RedirectProxy, proxy
+      assert_equal 'Deas::RedirectHandler', proxy.handler_class_name
+    end
+
+  end
+
+  class NamedUrlTests < InitTests
     setup do
       @router.url('get_info', '/info/:for')
     end
@@ -220,4 +278,63 @@ class Deas::Router
 
   end
 
+  class HandlerProxiesTests < UnitTests
+    desc "HandlerProxies"
+    setup do
+      @default_type = Factory.string
+      @other_type   = Factory.string
+      @proxies = {
+        @default_type => Factory.string,
+        @other_type   => Factory.string
+      }
+      @handler_proxies = HandlerProxies.new(@proxies, @default_type)
+    end
+    subject{ @handler_proxies }
+
+    should have_reader :default_type
+    should have_imeths :[], :each, :empty?
+
+    should "know its default type" do
+      assert_equal @default_type, subject.default_type
+    end
+
+    should "find the proxy for the given type" do
+      assert_equal @proxies[@other_type], subject[@other_type]
+    end
+
+    should "find the default proxy if there is no proxy for the given type" do
+      assert_equal @proxies[subject.default_type], subject[Factory.string]
+    end
+
+    should "complain if there is no proxy for the given type and no default proxy" do
+      handler_proxies = HandlerProxies.new({}, @default_type)
+      assert_raises(Deas::HandlerProxyNotFound) do
+        handler_proxies[Factory.string]
+      end
+    end
+
+    should "demeter its given proxies each method" do
+      exp = ''
+      @proxies.each{ |k, v| exp << v }
+      act = ''
+      subject.each{ |k, v| act << v }
+
+      assert_equal exp, act
+    end
+
+    should "demeter its given proxies empty? method" do
+      Assert.stub(@proxies, :empty?){ false }
+      assert_false subject.empty?
+
+      Assert.stub(@proxies, :empty?){ true }
+      assert_true subject.empty?
+    end
+
+  end
+
+  class RouteSpy < Struct.new(:method, :path, :args)
+    def initialize(method, path, *args)
+      super(method, path, args)
+    end
+  end
 end

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -90,10 +90,9 @@ class Deas::Server::Configuration
     setup do
       @initialized = false
       @other_initialized = false
-      proxy = Deas::RouteProxy.new('EmptyViewHandler')
-      @route = Deas::Route.new(:get, '/something', proxy)
       @router = Deas::Router.new
-      @router.routes = [ @route ]
+      @route = @router.get('/something', 'EmptyViewHandler')
+      @proxy = @route.handler_proxies[@router.default_request_type_name]
 
       @configuration = Deas::Server::Configuration.new.tap do |c|
         c.env              = 'staging'
@@ -121,12 +120,11 @@ class Deas::Server::Configuration
       assert_equal true, @other_initialized
     end
 
-    should "call constantize! on all routes" do
-      assert_nil @route.handler_class
+    should "call validate! on all routes" do
+      assert_nil @proxy.handler_class
 
       subject.validate!
-
-      assert_equal EmptyViewHandler, @route.handler_class
+      assert_equal EmptyViewHandler, @proxy.handler_class
     end
 
     should "default the :erb :outvar setting in the SinatraApp it creates" do

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -19,17 +19,18 @@ module Deas::Server
     # DSL for sinatra-based settings
     should have_imeths :env, :root, :public_root, :views_root
     should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
-    should have_imeths :static_files, :reload_templates, :default_charset
+    should have_imeths :static_files, :reload_templates
 
     # DSL for server handling settings
     should have_imeths :init, :error, :template_helpers, :template_helper?
-    should have_imeths :use, :set, :verbose_logging, :logger, :template_source
-    should have_imeths :get, :post, :put, :patch, :delete
-    should have_imeths :redirect, :route, :url, :url_for
+    should have_imeths :use, :set, :verbose_logging, :logger, :default_charset
+    should have_imeths :template_source
 
     # DSL for server routing settings
     should have_imeths :router, :view_handler_ns, :base_url
     should have_imeths :url, :url_for
+    should have_imeths :default_request_type_name, :add_request_type
+    should have_imeths :request_type_name
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :route, :redirect
 

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -14,10 +14,9 @@ module Deas::SinatraApp
   class UnitTests < Assert::Context
     desc "Deas::SinatraApp"
     setup do
-      proxy = Deas::RouteProxy.new('EmptyViewHandler')
-      @route = Deas::Route.new(:get, '/something', proxy)
       @router = Deas::Router.new
-      @router.routes = [ @route ]
+      @route = @router.get('/something', 'EmptyViewHandler')
+      @proxy = @route.handler_proxies[@router.default_request_type_name]
 
       @configuration = Deas::Server::Configuration.new.tap do |c|
         c.env              = 'staging'


### PR DESCRIPTION
This updates the API for defining routes to allow routing the same
method/path combination to different handlers based on the type of
request.  The goal here is to support rendering both mobile and
desktop versions of the same route.

A side-effect of this api change is you are no longer *forced* to
specify a handler when defining your routes.  In this case Deas will
error nicely.  Another side effect is handling the "default" case.
This involves optionally setting a default request type and handling
the case when no default handler is specified.

Note: this cleaned up the router/route/proxy handling too.  There
was a lot of coupling and who-handled-what didn't make a lot of sense.
These objects have been updated to better reflect their intended
responsibilities.  The associated tests are cleaned up and modernized
a bit too.

@jcredding ready for initial review.  I still need to add some system tests to this to ensure everything is behaving correctly.  I wanted to go ahead and get it in front of you though b/c it is not a trivial PR.