### PR TITLE
router: handler base urls on redirects

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -97,8 +97,7 @@ module Deas
       from_url = self.urls[from_path]
       from_url_path = from_url.path if from_url
 
-      # TODO: prepend base url
-      add_route(:get, from_url_path || from_path, proxies)
+      add_route(:get, prepend_base_url(from_url_path || from_path), proxies)
     end
 
     private

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -77,6 +77,16 @@ class Deas::Router
       assert_equal exp_path, route.path
     end
 
+    should "prepend the base url when adding redirects" do
+      url = Factory.url
+      subject.base_url url
+      path = Factory.path
+      redirect = subject.redirect(path, Factory.path)
+
+      exp_path = subject.prepend_base_url(path)
+      assert_equal exp_path, redirect.path
+    end
+
     should "set a default request type name" do
       subject.default_request_type_name(exp = Factory.string)
       assert_equal exp, subject.default_request_type_name


### PR DESCRIPTION
This was missed when I added the original base url handling.  I noticed
this while reworking the router for request type handling.

The original base url handling was done in #122 and #126, for reference.

@jcredding ready for review.