### PR TITLE
json view handler

### DIFF
--- a/lib/deas/json_view_handler.rb
+++ b/lib/deas/json_view_handler.rb
@@ -1,0 +1,34 @@
+require 'deas/view_handler'
+
+module Deas
+
+  module JsonViewHandler
+
+    def self.included(klass)
+      klass.class_eval do
+        include Deas::ViewHandler
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      def initialize(*args)
+        super(*args)
+        content_type :json
+      end
+
+      private
+
+      # Some http clients will error when trying to parse an empty body when the
+      # content type is 'json'.  This will default the body to a string that
+      # can be parsed to an empty json object
+      def halt(status, headers = {}, body = '{}')
+        super(status, headers, body)
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/json_view_handler_tests.rb
+++ b/test/unit/json_view_handler_tests.rb
@@ -1,0 +1,69 @@
+require 'assert'
+require 'deas/json_view_handler'
+
+require 'deas/test_helpers'
+
+module Deas::JsonViewHandler
+
+  class UnitTests < Assert::Context
+    desc "Deas::JsonViewHandler"
+    setup do
+      @handler_class = TestJsonHandler
+    end
+    subject{ @handler_class }
+
+    should "be a Deas ViewHandler" do
+      assert_includes Deas::ViewHandler, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    include Deas::TestHelpers
+
+    desc "when init"
+    setup do
+      @runner  = test_runner(@handler_class)
+      @handler = @runner.handler
+    end
+    subject{ @runner }
+
+    should "force its content type to :json" do
+      assert_equal :json, subject.content_type.value
+    end
+
+    should "default its body and headers if not provided" do
+      @handler.status = Factory.integer
+      response = @runner.run
+
+      assert_equal @handler.status, response.status
+      assert_equal({},              response.headers)
+      assert_equal '{}',            response.body
+    end
+
+    should "allow halting with a body and headers" do
+      @handler.status  = Factory.integer
+      @handler.headers = { Factory.string => Factory.string }
+      @handler.body    = Factory.text
+      response = @runner.run
+
+      assert_equal @handler.status,  response.status
+      assert_equal @handler.headers, response.headers
+      assert_equal @handler.body,    response.body
+    end
+
+  end
+
+  class TestJsonHandler
+    include Deas::JsonViewHandler
+
+    attr_accessor :status, :headers, :body
+
+    def run!
+      args = [status, headers, body].compact
+      halt *args
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a special view handler that forces the content type to
`:json` and updates `halt` to return an empty json object body if
no custom body is specified.

The goal here is to make working with json handlers easier.  Some
http clients require that the body be valid json if the response
content type is json (or even if the request made requested json).
Halting by default returns an empty body which isn't valid json.

@jcredding ready for review.