### PR TITLE
router: add `not_found` route definition

### DIFF
--- a/lib/deas/respond_with_proxy.rb
+++ b/lib/deas/respond_with_proxy.rb
@@ -1,0 +1,42 @@
+require 'deas/handler_proxy'
+require 'deas/url'
+require 'deas/view_handler'
+
+module Deas
+
+  class RespondWithProxy < HandlerProxy
+
+    attr_reader :handler_class_name, :handler_class
+
+    def initialize(halt_args)
+      @handler_class = Class.new do
+        include Deas::ViewHandler
+
+        def self.halt_args; @halt_args; end
+        def self.halt_args=(value)
+          @halt_args = value
+        end
+
+        def self.name; 'Deas::RespondWithHandler'; end
+
+        attr_reader :halt_args
+
+        def init!
+          @halt_args = self.class.halt_args
+        end
+
+        def run!
+          halt *self.halt_args
+        end
+
+      end
+
+      @handler_class.halt_args = halt_args
+      @handler_class_name = @handler_class.name
+    end
+
+    def validate!; end
+
+  end
+
+end

--- a/test/unit/respond_with_proxy_tests.rb
+++ b/test/unit/respond_with_proxy_tests.rb
@@ -1,0 +1,87 @@
+require 'assert'
+require 'deas/respond_with_proxy'
+
+require 'deas/handler_proxy'
+require 'deas/test_helpers'
+require 'deas/url'
+require 'deas/view_handler'
+
+class Deas::RespondWithProxy
+
+  class UnitTests < Assert::Context
+    desc "Deas::RespondWithProxy"
+    setup do
+      @status  = Factory.integer
+      @headers = { Factory.string => Factory.string }
+      @body    = Factory.string
+      @proxy    = Deas::RespondWithProxy.new([@status, @headers, @body])
+    end
+    subject{ @proxy }
+
+    should "be a HandlerProxy" do
+      assert_kind_of Deas::HandlerProxy, subject
+    end
+
+  end
+
+  class HandlerClassTests < UnitTests
+    include Deas::TestHelpers
+
+    desc "handler class"
+    setup do
+      @handler_class = @proxy.handler_class
+    end
+    subject{ @handler_class }
+
+    should have_accessor :halt_args
+    should have_imeth :name
+
+    should "be a view handler" do
+      subject.included_modules.tap do |modules|
+        assert_includes Deas::ViewHandler, modules
+      end
+    end
+
+    should "store the args to halt with" do
+      assert_equal [@status, @headers, @body], subject.halt_args
+    end
+
+    should "know its name" do
+      assert_equal 'Deas::RespondWithHandler', subject.name
+    end
+
+  end
+
+  class HandlerTests < HandlerClassTests
+    desc "handler instance"
+    setup do
+      @handler = test_handler(@handler_class)
+    end
+    subject{ @handler }
+
+    should have_reader :halt_args
+
+    should "know its halt args" do
+      assert_equal [@status, @headers, @body], subject.halt_args
+    end
+
+  end
+
+  class RunTests < HandlerClassTests
+    desc "when run"
+    setup do
+      @runner   = test_runner(@handler_class)
+      @handler  = @runner.handler
+      @response = @runner.run
+    end
+    subject{ @response }
+
+    should "halt and respond with the halt args" do
+      assert_equal @status,  subject.status
+      assert_equal @headers, subject.headers
+      assert_equal @body,    subject.body
+    end
+
+  end
+
+end


### PR DESCRIPTION
These routes will always respond with a 404.  Allows you to 404
known paths without relying on Sinatra to raise a `Sinatra::NotFound`
error.

This follows the pattern of the redirect definition.

@jcredding ready for review.