### PR TITLE
remove Sinatra from the error handling process

### DIFF
--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -28,8 +28,12 @@ module Deas
       })
 
       runner.request.env.tap do |env|
-        # add these env settings that are needed for summary logging
+        # make runner data available to Rack (ie middlewares)
+        # this is specifically needed by the Logging middleware
+        # this is also needed by the Sinatra error handlers so they can provide
+        # error context.  This may change when we eventually remove Sinatra.
         env['deas.handler_class'] = self.handler_class
+        env['deas.handler']       = runner.handler
         env['deas.params']        = runner.params
 
         # this handles the verbose logging (it is a no-op if summary logging)

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -227,7 +227,7 @@ module Deas
         # validate the routes
         self.routes.each(&:validate!)
 
-        # append the show exceptions and loggine middlewares last.  This ensures
+        # append the show exceptions and logging middlewares last.  This ensures
         # that the logging and exception showing happens just before the app gets
         # the request and just after the app sends a response.
         self.middlewares << [Deas::ShowExceptions] if self.show_exceptions

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -3,6 +3,7 @@ require 'deas/error_handler'
 require 'deas/server_data'
 
 module Deas
+
   module SinatraApp
 
     def self.new(server_config)
@@ -12,7 +13,6 @@ module Deas
       server_data = ServerData.new(server_config.to_hash)
 
       Sinatra.new do
-
         # built-in settings
         set :environment,      server_config.env
         set :root,             server_config.root
@@ -56,15 +56,32 @@ module Deas
 
         # error handling
         not_found do
+          # `self` is the sinatra call in this context
           env['sinatra.error'] ||= Sinatra::NotFound.new
-          ErrorHandler.run(env['sinatra.error'], self, server_data.error_procs)
+          ErrorHandler.run(env['sinatra.error'], {
+            :server_data   => server_data,
+            :request       => self.request,
+            :response      => self.response,
+            :handler_class => self.request.env['deas.handler_class'],
+            :handler       => self.request.env['deas.handler'],
+            :params        => self.request.env['deas.params'],
+          })
         end
         error do
-          ErrorHandler.run(env['sinatra.error'], self, server_data.error_procs)
+          # `self` is the sinatra call in this context
+          ErrorHandler.run(env['sinatra.error'], {
+            :server_data   => server_data,
+            :request       => self.request,
+            :response      => self.response,
+            :handler_class => self.request.env['deas.handler_class'],
+            :handler       => self.request.env['deas.handler'],
+            :params        => self.request.env['deas.params'],
+          })
         end
 
       end
     end
 
   end
+
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -8,6 +8,14 @@ require 'test/support/fake_sinatra_call'
 module Factory
   extend Assert::Factory
 
+  def self.exception(klass = nil, message = nil)
+    klass ||= StandardError
+    message ||= Factory.text
+    exception = nil
+    begin; raise(klass, message); rescue klass => exception; end
+    exception
+  end
+
   def self.server_data(opts = nil)
     Deas::ServerData.new({
       :logger          => Deas::NullLogger.new,

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -10,12 +10,12 @@ class DeasTestServer
 
   set :a_setting, 'something'
 
-  error do |exception|
+  error do |exception, context|
     case exception
     when Sinatra::NotFound
-      halt 404, "Couldn't be found"
+      [404, "Couldn't be found"]
     when Exception
-      halt 500, "Oops, something went wrong"
+      [500, "Oops, something went wrong"]
     end
   end
 

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -6,99 +6,150 @@ class Deas::ErrorHandler
   class UnitTests < Assert::Context
     desc "Deas::ErrorHandler"
     setup do
-      @exception = RuntimeError.new
-      @fake_sinatra_call = Factory.sinatra_call
-      @error_handler = Deas::ErrorHandler.new(@exception, @fake_sinatra_call, [])
+      # always make sure there are multiple error procs or tests can be false
+      # positives
+      @error_proc_spies = (Factory.integer(3) + 1).times.map{ ErrorProcSpy.new }
+      @server_data      = Factory.server_data(:error_procs => @error_proc_spies)
+      @request          = Factory.string
+      @response         = Factory.string
+      @handler_class    = Factory.string
+      @handler          = Factory.string
+      @params           = Factory.string
+
+      @context_hash = {
+        :server_data   => @server_data,
+        :request       => @request,
+        :response      => @response,
+        :handler_class => @handler_class,
+        :handler       => @handler,
+        :params        => @params,
+      }
+
+      @handler_class = Deas::ErrorHandler
+    end
+    subject{ @handler_class }
+
+    should have_imeths :run
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @exception = Factory.exception
+      @error_handler = @handler_class.new(@exception, @context_hash)
     end
     subject{ @error_handler }
 
-    should have_instance_methods :run
-    should have_class_methods :run
+    should have_readers :exception, :context, :error_procs
+    should have_imeths :run
 
-  end
+    should "know its attrs" do
+      assert_equal @exception, subject.exception
 
-  class RunTests < UnitTests
-    desc "run"
-    setup do
-      @error_procs = [ proc do |exception|
-        settings.exception_that_occurred = exception
-        "my return value"
-      end ]
+      exp = Context.new(@context_hash)
+      assert_equal exp, subject.context
 
-      @error_handler = Deas::ErrorHandler.new(@exception, @fake_sinatra_call, @error_procs)
-      @response = @error_handler.run
-    end
-
-    should "run the proc in the context of the app" do
-      assert_equal @exception, @fake_sinatra_call.settings.exception_that_occurred
-    end
-
-    should "return whatever the proc returns" do
-      assert_equal "my return value", @response
+      exp = @server_data.error_procs.reverse
+      assert_equal exp, subject.error_procs
     end
 
   end
 
-  class RunWithMultipleProcsTests < UnitTests
-    desc "run with multiple procs"
+  class RunTests < InitTests
+    desc "and run"
     setup do
-      @error_procs = [
-        proc do |exception|
-          settings.first_proc_run = true
-          'first'
-        end,
-        proc do |exception|
-          settings.second_proc_run = true
-          'second'
-        end,
-        proc do |exception|
-          settings.third_proc_run = true
-          nil
-        end
-      ]
-
-      @error_handler = Deas::ErrorHandler.new(@exception, @fake_sinatra_call, @error_procs)
       @response = @error_handler.run
     end
 
-    should "run all the error procs" do
-      assert_equal true, @fake_sinatra_call.settings.first_proc_run
-      assert_equal true, @fake_sinatra_call.settings.second_proc_run
-      assert_equal true, @fake_sinatra_call.settings.third_proc_run
+    should "call each of its procs" do
+      subject.error_procs.each do |proc_spy|
+        assert_true proc_spy.called
+        assert_equal subject.exception, proc_spy.exception
+        assert_equal subject.context,   proc_spy.context
+      end
     end
 
     should "return the last non-nil response" do
-      assert_equal 'second', @response
+      assert_nil @response
+
+      exp = Factory.string
+      subject.error_procs.first.response = exp
+      assert_equal exp, subject.run
     end
 
   end
 
-  class RunWithProcsThatHaltTests < UnitTests
-    desc "run with a proc that halts"
+  class RunWithProcsThatRaiseTests < InitTests
+    desc "and run with procs that raise exceptions"
     setup do
-      @error_procs = [
-        proc do |exception|
-          settings.first_proc_run = true
-          halt 401
-        end,
-        proc do |exception|
-          settings.second_proc_run = true
-        end
-      ]
+      @first_exception, @last_exception = Factory.exception, Factory.exception
+      @error_handler.error_procs.first.raise_exception = @first_exception
+      @error_handler.error_procs.last.raise_exception  = @last_exception
 
-      @error_handler = Deas::ErrorHandler.new(@exception, @fake_sinatra_call, @error_procs)
-      @response = catch(:halt){ @error_handler.run }
+      @error_handler.run
     end
 
-    should "run error procs until one halts" do
-      assert_equal true, @fake_sinatra_call.settings.first_proc_run
-      assert_nil @fake_sinatra_call.settings.second_proc_run
+    should "call each of its procs" do
+      subject.error_procs.each{ |proc_spy| assert_true proc_spy.called }
     end
 
-    should "return whatever was halted" do
-      assert_equal [ 401 ], @response
+    should "call each proc with the most recently raised exception" do
+      assert_equal @exception,       @error_handler.error_procs.first.exception
+      assert_equal @first_exception, @error_handler.error_procs.last.exception
     end
 
+    should "alter the handler's exception to be the last raised exception" do
+      assert_equal @last_exception, subject.exception
+    end
+
+  end
+
+  class ContextTests < UnitTests
+    desc "Context"
+    setup do
+      @context = Context.new(@context_hash)
+    end
+    subject{ @context }
+
+    should have_readers :server_data
+    should have_readers :request, :response, :handler_class, :handler, :params
+
+    should "know its attributes" do
+      assert_equal @context_hash[:server_data],   subject.server_data
+      assert_equal @context_hash[:request],       subject.request
+      assert_equal @context_hash[:response],      subject.response
+      assert_equal @context_hash[:handler_class], subject.handler_class
+      assert_equal @context_hash[:handler],       subject.handler
+      assert_equal @context_hash[:params],        subject.params
+    end
+
+    should "know if it equals another context" do
+      exp = Context.new(@context_hash)
+      assert_equal exp, subject
+
+      exp = Context.new({})
+      assert_not_equal exp, subject
+    end
+
+  end
+
+  class ErrorProcSpy
+    attr_reader :called, :exception, :context
+    attr_accessor :response, :raise_exception
+
+    def initialize
+      @called = false
+    end
+
+    def call(exception, context)
+      @called    = true
+      @exception = exception
+      @context   = context
+
+      raise self.raise_exception if self.raise_exception
+      @response
+    end
   end
 
 end

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -61,12 +61,13 @@ class Deas::HandlerProxy
       assert_true @runner_spy.run_called
     end
 
-    should "add the handler class to the request env" do
+    should "add data to the request env to make it available to Rack" do
       exp = subject.handler_class
       assert_equal exp, @fake_sinatra_call.request.env['deas.handler_class']
-    end
 
-    should "add the runner params to the request env" do
+      exp = @runner_spy.handler
+      assert_equal exp, @fake_sinatra_call.request.env['deas.handler']
+
       exp = @runner_spy.params
       assert_equal exp, @fake_sinatra_call.request.env['deas.params']
     end
@@ -84,7 +85,7 @@ class Deas::HandlerProxy
   class SinatraRunnerSpy
 
     attr_reader :run_called
-    attr_reader :handler_class, :args
+    attr_reader :handler_class, :handler, :args
     attr_reader :sinatra_call
     attr_reader :request, :response, :session, :params
     attr_reader :logger, :router, :template_source
@@ -94,7 +95,9 @@ class Deas::HandlerProxy
     end
 
     def build(handler_class, args)
-      @handler_class, @args = handler_class, args
+      @handler_class = handler_class
+      @handler       = handler_class.new(self)
+      @args          = args
 
       @sinatra_call    = args[:sinatra_call]
       @request         = args[:request]


### PR DESCRIPTION
This updates the error handler to not depend on Sinatra.  This is
part of prepping to remove Sinatra from Deas.  This also gets Deas'
error handling more inline with how Sanford handles errors.  Ther
are three big differences this introduces.

First, error procs are no longer evaluated in Sinatra's scope.
Practically this means you can no longer do Sinatra-y things like
halting in your error procs.  Proc return values are still used
to alter responses but you'll have to treat these handlers more
like raw Rack and manually return the appropriate response values.
This also means that *all* error procs will always be run and the
last non-nil return value will always be used as the response.
Before, you could theoretically halt in an error proc and cutoff
any remaining error procs.

Second, error procs are now called with some context data in addition
to the exception that is being raised.  This data includes the
server data, the request/response and the handler class (if any).
Previously some of this data was implicitly available to handlers
from the fact that the proc was run in sinatra's scope.  This
switches to making certain pieces of data *explicitly* available.

Finally, this makes the *actual runner's* handler and params
available via the context data.  Previously, these attrs were not
available to error procs b/c you were in the scope of sinatra who
was not aware of handlers or the params given to the handler.  The
only difference between the handler params and the request params
is that the handler params are formally normalized by the runner.
In non-test cases they should be equivalent.  In general, you
should prefer the context params but fall back to the context
request params if there are no context params (ie the error
happened before any handler/runner was invoked).

@jcredding ready for review.  This should get everything ready for us to hook our new error publisher up to our Deas apps.  This also makes the handler available so we can publish `current_user` and any other handler attrs with our error context.