### PR TITLE
view handlers: have `layout` DSL take procs that are instance eval'd

### DIFF
--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -46,7 +46,7 @@ module Deas
     end
 
     def render(template_name, view_handler, locals, &content)
-      [ view_handler.class.layouts,
+      [ view_handler.layouts,
         template_name
       ].flatten.reverse.inject(content) do |render_proc, name|
         proc{ get_engine(name).render(name, view_handler, locals, &render_proc) }

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -37,6 +37,10 @@ module Deas
         raise NotImplementedError
       end
 
+      def layouts
+        self.class.layouts.map{ |proc| self.instance_eval(&proc) }
+      end
+
       def inspect
         reference = '0x0%x' % (self.object_id << 1)
         "#<#{self.class}:#{reference} @request=#{request.inspect}>"
@@ -62,6 +66,7 @@ module Deas
       def source_partial(*args, &block); @deas_runner.source_partial(*args, &block); end
       def send_file(*args, &block);      @deas_runner.send_file(*args, &block);      end
 
+      # TODO: make these public when built using the test helpers
       def logger;   @deas_runner.logger;   end
       def router;   @deas_runner.router;   end
       def request;  @deas_runner.request;  end
@@ -79,10 +84,14 @@ module Deas
 
     module ClassMethods
 
-      def layout(*args)
-        (@layouts ||= []).tap{ |l| l.push(*args) }
+      def layout(path = nil, &block)
+        value = !path.nil? ? Proc.new{ path } : block
+        self.layouts.push(value) if value
       end
-      alias :layouts :layout
+
+      def layouts
+        @layouts ||= []
+      end
 
       def before_callbacks; @before_callbacks ||= []; end
       def after_callbacks;  @after_callbacks  ||= []; end

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -219,11 +219,11 @@ class Deas::TemplateSource
   end
 
   TestViewHandler = Class.new do
-    def self.layouts; []; end
+    def layouts; []; end
   end
 
   LayoutViewHandler = Class.new do
-    def self.layouts; ['test_layout1', 'test_layout2']; end
+    def layouts; ['test_layout1', 'test_layout2']; end
   end
 
 end


### PR DESCRIPTION
This is so you can use handler attributes to determine your layout
template paths.  This allows for dynamic layout templates based on
the nature of the request.

Note: this also changes the API of the layout method to no longer
take multiple paths.  It now expects either a single path or block.
This also removes the `layouts` alias.  Now, layouts just returns
the layouts that have been specified.  This is to simplify the layout
API now that it is taking procs.  Plus, the multiple layout template
path feature hasn't been used much in practice.

Note also: the view handler instance now has a `layouts` method that
returns the layout templates paths.  It handles instance eval'ing
the class layout procs against the handler instance.

@jcredding ready for review.