### PR TITLE
add server data object

### DIFF
--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -15,24 +15,28 @@ module Deas
       raise NotImplementedError
     end
 
-    def run(sinatra_call)
+    def run(server_data, sinatra_call)
       runner = SinatraRunner.new(self.handler_class, {
-        :sinatra_call => sinatra_call,
-        :request      => sinatra_call.request,
-        :response     => sinatra_call.response,
-        :session      => sinatra_call.session,
-        :params       => sinatra_call.params,
-        :logger       => sinatra_call.settings.logger,
-        :router       => sinatra_call.settings.router,
-        :template_source => sinatra_call.settings.template_source
+        :sinatra_call    => sinatra_call,
+        :request         => sinatra_call.request,
+        :response        => sinatra_call.response,
+        :session         => sinatra_call.session,
+        :params          => sinatra_call.params,
+        :logger          => server_data.logger,
+        :router          => server_data.router,
+        :template_source => server_data.template_source
       })
 
-      sinatra_call.request.env.tap do |env|
-        env['deas.params'] = runner.params
-        env['deas.handler_class_name'] = self.handler_class.name
-        env['deas.logging'].call "  Handler: #{env['deas.handler_class_name']}"
-        env['deas.logging'].call "  Params:  #{env['deas.params'].inspect}"
+      runner.request.env.tap do |env|
+        # add these env settings that are needed for summary logging
+        env['deas.handler_class'] = self.handler_class
+        env['deas.params']        = runner.params
+
+        # this handles the verbose logging (it is a no-op if summary logging)
+        env['deas.logging'].call "  Handler: #{self.handler_class.name}"
+        env['deas.logging'].call "  Params:  #{runner.params.inspect}"
       end
+
       runner.run
     end
 

--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -13,7 +13,7 @@ module Deas
 
     def initialize(app)
       @app    = app
-      @logger = @app.settings.logger
+      @logger = @app.settings.deas_server_data.logger
     end
 
     # The Rack call interface. The receiver acts as a prototype and runs
@@ -101,7 +101,7 @@ module Deas
       line_attrs = {
         'method'  => request.request_method,
         'path'    => request.path,
-        'handler' => env['deas.handler_class_name'],
+        'handler' => env['deas.handler_class'].name,
         'params'  => env['deas.params'],
         'time'    => env['deas.time_taken'],
         'status'  => status

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -16,14 +16,15 @@ module Deas
       end
     end
 
-    def run(sinatra_call)
-      type = sinatra_call.settings.router.request_type_name(sinatra_call.request)
+    def run(server_data, sinatra_call)
+      type = server_data.router.request_type_name(sinatra_call.request)
       proxy = begin
         @handler_proxies[type]
       rescue HandlerProxyNotFound
         sinatra_call.halt(404)
       end
-      proxy.run(sinatra_call)
+      # TODO: eventually stop sending sinatra call (part of phasing out Sinatra)
+      proxy.run(server_data, sinatra_call)
     end
 
   end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -192,7 +192,7 @@ module Deas
         @settings = {}
         @init_procs, @error_procs, @template_helpers, @middlewares = [], [], [], []
         @router = Deas::Router.new
-        @valid = nil
+        @valid  = nil
       end
 
       def urls
@@ -201,6 +201,13 @@ module Deas
 
       def routes
         self.router.routes
+      end
+
+      def to_hash
+        super.merge({
+          :error_procs => self.error_procs,
+          :router      => self.router
+        })
       end
 
       def valid?
@@ -219,12 +226,6 @@ module Deas
 
         # validate the routes
         self.routes.each(&:validate!)
-
-        # set the :erb :outvar setting if it hasn't been set.  this is used
-        # by template helpers and plugins and needs to be queryable.  the actual
-        # value doesn't matter - it just needs to be set
-        self.settings[:erb] ||= {}
-        self.settings[:erb][:outvar] ||= '@_out_buf'
 
         # append the show exceptions and loggine middlewares last.  This ensures
         # that the logging and exception showing happens just before the app gets

--- a/lib/deas/server_data.rb
+++ b/lib/deas/server_data.rb
@@ -1,0 +1,22 @@
+module Deas
+
+  class ServerData
+
+    # The server uses this to "compile" its configuration for speed. NsOptions
+    # is relatively slow everytime an option is read. To avoid this, we read the
+    # options one time here and memoize their values. This way, we don't pay the
+    # NsOptions overhead when reading them while handling a request.
+
+    attr_reader :error_procs, :logger, :router, :template_source
+
+    def initialize(args = nil)
+      args ||= {}
+      @error_procs     = args[:error_procs] || []
+      @logger          = args[:logger]
+      @router          = args[:router]
+      @template_source = args[:template_source]
+    end
+
+  end
+
+end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -1,5 +1,6 @@
 require 'sinatra/base'
 require 'deas/error_handler'
+require 'deas/server_data'
 
 module Deas
   module SinatraApp
@@ -8,16 +9,15 @@ module Deas
       # This is generic server initialization stuff.  Eventually do this in the
       # server's initialization logic more like Sanford does.
       server_config.validate!
+      server_data = ServerData.new(server_config.to_hash)
 
       Sinatra.new do
 
         # built-in settings
-        set :environment, server_config.env
-        set :root,        server_config.root
-
-        set :public_folder, server_config.public_root
-        set :views,         server_config.views_root
-
+        set :environment,      server_config.env
+        set :root,             server_config.root
+        set :public_folder,    server_config.public_root
+        set :views,            server_config.views_root
         set :dump_errors,      server_config.dump_errors
         set :method_override,  server_config.method_override
         set :sessions,         server_config.sessions
@@ -26,17 +26,17 @@ module Deas
         set :default_encoding, server_config.default_encoding
         set :logging,          false
 
-        # raise_errors and show_exceptions prevent Deas error handlers from
-        # being called and Deas' logging doesn't finish. They should always be
-        # false.
+        # TODO: sucks to have to do this but b/c or Rack there is no better way
+        # to make the server data available to middleware.  We should remove this
+        # once we remove Sinatra.  Whatever rack app implemenation will needs to
+        # provide the server data or maybe the server data *will be* the rack app.
+        # Not sure right now, just jotting down notes.
+        set :deas_server_data, server_data
+
+        # raise_errors and show_exceptions prevent Deas error handlers from being
+        # called and Deas' logging doesn't finish. They should always be false.
         set :raise_errors,     false
         set :show_exceptions,  false
-
-        # custom settings
-        set :deas_error_procs, server_config.error_procs
-        set :logger,           server_config.logger
-        set :router,           server_config.router
-        set :template_source,  server_config.template_source
 
         # TODO: rework with `server_config.default_encoding` once we move off of using Sinatra
         # TODO: could maybe move into a deas-json mixin once off of Sinatra
@@ -49,16 +49,18 @@ module Deas
 
         # routes
         server_config.routes.each do |route|
-          send(route.method, route.path){ route.run(self) }
+          # TODO: `self` is the sinatra_call; eventually stop sending it
+          # (part of phasing out Sinatra)
+          send(route.method, route.path){ route.run(server_data, self) }
         end
 
         # error handling
         not_found do
           env['sinatra.error'] ||= Sinatra::NotFound.new
-          ErrorHandler.run(env['sinatra.error'], self, settings.deas_error_procs)
+          ErrorHandler.run(env['sinatra.error'], self, server_data.error_procs)
         end
         error do
-          ErrorHandler.run(env['sinatra.error'], self, settings.deas_error_procs)
+          ErrorHandler.run(env['sinatra.error'], self, server_data.error_procs)
         end
 
       end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,6 +1,23 @@
 require 'assert/factory'
+require 'deas/logger'
+require 'deas/router'
+require 'deas/server_data'
+require 'deas/template_source'
+require 'test/support/fake_sinatra_call'
 
 module Factory
   extend Assert::Factory
+
+  def self.server_data(opts = nil)
+    Deas::ServerData.new({
+      :logger          => Deas::NullLogger.new,
+      :router          => Deas::Router.new,
+      :template_source => Deas::NullTemplateSource.new
+    }.merge(opts || {}))
+  end
+
+  def self.sinatra_call(settings = nil)
+    FakeSinatraCall.new(settings)
+  end
 
 end

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -1,7 +1,4 @@
 require 'ostruct'
-require 'deas/logger'
-require 'deas/router'
-require 'deas/template_source'
 
 class FakeSinatraCall
 
@@ -11,7 +8,7 @@ class FakeSinatraCall
   attr_accessor :request, :response, :params, :logger, :router, :session
   attr_accessor :settings
 
-  def initialize(settings = {})
+  def initialize(settings = nil)
     @request         = FakeRequest.new('GET','/something', {}, OpenStruct.new)
     @response        = FakeResponse.new
     @session         = @request.session
@@ -25,10 +22,8 @@ class FakeSinatraCall
     @headers      = {}
 
     @settings = OpenStruct.new({
-      :logger => @logger,
-      :router => @router,
-      :template_source => @template_source
-    }.merge(settings))
+      :deas_server_data => Factory.server_data
+    }.merge(settings || {}))
   end
 
   def halt(*args)

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -1,15 +1,13 @@
 require 'assert'
 require 'deas/error_handler'
 
-require 'test/support/fake_sinatra_call'
-
 class Deas::ErrorHandler
 
   class UnitTests < Assert::Context
     desc "Deas::ErrorHandler"
     setup do
       @exception = RuntimeError.new
-      @fake_sinatra_call  = FakeSinatraCall.new
+      @fake_sinatra_call = Factory.sinatra_call
       @error_handler = Deas::ErrorHandler.new(@exception, @fake_sinatra_call, [])
     end
     subject{ @error_handler }

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -1,14 +1,12 @@
 require 'assert'
 require 'deas/logging'
 
-require 'test/support/fake_sinatra_call'
-
 module Deas::Logging
 
   class UnitTests < Assert::Context
     desc "Deas::Logging"
     setup do
-      @app = FakeSinatraCall.new
+      @app = Factory.sinatra_call
     end
     subject{ Deas::Logging }
 

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -1,0 +1,43 @@
+require 'assert'
+require 'deas/server_data'
+
+class Deas::ServerData
+
+  class UnitTests < Assert::Context
+    desc "Deas::ServerData"
+    setup do
+      @error_procs     = Factory.integer(3).times.map{ proc{} }
+      @logger          = Factory.string
+      @router          = Factory.string
+      @template_source = Factory.string
+
+      @server_data = Deas::ServerData.new({
+        :error_procs     => @error_procs,
+        :logger          => @logger,
+        :router          => @router,
+        :template_source => @template_source
+      })
+    end
+    subject{ @server_data }
+
+    should have_readers :error_procs, :logger, :router, :template_source
+
+    should "know its attributes" do
+      assert_equal @error_procs,     subject.error_procs
+      assert_equal @logger,          subject.logger
+      assert_equal @router,          subject.router
+      assert_equal @template_source, subject.template_source
+    end
+
+    should "default its attributes when they aren't provided" do
+      server_data = Deas::ServerData.new
+
+      assert_equal [], server_data.error_procs
+      assert_nil server_data.logger
+      assert_nil server_data.router
+      assert_nil server_data.template_source
+    end
+
+  end
+
+end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -138,6 +138,7 @@ module Deas::Server
     should have_accessors :settings, :init_procs, :error_procs, :template_helpers
     should have_accessors :middlewares, :router
     should have_imeths :valid?, :validate!, :urls, :routes
+    should have_imeths :to_hash
 
     should "default the env to 'development'" do
       assert_equal 'development', subject.env
@@ -191,6 +192,13 @@ module Deas::Server
       assert_equal 'utf-8', subject.default_encoding
     end
 
+    should "include its error procs and router in its `to_hash`" do
+      config_hash = subject.to_hash
+
+      assert_equal subject.error_procs, config_hash[:error_procs]
+      assert_equal subject.router,      config_hash[:router]
+    end
+
   end
 
   class ValidationTests < ConfigurationTests
@@ -233,15 +241,6 @@ module Deas::Server
 
       subject.validate!
       assert_equal EmptyViewHandler, @proxy.handler_class
-    end
-
-    should "default the :erb :outvar setting in the SinatraApp it creates" do
-      assert_nil subject.settings[:erb]
-
-      subject.validate!
-
-      assert_kind_of ::Hash, subject.settings[:erb]
-      assert_equal '@_out_buf', subject.settings[:erb][:outvar]
     end
 
     should "add the Logging and ShowExceptions middleware to the end" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -7,6 +7,7 @@ require 'deas/route_proxy'
 require 'deas/route'
 require 'deas/router'
 require 'deas/server'
+require 'deas/server_data'
 require 'test/support/view_handlers'
 
 module Deas::SinatraApp
@@ -44,24 +45,29 @@ module Deas::SinatraApp
 
     should "have it's configuration set based on the server configuration" do
       subject.settings.tap do |settings|
-        assert_equal 'staging',                      settings.environment
-        assert_equal 'path/to/somewhere',            settings.root.to_s
-        assert_equal 'path/to/somewhere/public',     settings.public_folder.to_s
-        assert_equal 'path/to/somewhere/views',      settings.views.to_s
-        assert_equal true,                           settings.dump_errors
-        assert_equal false,                          settings.method_override
-        assert_equal false,                          settings.sessions
-        assert_equal true,                           settings.static
-        assert_equal true,                           settings.reload_templates
-        assert_equal 'latin1',                       settings.default_encoding
-        assert_instance_of Deas::NullLogger,         settings.logger
-        assert_instance_of Deas::Router,             settings.router
-        assert_instance_of Deas::NullTemplateSource, settings.template_source
+        assert_equal 'staging',                  settings.environment
+        assert_equal 'path/to/somewhere',        settings.root.to_s
+        assert_equal 'path/to/somewhere/public', settings.public_folder.to_s
+        assert_equal 'path/to/somewhere/views',  settings.views.to_s
+        assert_equal true,                       settings.dump_errors
+        assert_equal false,                      settings.method_override
+        assert_equal false,                      settings.sessions
+        assert_equal true,                       settings.static
+        assert_equal true,                       settings.reload_templates
+        assert_equal 'latin1',                   settings.default_encoding
 
         # settings that are set but can't be changed
         assert_equal false, settings.logging
         assert_equal false, settings.raise_errors
         assert_equal false, settings.show_exceptions
+
+        exp = Deas::ServerData.new(@configuration.to_hash)
+        sd = settings.deas_server_data
+        assert_instance_of Deas::ServerData,          sd
+        assert_instance_of exp.template_source.class, sd.template_source
+        assert_instance_of exp.logger.class,          sd.logger
+        assert_equal exp.error_procs, sd.error_procs
+        assert_equal exp.router,      sd.router
 
         assert_includes "application/json", settings.add_charset
       end

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -2,7 +2,6 @@ require 'assert'
 require 'deas/sinatra_runner'
 
 require 'deas/deas_runner'
-require 'test/support/fake_sinatra_call'
 require 'test/support/view_handlers'
 
 class Deas::SinatraRunner
@@ -23,7 +22,7 @@ class Deas::SinatraRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @fake_sinatra_call = FakeSinatraCall.new
+      @fake_sinatra_call = Factory.sinatra_call
       @runner = @runner_class.new(DeasRunnerViewHandler, {
         :sinatra_call => @fake_sinatra_call
       })


### PR DESCRIPTION
This organizes some server attributes and makes them available to
the things processing the request: the route, handler proxies,
middleware, etc.  This goal here is to more closely match Sanford's
implementation and also take another step towards phasing out
Sinatra.

Right now, I'm choosing to only track the error procs, logger, router,
and template source.  As we phase out sinatra more, we can move over
additional server attrs.

This is prep for getting sinatra out of the error handling logic.

Note: this removes some legacy :erb settings.  These sould have
been removed back when template rendering was reworked but were
missed.

@jcredding ready for review.