### PR TITLE
redirect proxy: rename "path" to "location"

### DIFF
--- a/lib/deas/redirect_proxy.rb
+++ b/lib/deas/redirect_proxy.rb
@@ -8,7 +8,7 @@ module Deas
 
     attr_reader :handler_class_name, :handler_class
 
-    def initialize(router, path = nil, &block)
+    def initialize(router, location = nil, &block)
       @handler_class = Class.new do
         include Deas::ViewHandler
 
@@ -17,34 +17,34 @@ module Deas
           @router = value
         end
 
-        def self.redirect_path; @redirect_path; end
-        def self.redirect_path=(value)
-          @redirect_path = value
+        def self.redirect_location; @redirect_location; end
+        def self.redirect_location=(value)
+          @redirect_location = value
         end
 
         def self.name; 'Deas::RedirectHandler'; end
 
-        attr_reader :redirect_path
+        attr_reader :redirect_location
 
         def init!
-          @redirect_path = self.class.router.prepend_base_url(
-            self.instance_eval(&self.class.redirect_path)
+          @redirect_location = self.class.router.prepend_base_url(
+            self.instance_eval(&self.class.redirect_location)
           )
         end
 
         def run!
-          redirect @redirect_path
+          redirect @redirect_location
         end
 
       end
 
       @handler_class.router = router
-      @handler_class.redirect_path = if path.nil?
+      @handler_class.redirect_location = if location.nil?
         block
-      elsif path.kind_of?(Deas::Url)
-        proc{ path.path_for(params) }
+      elsif location.kind_of?(Deas::Url)
+        proc{ location.path_for(params) }
       else
-        proc{ path }
+        proc{ location }
       end
       @handler_class_name = @handler_class.name
     end

--- a/test/unit/redirect_proxy_tests.rb
+++ b/test/unit/redirect_proxy_tests.rb
@@ -31,7 +31,7 @@ class Deas::RedirectProxy
     end
     subject{ @handler_class }
 
-    should have_accessor :router, :redirect_path
+    should have_accessor :router, :redirect_location
     should have_imeth :name
 
     should "be a view handler" do
@@ -44,16 +44,16 @@ class Deas::RedirectProxy
       assert_equal @router, subject.router
     end
 
-    should "store its redirect path as a proc" do
-      assert_kind_of Proc, subject.redirect_path
+    should "store its redirect location as a proc" do
+      assert_kind_of Proc, subject.redirect_location
 
       url = Deas::Url.new(:some_thing, '/:some/:thing')
       handler_class = Deas::RedirectProxy.new(@router, url).handler_class
-      assert_kind_of Proc, handler_class.redirect_path
+      assert_kind_of Proc, handler_class.redirect_location
 
-      path_proc = proc{ '/somewhere' }
-      handler_class = Deas::RedirectProxy.new(@router, &path_proc).handler_class
-      assert_kind_of Proc, handler_class.redirect_path
+      location_proc = proc{ '/somewhere' }
+      handler_class = Deas::RedirectProxy.new(@router, &location_proc).handler_class
+      assert_kind_of Proc, handler_class.redirect_location
     end
 
     should "know its name" do
@@ -69,48 +69,48 @@ class Deas::RedirectProxy
     end
     subject{ @handler }
 
-    should have_reader :redirect_path
+    should have_reader :redirect_location
 
-    should "know its redir path if from a path string" do
-      exp_path = '/somewhere'
-      assert_equal exp_path, subject.redirect_path
+    should "know its redir location if from a location string" do
+      exp_location = '/somewhere'
+      assert_equal exp_location, subject.redirect_location
 
       @router.base_url(@base_url)
       handler = test_handler(@handler_class)
-      exp = @router.prepend_base_url(exp_path)
-      assert_equal exp, handler.redirect_path
+      exp = @router.prepend_base_url(exp_location)
+      assert_equal exp, handler.redirect_location
     end
 
-    should "know its redir path if from Url" do
+    should "know its redir location if from Url" do
       url = Deas::Url.new(:some_thing, '/:some/:thing')
       handler_class = Deas::RedirectProxy.new(@router, url).handler_class
       handler = test_handler(handler_class, {
         :params => { 'some' => 'a', 'thing' => 'goose' }
       })
 
-      exp_path = '/a/goose'
-      assert_equal exp_path, handler.redirect_path
+      exp_location = '/a/goose'
+      assert_equal exp_location, handler.redirect_location
 
       @router.base_url(@base_url)
       handler = test_handler(handler_class, {
         :params => { 'some' => 'a', 'thing' => 'goose' }
       })
-      exp = @router.prepend_base_url(exp_path)
-      assert_equal exp, handler.redirect_path
+      exp = @router.prepend_base_url(exp_location)
+      assert_equal exp, handler.redirect_location
     end
 
-    should "know its redir path if from a block" do
-      path_proc = proc{ '/from-block-arg' }
-      handler_class = Deas::RedirectProxy.new(@router, &path_proc).handler_class
+    should "know its redir location if from a block" do
+      location_proc = proc{ '/from-block-arg' }
+      handler_class = Deas::RedirectProxy.new(@router, &location_proc).handler_class
       handler = test_handler(handler_class)
 
-      exp_path = '/from-block-arg'
-      assert_equal exp_path , handler.redirect_path
+      exp_location = '/from-block-arg'
+      assert_equal exp_location , handler.redirect_location
 
       @router.base_url(@base_url)
       handler = test_handler(handler_class)
-      exp = @router.prepend_base_url(exp_path)
-      assert_equal exp, handler.redirect_path
+      exp = @router.prepend_base_url(exp_location)
+      assert_equal exp, handler.redirect_location
     end
 
   end
@@ -118,14 +118,14 @@ class Deas::RedirectProxy
   class RunTests < HandlerClassTests
     desc "when run"
     setup do
-      @runner = test_runner(@handler_class)
-      @handler = @runner.handler
-      @render_args = @runner.run
+      @runner   = test_runner(@handler_class)
+      @handler  = @runner.handler
+      @response = @runner.run
     end
 
-    should "redirect to the handler's redirect path" do
-      assert @render_args.redirect?
-      assert_equal @handler.redirect_path, @render_args.path
+    should "redirect to the handler's redirect location" do
+      assert_true @response.redirect?
+      assert_equal @handler.redirect_location, @response.path
     end
 
   end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -223,7 +223,7 @@ class Deas::Router
       proxy = redirect.handler_proxies[subject.default_request_type_name]
       handler = test_handler(proxy.handler_class)
       exp = subject.prepend_base_url(path2)
-      assert_equal exp, handler.redirect_path
+      assert_equal exp, handler.redirect_location
     end
 
     should "prepend the base url when adding not founds" do
@@ -343,7 +343,7 @@ class Deas::Router
 
       handler = test_handler(proxy.handler_class)
       exp = subject.prepend_base_url(@path2)
-      assert_equal exp, handler.redirect_path
+      assert_equal exp, handler.redirect_location
     end
 
     should "add not found routes" do


### PR DESCRIPTION
This is more proper and better aligns with the header name that
redirects affect.  This is a cleanup in prep for removing Sinatra
from response handling.

@jcredding ready for review.