### PR TITLE
remove `response` as a handler/runner attribute

### DIFF
--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -19,7 +19,6 @@ module Deas
       runner = SinatraRunner.new(self.handler_class, {
         :sinatra_call    => sinatra_call,
         :request         => sinatra_call.request,
-        :response        => sinatra_call.response,
         :session         => sinatra_call.session,
         :params          => sinatra_call.params,
         :logger          => server_data.logger,

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -8,8 +8,8 @@ module Deas
   class Runner
 
     attr_reader :handler_class, :handler
-    attr_reader :request, :response, :session
-    attr_reader :params, :logger, :router, :template_source
+    attr_reader :request, :session, :params
+    attr_reader :logger, :router, :template_source
 
     def initialize(handler_class, args = nil)
       @handler_class = handler_class
@@ -17,7 +17,6 @@ module Deas
 
       a = args || {}
       @request         = a[:request]
-      @response        = a[:response]
       @session         = a[:session]
       @params          = a[:params] || {}
       @logger          = a[:logger] || Deas::NullLogger.new

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -19,12 +19,11 @@ module Deas
 
       args = (args || {}).dup
       super(handler_class, {
-        :request  => args.delete(:request),
-        :response => args.delete(:response),
-        :session  => args.delete(:session),
-        :params   => NormalizedParams.new(args.delete(:params) || {}).value,
-        :logger   => args.delete(:logger),
-        :router   => args.delete(:router),
+        :request         => args.delete(:request),
+        :session         => args.delete(:session),
+        :params          => NormalizedParams.new(args.delete(:params) || {}).value,
+        :logger          => args.delete(:logger),
+        :router          => args.delete(:router),
         :template_source => args.delete(:template_source)
       })
       args.each{|key, value| self.handler.send("#{key}=", value) }

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -66,12 +66,11 @@ module Deas
       def source_partial(*args, &block); @deas_runner.source_partial(*args, &block); end
       def send_file(*args, &block);      @deas_runner.send_file(*args, &block);      end
 
-      def request;  @deas_runner.request;  end
-      def response; @deas_runner.response; end
-      def session;  @deas_runner.session;  end
-      def params;   @deas_runner.params;   end
-      def logger;   @deas_runner.logger;   end
-      def router;   @deas_runner.router;   end
+      def request; @deas_runner.request; end
+      def session; @deas_runner.session; end
+      def params;  @deas_runner.params;  end
+      def logger;  @deas_runner.logger;  end
+      def router;  @deas_runner.router;  end
 
       def run_callback(callback)
         (self.class.send("#{callback}_callbacks") || []).each do |callback|
@@ -124,9 +123,8 @@ module Deas
 
       def test_runner(handler_class, args = nil)
         args ||= {}
-        args[:request]  ||= Rack::Request.new({})
-        args[:response] ||= Rack::Response.new
-        args[:session]  ||= args[:request].session
+        args[:request] ||= Rack::Request.new({})
+        args[:session] ||= args[:request].session
         TestRunner.new(handler_class, args)
       end
 

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -189,7 +189,6 @@ class HandlerTestsHandler
     @data = {}
     set_data('logger_class_name'){ logger.class.name }
     set_data('request_method'){ request.request_method.to_s }
-    set_data('response_firstheaderval'){ response.headers.sort.first.to_s }
     set_data('params_a_param'){ params['a-param'] }
     set_data('session_inspect'){ session.inspect }
   end

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -133,11 +133,10 @@ module Deas
 
     should "be able to access sinatra call data" do
       exp = {
-        'logger_class_name'       => 'Logger',
-        'request_method'          => 'GET',
-        'response_firstheaderval' => 'Content-Type',
-        'params_a_param'          => 'something',
-        'session_inspect'         => '{}'
+        'logger_class_name' => 'Logger',
+        'request_method'    => 'GET',
+        'params_a_param'    => 'something',
+        'session_inspect'   => '{}'
       }
       assert_equal exp.inspect, @data_inspect
     end

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -49,7 +49,6 @@ class Deas::HandlerProxy
       exp_args = {
         :sinatra_call    => @fake_sinatra_call,
         :request         => @fake_sinatra_call.request,
-        :response        => @fake_sinatra_call.response,
         :session         => @fake_sinatra_call.session,
         :params          => @fake_sinatra_call.params,
         :logger          => @server_data.logger,

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -24,8 +24,8 @@ class Deas::Runner
     subject{ @runner }
 
     should have_readers :handler_class, :handler
-    should have_readers :request, :response, :session
-    should have_readers :params, :logger, :router, :template_source
+    should have_readers :request, :session, :params
+    should have_readers :logger, :router, :template_source
     should have_imeths :halt, :redirect, :content_type, :status, :headers
     should have_imeths :render, :source_render, :partial, :source_partial
     should have_imeths :send_file
@@ -37,7 +37,6 @@ class Deas::Runner
 
     should "default its settings" do
       assert_nil subject.request
-      assert_nil subject.response
       assert_nil subject.session
       assert_equal ::Hash.new, subject.params
       assert_kind_of Deas::NullLogger, subject.logger

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -28,12 +28,11 @@ class Deas::TestRunner
     setup do
       @params = { 'value' => '1' }
       @args = {
-        :request  => 'a-request',
-        :response => 'a-response',
-        :session  => 'a-session',
-        :params   => @params,
-        :logger   => 'a-logger',
-        :router   => 'a-router',
+        :request         => 'a-request',
+        :session         => 'a-session',
+        :params          => @params,
+        :logger          => 'a-logger',
+        :router          => 'a-router',
         :template_source => 'a-source'
       }
 
@@ -54,13 +53,12 @@ class Deas::TestRunner
     end
 
     should "super its standard args" do
-      assert_equal 'a-request',  subject.request
-      assert_equal 'a-response', subject.response
-      assert_equal 'a-session',  subject.session
-      assert_equal @params,      subject.params
-      assert_equal 'a-logger',   subject.logger
-      assert_equal 'a-router',   subject.router
-      assert_equal 'a-source',   subject.template_source
+      assert_equal 'a-request', subject.request
+      assert_equal 'a-session', subject.session
+      assert_equal @params,     subject.params
+      assert_equal 'a-logger',  subject.logger
+      assert_equal 'a-router',  subject.router
+      assert_equal 'a-source',  subject.template_source
     end
 
     should "call to normalize its params" do

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -297,7 +297,6 @@ module Deas::ViewHandler
 
       assert_kind_of ::Deas::TestRunner, runner
       assert_kind_of Rack::Request,  runner.request
-      assert_kind_of Rack::Response, runner.response
       assert_equal runner.request.session, runner.session
     end
 


### PR DESCRIPTION
This effectively means you can't do direct rack response manipulation
in the handlers.  You must use a helper (ie status, headers, body, halt,
etc).

This is prep for adding a `response` handler helper for setting
responses (similar to `halt` except it won't halt execution).  This
helper will be how response data is set and will deprecate the
run-return-value-gets-set-as-the-response behavior.

Related to #174 

@jcredding ready for review.