### PR TITLE
Cleanups for show exceptions and its tests

### DIFF
--- a/lib/deas/show_exceptions.rb
+++ b/lib/deas/show_exceptions.rb
@@ -27,24 +27,19 @@ module Deas
         error_body = Body.new(error)
 
         headers['Content-Length'] = error_body.size.to_s
-        headers['Content-Type'] = error_body.mime_type.to_s
+        headers['Content-Type']   = error_body.mime_type.to_s
         body = [error_body.content]
       end
-      [ status, headers, body ]
+      [status, headers, body]
     end
 
     class Body
-      attr_reader :content
+      attr_reader :content, :size, :mime_type
+
       def initialize(e)
-        @content ||= "#{e.class}: #{e.message}\n#{(e.backtrace || []).join("\n")}"
-      end
-
-      def size
-        @size ||= Rack::Utils.bytesize(self.content)
-      end
-
-      def mime_type
-        @mime_type ||= "text/plain"
+        @content   = "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
+        @size      = Rack::Utils.bytesize(@content)
+        @mime_type = "text/plain"
       end
     end
 

--- a/test/unit/show_exceptions_tests.rb
+++ b/test/unit/show_exceptions_tests.rb
@@ -8,27 +8,60 @@ class Deas::ShowExceptions
   class UnitTests < Assert::Context
     desc "Deas::ShowExceptions"
     setup do
-      exception = Sinatra::NotFound.new
-      @app = proc do |env|
-        env['sinatra.error'] = exception
-        [ 404, {}, [] ]
-      end
-      @exception = exception
-      @show_exceptions = Deas::ShowExceptions.new(@app)
+      @middleware_class = Deas::ShowExceptions
     end
-    subject{ @show_exceptions }
+    subject{ @middleware_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @app = Factory.sinatra_call
+      @env = { 'sinatra.error' => Factory.exception }
+      @middleware = @middleware_class.new(@app)
+    end
+    subject{ @middleware }
 
     should have_imeths :call, :call!
 
-    should "return a body that contains details about the exception" do
-      status, headers, body = subject.call({})
-      expected_body = "#{@exception.class}: #{@exception.message}\n" \
-                      "#{(@exception.backtrace || []).join("\n")}"
-      expected_body_size = Rack::Utils.bytesize(expected_body).to_s
+    should "return a response for the exception when called" do
+      status, headers, body = subject.call(@env)
+      error_body = Body.new(@env['sinatra.error'])
 
-      assert_equal expected_body_size, headers['Content-Length']
-      assert_equal "text/plain",       headers['Content-Type']
-      assert_equal [expected_body],    body
+      assert_equal @app.response.status, status
+      assert_equal error_body.size.to_s, headers['Content-Length']
+      assert_equal error_body.mime_type, headers['Content-Type']
+      assert_equal [error_body.content], body
+    end
+
+    should "return the apps response if there isn't an exception" do
+      @env.delete('sinatra.error')
+      status, headers, body = subject.call(@env)
+
+      assert_equal @app.response.status,  status
+      assert_equal @app.response.headers, headers
+      assert_equal @app.response.body,    body
+    end
+
+  end
+
+  class BodyTests < UnitTests
+    desc "Body"
+    setup do
+      @exception = Factory.exception
+      @body = Body.new(@exception)
+    end
+    subject{ @body }
+
+    should have_readers :content, :size, :mime_type
+
+    should "know its attributes" do
+      exp_content = "#{@exception.class}: #{@exception.message}\n" \
+                "#{@exception.backtrace.join("\n")}"
+      assert_equal exp_content, subject.content
+      assert_equal Rack::Utils.bytesize(exp_content), subject.size
+      assert_equal "text/plain", subject.mime_type
     end
 
   end


### PR DESCRIPTION
This is a small set of cleanups to the show exceptions middleware
and its tests to match our latest conventions. This is part of
cleaning up our middlewares and testing them consistently.

This simplifies the `Body` helper. It doesn't need to lazily set
its content, size and mime type because we use all of them when we
build it. This also reorganizes the tests to match our latest
conventions and switches to using the fake sinatra call for the
middlewares app. This also adds a test to make sure the apps
response isn't modified if there isn't an error.

@kellyredding - Ready for review. This was the only other middleware we have in Deas. There are also system tests that test the show exceptions middleware already.