### PR TITLE
router: lazy apply routes definitions

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -224,8 +224,8 @@ module Deas
         self.init_procs.each{ |p| p.call }
         raise Deas::ServerRootError if self.root.nil?
 
-        # validate the routes
-        self.routes.each(&:validate!)
+        # validate the router
+        self.router.validate!
 
         # append the show exceptions and logging middlewares last.  This ensures
         # that the logging and exception showing happens just before the app gets

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -207,8 +207,9 @@ module Deas::Server
       @initialized = false
       @other_initialized = false
       @router = Deas::Router.new
-      @route = @router.get('/something', 'EmptyViewHandler')
-      @proxy = @route.handler_proxies[@router.default_request_type_name]
+
+      @router_validate_called = false
+      Assert.stub(@router, :validate!){ @router_validate_called = true }
 
       @configuration = Configuration.new.tap do |c|
         c.env              = 'staging'
@@ -236,11 +237,11 @@ module Deas::Server
       assert_equal true, @other_initialized
     end
 
-    should "call validate! on all routes" do
-      assert_nil @proxy.handler_class
+    should "call validate! on the router" do
+      assert_false @router_validate_called
 
       subject.validate!
-      assert_equal EmptyViewHandler, @proxy.handler_class
+      assert_true @router_validate_called
     end
 
     should "add the Logging and ShowExceptions middleware to the end" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -16,8 +16,8 @@ module Deas::SinatraApp
     desc "Deas::SinatraApp"
     setup do
       @router = Deas::Router.new
-      @route = @router.get('/something', 'EmptyViewHandler')
-      @proxy = @route.handler_proxies[@router.default_request_type_name]
+      @router.get('/something', 'EmptyViewHandler')
+      @router.validate!
 
       @configuration = Deas::Server::Configuration.new.tap do |c|
         c.env              = 'staging'
@@ -74,10 +74,10 @@ module Deas::SinatraApp
     end
 
     should "define Sinatra routes for every route in the configuration" do
-      get_routes = subject.routes[@route.method.to_s.upcase] || []
-      sinatra_route = get_routes.detect{ |route| route[0].match(@route.path) }
+      router_route   = @router.routes.last
+      sinatra_routes = subject.routes[router_route.method.to_s.upcase] || []
 
-      assert_not_nil sinatra_route
+      assert_not_nil sinatra_routes.detect{ |r| r[0].match(router_route.path) }
     end
 
   end


### PR DESCRIPTION
This switches the router logic to lazily apply route definitions.
The goal here is to allow defining a route that uses named urls
without first having defined the named url.  Overall, the router
should not be picky about the order directives are specified as long
as everything is valid once all directives have been specified.

To facilitate this, the route now only stores the definitions for
routes when a route or redirect method is called.  These definitions
build up and can be converted to actual routes on the router by
calling the `apply_definitions!` method.  The server now auto applies
definitions during its validation.

Note: to simplify the server and require it to know as little about
the router as possible, I chose to add a `validate!` method to the
router that the server now calls.  This method not only applies
any pending definitions, it also validates each one of its routes
like the server was doing previously.

@jcredding ready for review.