### PR TITLE
have redirects honor any router base url

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency("rack",       ["~> 1.5"])
   gem.add_dependency("sinatra",    ["~> 1.4"])
 
-  gem.add_development_dependency("assert", ["~> 2.12"])
+  gem.add_development_dependency("assert", ["~> 2.15"])
   gem.add_development_dependency("assert-rack-test")
 
 end

--- a/lib/deas/redirect_proxy.rb
+++ b/lib/deas/redirect_proxy.rb
@@ -8,9 +8,14 @@ module Deas
 
     attr_reader :handler_class_name, :handler_class
 
-    def initialize(path = nil, &block)
+    def initialize(router, path = nil, &block)
       @handler_class = Class.new do
         include Deas::ViewHandler
+
+        def self.router; @router; end
+        def self.router=(value)
+          @router = value
+        end
 
         def self.redirect_path; @redirect_path; end
         def self.redirect_path=(value)
@@ -22,7 +27,9 @@ module Deas
         attr_reader :redirect_path
 
         def init!
-          @redirect_path = self.instance_eval(&self.class.redirect_path)
+          @redirect_path = self.class.router.prepend_base_url(
+            self.instance_eval(&self.class.redirect_path)
+          )
         end
 
         def run!
@@ -31,6 +38,7 @@ module Deas
 
       end
 
+      @handler_class.router = router
       @handler_class.redirect_path = if path.nil?
         block
       elsif path.kind_of?(Deas::Url)

--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -30,8 +30,12 @@ module Deas
     end
 
     def base_url(value = nil)
-      @base_url = value if !value.nil?
+      set_base_url(value) if !value.nil?
       @base_url
+    end
+
+    def set_base_url(value)
+      @base_url = value
     end
 
     def prepend_base_url(url_path)
@@ -98,7 +102,7 @@ module Deas
       end
 
       require 'deas/redirect_proxy'
-      proxy = Deas::RedirectProxy.new(to_url || to_path, &block)
+      proxy = Deas::RedirectProxy.new(self, to_url || to_path, &block)
       proxies = { self.default_request_type_name => proxy }
 
       from_url = self.urls[from_path]


### PR DESCRIPTION
This was missed when I originally added the redirect base url logic
back in PR 172.  In that effort I took care of honoring the base
url on the incoming path, but not on the redirect path.

This logic adds handling for the redirect path side of things.  To
accomplish this, redirect proxies need to be passed a router so
they can prepend the router's base url when generating their redir
paths.

In addition, I updated the router tests to randomly have a base url 
set or not and to actually test the redirect paths that were being
produced.  The orig tests didn't do these things which contributed
to this logic being missed in the first place.  This involved adding
a `set_base_url` method allows manually resetting the base url to
`nil` since this can't be done wth the `base_url` method.

See #172, #126 and #122 for reference.

@jcredding ready for review.