### PR TITLE
remove 'splat' and 'captures' from params in SinatraRunner

### DIFF
--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -5,7 +5,18 @@ module Deas
   class SinatraRunner < DeasRunner
 
     def initialize(handler_class, args = nil)
-      @sinatra_call = (args || {})[:sinatra_call]
+      args ||= {}
+      @sinatra_call = args[:sinatra_call]
+
+      # these are not part of Deas' intended behavior and route matching
+      # they are side-effects of using Sinatra.  remove them so they won't
+      # be relied upon in Deas apps.
+      args[:params] ||= {}
+      args[:params].delete(:splat)
+      args[:params].delete('splat')
+      args[:params].delete(:captures)
+      args[:params].delete('captures')
+
       super(handler_class, args)
     end
 

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -22,14 +22,28 @@ class Deas::SinatraRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
+      @params = {
+        :splat  => Factory.string,
+        'splat' => Factory.string,
+        :captures  => [Factory.string],
+        'captures' => [Factory.string]
+      }
+
       @fake_sinatra_call = Factory.sinatra_call
       @runner = @runner_class.new(DeasRunnerViewHandler, {
-        :sinatra_call => @fake_sinatra_call
+        :sinatra_call => @fake_sinatra_call,
+        :params       => @params
       })
     end
     subject{ @runner }
 
     should have_imeths :run
+
+    should "remove any 'splat' or 'captures' params added by Sinatra's router" do
+      [:splat, 'splat', :captures, 'captures'].each do |param_name|
+        assert_nil subject.params[param_name]
+      end
+    end
 
     should "call the sinatra_call's halt with" do
       response_value = catch(:halt){ subject.halt('test') }


### PR DESCRIPTION
These params are side-effects of using Sinatra under the covers
and aren't intended features we want to support.  This removes them
now so they won't be relied upon when we remove Sinatra at a later
date.

This is prep for removing Sinatra as a dependency.

@jcredding ready for review.