### PR TITLE
cleanup content type and default encoding handling

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -29,7 +29,7 @@ module Deas::Server
     option :show_exceptions,  NsOptions::Boolean, :default => false
     option :static_files,     NsOptions::Boolean, :default => true
     option :reload_templates, NsOptions::Boolean, :default => false
-    option :default_charset,  String,             :default => 'utf-8'
+    option :default_encoding, String,             :default => 'utf-8'
 
     # server handling options
 
@@ -190,8 +190,8 @@ module Deas::Server
       self.configuration.logger *args
     end
 
-    def default_charset(*args)
-      self.configuration.default_charset *args
+    def default_encoding(*args)
+      self.configuration.default_encoding *args
     end
 
     def template_source(*args)

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -21,6 +21,7 @@ module Deas
         set :sessions,         server_config.sessions
         set :static,           server_config.static_files
         set :reload_templates, server_config.reload_templates
+        set :default_encoding, server_config.default_encoding
         set :logging,          false
 
         # raise_errors and show_exceptions prevent Deas error handlers from
@@ -30,11 +31,16 @@ module Deas
         set :show_exceptions,  false
 
         # custom settings
-        set :deas_error_procs,     server_config.error_procs
-        set :deas_default_charset, server_config.default_charset
-        set :logger,               server_config.logger
-        set :router,               server_config.router
-        set :template_source,      server_config.template_source
+        set :deas_error_procs, server_config.error_procs
+        set :logger,           server_config.logger
+        set :router,           server_config.router
+        set :template_source,  server_config.template_source
+
+        # TODO: rework with `server_config.default_encoding` once we move off of using Sinatra
+        # TODO: could maybe move into a deas-json mixin once off of Sinatra
+        # Add charset to json content type responses - by default only added to these:
+        # ["application/javascript", "application/xml", "application/xhtml+xml", /^text\//]
+        settings.add_charset << "application/json"
 
         server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -20,15 +20,7 @@ module Deas
     end
 
     def content_type(*args)
-      return @sinatra_call.content_type if args.empty?
-
-      opts, value = [
-        args.last.kind_of?(::Hash) ? args.pop : {},
-        args.first
-      ]
-      @sinatra_call.content_type(value, {
-        :charset => @sinatra_call.settings.deas_default_charset
-      }.merge(opts || {}))
+      @sinatra_call.content_type(*args)
     end
 
     def status(*args)
@@ -40,18 +32,23 @@ module Deas
     end
 
     def source_render(source, template_name, locals = nil)
-      self.content_type(get_content_type(template_name)) if self.content_type.nil?
+      if self.content_type.nil?
+        self.content_type(get_content_type_ext(template_name) || 'html')
+      end
       super
     end
 
-    def send_file(*args, &block)
-      @sinatra_call.send_file(*args, &block)
+    def send_file(file_path, opts = nil, &block)
+      if self.content_type.nil?
+        self.content_type(get_content_type_ext(file_path))
+      end
+      @sinatra_call.send_file(file_path, opts || {}, &block)
     end
 
     private
 
-    def get_content_type(template_name)
-      File.extname(template_name)[1..-1] || 'html'
+    def get_content_type_ext(file_path)
+      File.extname(file_path)[1..-1]
     end
 
   end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -68,26 +68,26 @@ module Deas
     end
 
     def content_type(*args)
-      return @content_type_value if args.empty?
+      return @content_type if args.empty?
       opts, value = [
         args.last.kind_of?(Hash) ? args.pop : {},
         args.last
       ]
-      @content_type_value = ContentTypeArgs.new(value, opts)
+      @content_type = ContentTypeArgs.new(value, opts)
     end
     ContentTypeArgs = Struct.new(:value, :opts)
 
     def status(*args)
-      return @status_value if args.empty?
+      return @status if args.empty?
       value = args.last
-      @status_value = StatusArgs.new(value)
+      @status = StatusArgs.new(value)
     end
     StatusArgs = Struct.new(:value)
 
     def headers(*args)
-      return @headers_value if args.empty?
+      return @headers if args.empty?
       value = args.last
-      @headers_value = HeadersArgs.new(value)
+      @headers = HeadersArgs.new(value)
     end
     HeadersArgs = Struct.new(:value)
 

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -20,8 +20,11 @@ class FakeSinatraCall
     @router          = Deas::Router.new
     @template_source = Deas::NullTemplateSource.new
 
+    @content_type = nil
+    @status       = 200
+    @headers      = {}
+
     @settings = OpenStruct.new({
-      :deas_default_charset => 'utf-8',
       :logger => @logger,
       :router => @router,
       :template_source => @template_source
@@ -36,9 +39,25 @@ class FakeSinatraCall
     halt 302, { 'Location' => args[0] }
   end
 
-  def content_type(*args); args; end
-  def status(*args);       args; end
-  def headers(*args);      args; end
+  def content_type(*args)
+    return @content_type if args.empty?
+    opts, value = [
+      args.last.kind_of?(Hash) ? args.pop : {},
+      args.last
+    ]
+    opts_value = opts.keys.map{ |k| "#{k}=#{opts[k]}" }.join(';')
+    @content_type = [value, opts_value].reject{ |v| v.to_s.empty? }.join(';')
+  end
+
+  def status(*args)
+    return @status if args.empty?
+    @status = args.last
+  end
+
+  def headers(*args)
+    return @headers if args.empty?
+    @headers = args.last
+  end
 
   def send_file(file_path, opts, &block)
     if block

--- a/test/unit/server_configuration_tests.rb
+++ b/test/unit/server_configuration_tests.rb
@@ -21,7 +21,7 @@ class Deas::Server::Configuration
 
     should have_imeths :env, :root, :public_root, :views_root
     should have_imeths :dump_errors, :method_override, :sessions, :show_exceptions
-    should have_imeths :static_files, :reload_templates, :default_charset
+    should have_imeths :static_files, :reload_templates, :default_encoding
 
     # server handling options
 
@@ -79,8 +79,8 @@ class Deas::Server::Configuration
       assert_nothing_raised{ config.root '/path/to/root'; config.validate! }
     end
 
-    should "use `utf-8` as the default_charset by default" do
-      assert_equal 'utf-8', subject.default_charset
+    should "use `utf-8` as the default encoding by default" do
+      assert_equal 'utf-8', subject.default_encoding
     end
 
   end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -23,7 +23,7 @@ module Deas::Server
 
     # DSL for server handling settings
     should have_imeths :init, :error, :template_helpers, :template_helper?
-    should have_imeths :use, :set, :verbose_logging, :logger, :default_charset
+    should have_imeths :use, :set, :verbose_logging, :logger, :default_encoding
     should have_imeths :template_source
 
     # DSL for server routing settings
@@ -93,8 +93,8 @@ module Deas::Server
       subject.template_source a_source
       assert_equal a_source, config.template_source
 
-      subject.default_charset 'latin1'
-      assert_equal 'latin1', config.default_charset
+      subject.default_encoding 'latin1'
+      assert_equal 'latin1', config.default_encoding
     end
 
     should "add and query helper modules" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -27,6 +27,7 @@ module Deas::SinatraApp
         c.show_exceptions  = true
         c.static           = true
         c.reload_templates = true
+        c.default_encoding = 'latin1'
         c.router           = @router
       end
       @sinatra_app = Deas::SinatraApp.new(@configuration)
@@ -52,6 +53,7 @@ module Deas::SinatraApp
         assert_equal false,                          settings.sessions
         assert_equal true,                           settings.static
         assert_equal true,                           settings.reload_templates
+        assert_equal 'latin1',                       settings.default_encoding
         assert_instance_of Deas::NullLogger,         settings.logger
         assert_instance_of Deas::Router,             settings.router
         assert_instance_of Deas::NullTemplateSource, settings.template_source
@@ -60,6 +62,8 @@ module Deas::SinatraApp
         assert_equal false, settings.logging
         assert_equal false, settings.raise_errors
         assert_equal false, settings.show_exceptions
+
+        assert_includes "application/json", settings.add_charset
       end
     end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -39,21 +39,21 @@ class Deas::SinatraRunner
 
     should "call the sinatra_call's redirect method with" do
       response_value = catch(:halt){ subject.redirect('http://google.com') }
-      expected = [ 302, { 'Location' => 'http://google.com' } ]
+      exp = [ 302, { 'Location' => 'http://google.com' } ]
 
-      assert_equal expected, response_value
+      assert_equal exp, response_value
     end
 
-    should "call the sinatra_call's content_type method using the default_charset" do
-      expected = @fake_sinatra_call.content_type('text/plain', :charset => 'utf-8')
-      assert_equal expected, subject.content_type('text/plain')
-
-      expected = @fake_sinatra_call.content_type('text/plain', :charset => 'latin1')
-      assert_equal expected, subject.content_type('text/plain', :charset => 'latin1')
+    should "call the sinatra_call's content_type to set the response content type" do
+      args = ['txt', { :charset => 'latin1' }]
+      exp = @fake_sinatra_call.content_type(*args)
+      subject.content_type(*args)
+      assert_equal exp, subject.content_type
     end
 
     should "call the sinatra_call's status to set the response status" do
-      assert_equal [422], subject.status(422)
+      subject.status(422)
+      assert_equal 422, subject.status
     end
 
     should "call the sinatra_call's headers to set the response headers" do
@@ -61,15 +61,18 @@ class Deas::SinatraRunner
         'a-header' => 'some value',
         'other'    => 'other'
       }
-      assert_equal [exp_headers], subject.headers(exp_headers)
+      subject.headers(exp_headers)
+      assert_equal exp_headers, subject.headers
     end
 
     should "call the sinatra_call's send_file to set the send files" do
       block_called = false
-      args = subject.send_file('a/file', {:some => 'opts'}, &proc{ block_called = true })
-      assert_equal 'a/file', args.file_path
+      args = subject.send_file('a/file.txt', {:some => 'opts'}, &proc{ block_called = true })
+      assert_equal 'a/file.txt', args.file_path
       assert_equal({:some => 'opts'}, args.options)
       assert_true block_called
+
+      assert_equal 'txt', subject.content_type
     end
 
   end


### PR DESCRIPTION
This is some changes to how Deas handles content type.  The goal
is to have less coupling with Sinatra (in prep for moving off of
Sinatra in the future) and to have a more consistent experience using
and testing content type handling.

There are a number of changes here:

* remove `deas_default_charset` custom setting - this was a hacky
  shim of a solution to to allow deas apps to specify default encodings
* rename `default_charset` config opt to `default_encoding` - this
  name matches the sinatra setting is drives and is also more accurate.
* properly set sinatra's default encoding from the config opt
* add `application/json` to the mime-types that get charset info added
* remove custom logic in the sinatra runner `content_type` method for
  applying charset.  Now that we are properly configuring Sinatra,
  it handles this logic for us.  This also removed the need for the
  `deas_default_charset` hack and opened up calling content type for
  non-charset-specific responses.
* auto-set the content type when calling `send_file`.  Now that content
  type is simplified, it is safe to call in this scenario.  This makes
  send file more consistent with render calls.
* update the fake sinatra call to more closely mimic true Sinatra
  behavior related to setting content type, status and headers.  This
  cleanup allowed me to properly test all of the changes above.

@jcredding ready for review.  After we talked yesterday, I realized the fake sinatra call was not handling things good enough for me to test these changes.  I also did more digging into how Sinatra handles content type (ie, `default_encoding` and `add_charset`).  Overall, this does everything we were doing before but without the hacks.  And I get to set content type automatically on send file.