### PR TITLE
router: properly complain about named urls that aren't defined

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -83,14 +83,17 @@ module Deas
         handler_names[self.default_request_type_name] = default_handler_name
       end
 
+      from_url = self.urls[from_path]
+      if from_path.kind_of?(::Symbol) && from_url.nil?
+        raise ArgumentError, "no url named `#{from_path.inspect}`"
+      end
+      from_url_path = from_url.path if from_url
+
       require 'deas/route_proxy'
       proxies = handler_names.inject({}) do |proxies, (req_type_name, handler_name)|
         proxies[req_type_name] = Deas::RouteProxy.new(handler_name, self.view_handler_ns)
         proxies
       end
-
-      from_url = self.urls[from_path]
-      from_url_path = from_url.path if from_url
 
       add_route(http_method, prepend_base_url(from_url_path || from_path), proxies)
     end
@@ -100,13 +103,15 @@ module Deas
       if to_path.kind_of?(::Symbol) && to_url.nil?
         raise ArgumentError, "no url named `#{to_path.inspect}`"
       end
+      from_url = self.urls[from_path]
+      if from_path.kind_of?(::Symbol) && from_url.nil?
+        raise ArgumentError, "no url named `#{from_path.inspect}`"
+      end
+      from_url_path = from_url.path if from_url
 
       require 'deas/redirect_proxy'
       proxy = Deas::RedirectProxy.new(self, to_url || to_path, &block)
       proxies = { self.default_request_type_name => proxy }
-
-      from_url = self.urls[from_path]
-      from_url_path = from_url.path if from_url
 
       add_route(:get, prepend_base_url(from_url_path || from_path), proxies)
     end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -300,9 +300,12 @@ class Deas::Router
       end
     end
 
-    should "complain if redirecting to a named url that hasn't been defined" do
+    should "complain if redirecting to/from a named url that hasn't been defined" do
       assert_raises ArgumentError do
         subject.redirect('/somewhere', :not_defined_url)
+      end
+      assert_raises ArgumentError do
+        subject.redirect(:not_defined_url, '/somewhere')
       end
     end
 
@@ -322,6 +325,12 @@ class Deas::Router
 
       exp = subject.prepend_base_url(url.path)
       assert_equal exp, route.path
+    end
+
+    should "complain if routing a named url that hasn't been defined" do
+      assert_raises ArgumentError do
+        subject.route(:get, :not_defined_url, 'GetInfo')
+      end
     end
 
     should "prepend the base url when building named urls" do


### PR DESCRIPTION
The router was missing a couple of cases where a named url could
be specified but not yet defined: the redirect from url and the
main router from url.  This cleans up the logic and adds tests to
cover these cases.

@jcredding ready for review.  Just a cleanup I noticed while working in the router on the not found directive and lazy named url eval.