### PR TITLE
remove usage of `env['sinatra.error']` and `Sinatra::NotFound`

### DIFF
--- a/lib/deas/exceptions.rb
+++ b/lib/deas/exceptions.rb
@@ -18,4 +18,6 @@ module Deas
 
   HandlerProxyNotFound = Class.new(Error)
 
+  NotFound = Class.new(Error)
+
 end

--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -38,7 +38,7 @@ module Deas
       benchmark = Benchmark.measure do
         status, headers, body = @app.call(env)
       end
-      log_error(env['sinatra.error'])
+      log_error(env['deas.error'])
       env['deas.time_taken'] = RoundedTime.new(benchmark.real)
 
       [status, headers, body]
@@ -49,9 +49,9 @@ module Deas
     end
 
     def log_error(exception)
-      return if !exception || exception.kind_of?(Sinatra::NotFound)
+      return if !exception
       log "#{exception.class}: #{exception.message}\n" \
-          "#{exception.backtrace.join("\n")}"
+          "#{(exception.backtrace || []).join("\n")}"
     end
 
   end

--- a/lib/deas/show_exceptions.rb
+++ b/lib/deas/show_exceptions.rb
@@ -23,7 +23,7 @@ module Deas
     # The real Rack call interface.
     def call!(env)
       status, headers, body = @app.call(env)
-      if error = env['sinatra.error']
+      if error = env['deas.error']
         error_body = Body.new(error)
 
         headers['Content-Length'] = error_body.size.to_s
@@ -37,7 +37,7 @@ module Deas
       attr_reader :content, :size, :mime_type
 
       def initialize(e)
-        @content   = "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
+        @content   = "#{e.class}: #{e.message}\n#{(e.backtrace || []).join("\n")}"
         @size      = Rack::Utils.bytesize(@content)
         @mime_type = "text/plain"
       end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -13,6 +13,7 @@ module Factory
     message ||= Factory.text
     exception = nil
     begin; raise(klass, message); rescue klass => exception; end
+    exception.set_backtrace(nil) if Factory.boolean
     exception
   end
 

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -12,7 +12,7 @@ class DeasTestServer
 
   error do |exception, context|
     case exception
-    when Sinatra::NotFound
+    when Deas::NotFound
       [404, "Couldn't be found"]
     when Exception
       [500, "Oops, something went wrong"]

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -155,7 +155,7 @@ module Deas
 
       assert_equal 404, last_response.status
       assert_equal "text/plain", last_response.headers['Content-Type']
-      assert_match "Sinatra::NotFound: Sinatra::NotFound", last_response.body
+      assert_match "Deas::NotFound: /not_defined", last_response.body
     end
 
     should "return a text/plain body when an exception occurs" do

--- a/test/unit/exceptions_tests.rb
+++ b/test/unit/exceptions_tests.rb
@@ -41,6 +41,11 @@ module Deas
       assert_kind_of Deas::Error, Deas::HandlerProxyNotFound.new
     end
 
+    should "provide a generic not found exception" do
+      assert Deas::NotFound
+      assert_kind_of Deas::Error, Deas::NotFound.new
+    end
+
   end
 
 end

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -85,18 +85,15 @@ module Deas::Logging
       assert_equal exp, @env['deas.time_taken']
     end
 
-    should "log a sinatra.error env key if it exists" do
-      @env.delete('sinatra.error')
+    should "log a deas.error env key if it exists" do
+      @env.delete('deas.error')
       subject.call(@env)
       assert_empty @logger.info_logged
 
-      @env['sinatra.error'] = Factory.exception(Sinatra::NotFound)
+      @env['deas.error'] = error = Factory.exception
       subject.call(@env)
-      assert_empty @logger.info_logged
-
-      @env['sinatra.error'] = error = Factory.exception
-      subject.call(@env)
-      exp = "[Deas] #{error.class}: #{error.message}\n#{error.backtrace.join("\n")}"
+      exp = "[Deas] #{error.class}: #{error.message}\n" \
+            "#{(error.backtrace || []).join("\n")}"
       assert_includes exp, @logger.info_logged
     end
 

--- a/test/unit/show_exceptions_tests.rb
+++ b/test/unit/show_exceptions_tests.rb
@@ -18,7 +18,7 @@ class Deas::ShowExceptions
     desc "when init"
     setup do
       @app = Factory.sinatra_call
-      @env = { 'sinatra.error' => Factory.exception }
+      @env = { 'deas.error' => Factory.exception }
       @middleware = @middleware_class.new(@app)
     end
     subject{ @middleware }
@@ -27,7 +27,7 @@ class Deas::ShowExceptions
 
     should "return a response for the exception when called" do
       status, headers, body = subject.call(@env)
-      error_body = Body.new(@env['sinatra.error'])
+      error_body = Body.new(@env['deas.error'])
 
       assert_equal @app.response.status, status
       assert_equal error_body.size.to_s, headers['Content-Length']
@@ -36,7 +36,7 @@ class Deas::ShowExceptions
     end
 
     should "return the apps response if there isn't an exception" do
-      @env.delete('sinatra.error')
+      @env.delete('deas.error')
       status, headers, body = subject.call(@env)
 
       assert_equal @app.response.status,  status
@@ -58,7 +58,7 @@ class Deas::ShowExceptions
 
     should "know its attributes" do
       exp_content = "#{@exception.class}: #{@exception.message}\n" \
-                "#{@exception.backtrace.join("\n")}"
+                    "#{(@exception.backtrace || []).join("\n")}"
       assert_equal exp_content, subject.content
       assert_equal Rack::Utils.bytesize(exp_content), subject.size
       assert_equal "text/plain", subject.mime_type


### PR DESCRIPTION
This is another small piece in prep for removing Sinatra as a
dependency.  This does a few things:

* replaces `Sinatra::NotFound` exception handling with `Deas::NotFound`
* includes the path info in the not found exception message
* makes the exception factory randomly generate with `nil` backtraces
  as we've seen this come up in production
* make the error handling tolerate exceptions with `nil` backtraces
  gracefully

Overall, this is about removing sinatra usage.  In addition we get
the benefit of not found exceptions that actually include the path
that wasn't found (which is really helpful when debugging or when
these come up in production).

@jcredding ready for review.