### PR TITLE
test runner: deprecate `return_value`; switch to `response_value`

### DIFF
--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -9,7 +9,7 @@ module Deas
 
   class TestRunner < Runner
 
-    attr_reader :return_value
+    attr_reader :response_value
 
     def initialize(handler_class, args = nil)
       if !handler_class.include?(Deas::ViewHandler)
@@ -29,11 +29,18 @@ module Deas
       })
       args.each{|key, value| self.handler.send("#{key}=", value) }
 
-      @return_value = catch(:halt){ self.handler.init; nil }
+      @response_value = catch(:halt){ self.handler.init; nil }
+    end
+
+    # TODO: remove eventually
+    def return_value
+      warn "calling `return_value` on a test runner is deprecated - " \
+           "switch to `response_value` instead"
+      self.response_value
     end
 
     def run
-      @return_value ||= catch(:halt){ self.handler.run }
+      @response_value ||= catch(:halt){ self.handler.run }
     end
 
     # Helpers

--- a/test/unit/deas_runner_tests.rb
+++ b/test/unit/deas_runner_tests.rb
@@ -48,7 +48,7 @@ class Deas::DeasRunner
   class RunTests < InitTests
     desc "and run"
     setup do
-      @return_value = @runner.run
+      @response_value = @runner.run
       @handler = @runner.instance_variable_get("@handler")
     end
     subject{ @handler }
@@ -63,8 +63,8 @@ class Deas::DeasRunner
       assert_equal true, subject.run_bang_called
     end
 
-    should "return the handler's run! return value" do
-      assert_equal true, @return_value
+    should "use the handler's run! return value as its response value" do
+      assert_equal true, @response_value
     end
 
   end

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -33,15 +33,15 @@ class Deas::SinatraRunner
     should have_imeths :run
 
     should "call the sinatra_call's halt with" do
-      return_value = catch(:halt){ subject.halt('test') }
-      assert_equal [ 'test' ], return_value
+      response_value = catch(:halt){ subject.halt('test') }
+      assert_equal [ 'test' ], response_value
     end
 
     should "call the sinatra_call's redirect method with" do
-      return_value = catch(:halt){ subject.redirect('http://google.com') }
+      response_value = catch(:halt){ subject.redirect('http://google.com') }
       expected = [ 302, { 'Location' => 'http://google.com' } ]
 
-      assert_equal expected, return_value
+      assert_equal expected, response_value
     end
 
     should "call the sinatra_call's content_type method using the default_charset" do

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -44,8 +44,9 @@ class Deas::TestRunner
     end
     subject{ @runner }
 
-    should have_readers :return_value
+    should have_readers :response_value
     should have_imeths :run
+    should have_imeths :return_value # TODO: deprecated
 
     should "raise an invalid error when not passed a view handler" do
       assert_raises(Deas::InvalidServiceHandlerError) do
@@ -81,14 +82,21 @@ class Deas::TestRunner
       assert_true subject.handler.init_called
     end
 
-    should "not set a return value on initialize" do
-      assert_nil subject.return_value
+    should "not set a response value on initialize" do
+      assert_nil subject.response_value
     end
 
-    should "set its return value to the return value of `run!` on run" do
-      assert_nil subject.return_value
+    should "set its response value to the return value of `run!` on run" do
+      assert_nil subject.response_value
       subject.run
-      assert_equal subject.handler.run!, subject.return_value
+      assert_equal subject.handler.run!, subject.response_value
+    end
+
+    # TODO: deprecated
+    should "alias its response value at `return_value`" do
+      assert_equal subject.response_value, subject.return_value
+      subject.run
+      assert_equal subject.response_value, subject.return_value
     end
 
     should "build halt args if halt is called" do

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -225,9 +225,9 @@ module Deas::ViewHandler
       })
       runner.run
 
-      assert_equal 200,                                runner.return_value.status
-      assert_equal({ 'Content-Type' => 'text/plain' }, runner.return_value.headers)
-      assert_equal 'test halting',                     runner.return_value.body
+      assert_equal 200,                                runner.response_value.status
+      assert_equal({ 'Content-Type' => 'text/plain' }, runner.response_value.headers)
+      assert_equal 'test halting',                     runner.response_value.body
     end
 
   end


### PR DESCRIPTION
Response value better describes what is being returned.  Yes, it
is a return value of some sorts, but what's return value.  It could
be from the run method or it could be from a halt in the init method.

I proposing it is better to describe it more specifically as a
value that represents the type of response that would result from
this action.  Thus, `response_value`.

This deprecates the `return_value` method with a warning so that
pre-existing test code can be migrated to this new method.

Closes #170.  Note I can't call it `response` as this method is already in use by the base runner.

@jcredding ready for review.