### PR TITLE
test runner: allow spying on the content type, status and headers

### DIFF
--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -67,18 +67,27 @@ module Deas
       def redirect?; true; end
     end
 
-    def content_type(value, opts={})
-      ContentTypeArgs.new(value, opts)
+    def content_type(*args)
+      return @content_type_value if args.empty?
+      opts, value = [
+        args.last.kind_of?(Hash) ? args.pop : {},
+        args.last
+      ]
+      @content_type_value = ContentTypeArgs.new(value, opts)
     end
     ContentTypeArgs = Struct.new(:value, :opts)
 
-    def status(value)
-      StatusArgs.new(value)
+    def status(*args)
+      return @status_value if args.empty?
+      value = args.last
+      @status_value = StatusArgs.new(value)
     end
     StatusArgs = Struct.new(:value)
 
-    def headers(value)
-      HeadersArgs.new(value)
+    def headers(*args)
+      return @headers_value if args.empty?
+      value = args.last
+      @headers_value = HeadersArgs.new(value)
     end
     HeadersArgs = Struct.new(:value)
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -124,6 +124,8 @@ class Deas::TestRunner
         assert_respond_to meth, value
       end
       assert_equal 'something', value.value
+
+      assert_same value, subject.content_type
     end
 
     should "build status args if status is called" do
@@ -131,6 +133,8 @@ class Deas::TestRunner
       assert_kind_of StatusArgs, value
       assert_respond_to :value, value
       assert_equal 432, value.value
+
+      assert_same value, subject.status
     end
 
     should "build headers args if headers is called" do
@@ -139,6 +143,8 @@ class Deas::TestRunner
       assert_respond_to :value, value
       exp_val = {:some => 'thing'}
       assert_equal exp_val, value.value
+
+      assert_same value, subject.headers
     end
 
     should "build send file args if send file is called" do


### PR DESCRIPTION
Unlike halt, render, redirect and send file, these methods aren't
typically called so that there return values are the return value
of the `run!` method.  This means they build their args in the test
runner but you can never access those args and test that their
values have been set appropriately.

This switches to storing their values in the test runner and making
these methods so that you can get the values if they are called with
no args.  This will allow you to check their values after a handler
has been run using the test runner.

Closes #152.

@jcredding ready for review.