### PR TITLE
minor cleanups to prepare for removing Sinatra from response handling

### DIFF
--- a/lib/deas/deas_runner.rb
+++ b/lib/deas/deas_runner.rb
@@ -21,7 +21,7 @@ module Deas
     private
 
     def run_callbacks(callbacks)
-      callbacks.each{|proc| self.handler.instance_eval(&proc) }
+      callbacks.each{ |proc| self.handler.instance_eval(&proc) }
     end
 
     class NormalizedParams < Deas::Runner::NormalizedParams

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -16,14 +16,22 @@ module Deas
     end
 
     def run(server_data, sinatra_call)
+      # these are not part of Deas' intended behavior and route matching
+      # they are side-effects of using Sinatra.  remove them so they won't
+      # be relied upon in Deas apps.
+      sinatra_call.params.delete(:splat)
+      sinatra_call.params.delete('splat')
+      sinatra_call.params.delete(:captures)
+      sinatra_call.params.delete('captures')
+
       runner = SinatraRunner.new(self.handler_class, {
         :sinatra_call    => sinatra_call,
-        :request         => sinatra_call.request,
-        :session         => sinatra_call.session,
-        :params          => sinatra_call.params,
         :logger          => server_data.logger,
         :router          => server_data.router,
-        :template_source => server_data.template_source
+        :template_source => server_data.template_source,
+        :request         => sinatra_call.request,
+        :session         => sinatra_call.session,
+        :params          => sinatra_call.params
       })
 
       runner.request.env.tap do |env|

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -8,20 +8,20 @@ module Deas
   class Runner
 
     attr_reader :handler_class, :handler
-    attr_reader :request, :session, :params
     attr_reader :logger, :router, :template_source
+    attr_reader :request, :session, :params
 
     def initialize(handler_class, args = nil)
       @handler_class = handler_class
       @handler = @handler_class.new(self)
 
-      a = args || {}
-      @request         = a[:request]
-      @session         = a[:session]
-      @params          = a[:params] || {}
-      @logger          = a[:logger] || Deas::NullLogger.new
-      @router          = a[:router] || Deas::Router.new
-      @template_source = a[:template_source] || Deas::NullTemplateSource.new
+      args ||= {}
+      @logger          = args[:logger] || Deas::NullLogger.new
+      @router          = args[:router] || Deas::Router.new
+      @template_source = args[:template_source] || Deas::NullTemplateSource.new
+      @request         = args[:request]
+      @session         = args[:session]
+      @params          = args[:params] || {}
     end
 
     def halt(*args);           raise NotImplementedError; end

--- a/lib/deas/sinatra_runner.rb
+++ b/lib/deas/sinatra_runner.rb
@@ -7,16 +7,6 @@ module Deas
     def initialize(handler_class, args = nil)
       args ||= {}
       @sinatra_call = args[:sinatra_call]
-
-      # these are not part of Deas' intended behavior and route matching
-      # they are side-effects of using Sinatra.  remove them so they won't
-      # be relied upon in Deas apps.
-      args[:params] ||= {}
-      args[:params].delete(:splat)
-      args[:params].delete('splat')
-      args[:params].delete(:captures)
-      args[:params].delete('captures')
-
       super(handler_class, args)
     end
 

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -19,12 +19,12 @@ module Deas
 
       args = (args || {}).dup
       super(handler_class, {
-        :request         => args.delete(:request),
-        :session         => args.delete(:session),
-        :params          => NormalizedParams.new(args.delete(:params) || {}).value,
         :logger          => args.delete(:logger),
         :router          => args.delete(:router),
-        :template_source => args.delete(:template_source)
+        :template_source => args.delete(:template_source),
+        :request         => args.delete(:request),
+        :session         => args.delete(:session),
+        :params          => NormalizedParams.new(args.delete(:params) || {}).value
       })
       args.each{|key, value| self.handler.send("#{key}=", value) }
 

--- a/test/unit/deas_runner_tests.rb
+++ b/test/unit/deas_runner_tests.rb
@@ -11,7 +11,8 @@ class Deas::DeasRunner
   class UnitTests < Assert::Context
     desc "Deas::DeasRunner"
     setup do
-      @runner_class = Deas::DeasRunner
+      @handler_class = DeasRunnerViewHandler
+      @runner_class  = Deas::DeasRunner
     end
     subject{ @runner_class }
 
@@ -28,24 +29,31 @@ class Deas::DeasRunner
       @norm_params_spy = Deas::Runner::NormalizedParamsSpy.new
       Assert.stub(NormalizedParams, :new){ |p| @norm_params_spy.new(p) }
 
-      @runner = @runner_class.new(DeasRunnerViewHandler, :params => @params)
+      @runner = @runner_class.new(@handler_class, :params => @params)
     end
     subject{ @runner }
 
     should have_imeths :run
-
-    should "super its params arg" do
-      assert_equal @params, subject.params
-    end
 
     should "call to normalize its params" do
       assert_equal @params, @norm_params_spy.params
       assert_true @norm_params_spy.value_called
     end
 
+    should "super its params arg" do
+      assert_equal @params, subject.params
+    end
+
   end
 
-  class RunTests < InitTests
+  class InitHandlerTests < InitTests
+    setup do
+      @handler = @runner.instance_variable_get("@handler")
+    end
+
+  end
+
+  class RunTests < InitHandlerTests
     desc "and run"
     setup do
       @response_value = @runner.run

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -24,8 +24,8 @@ class Deas::Runner
     subject{ @runner }
 
     should have_readers :handler_class, :handler
-    should have_readers :request, :session, :params
     should have_readers :logger, :router, :template_source
+    should have_readers :request, :session, :params
     should have_imeths :halt, :redirect, :content_type, :status, :headers
     should have_imeths :render, :source_render, :partial, :source_partial
     should have_imeths :send_file
@@ -36,12 +36,12 @@ class Deas::Runner
     end
 
     should "default its settings" do
-      assert_nil subject.request
-      assert_nil subject.session
-      assert_equal ::Hash.new, subject.params
       assert_kind_of Deas::NullLogger, subject.logger
       assert_kind_of Deas::Router, subject.router
       assert_kind_of Deas::NullTemplateSource, subject.template_source
+      assert_nil subject.request
+      assert_nil subject.session
+      assert_equal ::Hash.new, subject.params
     end
 
     should "not implement its non-rendering actions" do

--- a/test/unit/sinatra_runner_tests.rb
+++ b/test/unit/sinatra_runner_tests.rb
@@ -22,28 +22,14 @@ class Deas::SinatraRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @params = {
-        :splat  => Factory.string,
-        'splat' => Factory.string,
-        :captures  => [Factory.string],
-        'captures' => [Factory.string]
-      }
-
       @fake_sinatra_call = Factory.sinatra_call
       @runner = @runner_class.new(DeasRunnerViewHandler, {
-        :sinatra_call => @fake_sinatra_call,
-        :params       => @params
+        :sinatra_call => @fake_sinatra_call
       })
     end
     subject{ @runner }
 
     should have_imeths :run
-
-    should "remove any 'splat' or 'captures' params added by Sinatra's router" do
-      [:splat, 'splat', :captures, 'captures'].each do |param_name|
-        assert_nil subject.params[param_name]
-      end
-    end
 
     should "call the sinatra_call's halt with" do
       response_value = catch(:halt){ subject.halt('test') }

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -13,7 +13,7 @@ class Deas::TestRunner
     desc "Deas::TestRunner"
     setup do
       @handler_class = TestRunnerViewHandler
-      @runner_class = Deas::TestRunner
+      @runner_class  = Deas::TestRunner
     end
     subject{ @runner_class }
 
@@ -26,14 +26,16 @@ class Deas::TestRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @params = { 'value' => '1' }
+      @request = Factory.request
+      @params  = { Factory.string => Factory.string }
+
       @args = {
-        :request         => 'a-request',
-        :session         => 'a-session',
-        :params          => @params,
-        :logger          => 'a-logger',
-        :router          => 'a-router',
-        :template_source => 'a-source'
+        :logger          => Factory.string,
+        :router          => Factory.string,
+        :template_source => Factory.string,
+        :request         => @request,
+        :session         => Factory.string,
+        :params          => @params
       }
 
       @norm_params_spy = Deas::Runner::NormalizedParamsSpy.new
@@ -53,12 +55,12 @@ class Deas::TestRunner
     end
 
     should "super its standard args" do
-      assert_equal 'a-request', subject.request
-      assert_equal 'a-session', subject.session
-      assert_equal @params,     subject.params
-      assert_equal 'a-logger',  subject.logger
-      assert_equal 'a-router',  subject.router
-      assert_equal 'a-source',  subject.template_source
+      assert_equal @args[:logger],          subject.logger
+      assert_equal @args[:router],          subject.router
+      assert_equal @args[:template_source], subject.template_source
+      assert_equal @args[:request],         subject.request
+      assert_equal @args[:session],         subject.session
+      assert_equal @args[:params],          subject.params
     end
 
     should "call to normalize its params" do


### PR DESCRIPTION
This are some random things I discovered are needed to help remove
Sinatra from response handling.  They essentially just add "noise"
to that coming effort so I want to break them off in their own
PR to keep the coming effort as focused as possible.  They include

* minor style cleanups and updates to get tests on latest conventions
* moving the logic for removing splat/captures params into the
  handler proxy and out of the sinatra runner as the sinatra runner
  will be removed in the coming effort
* order args consistently in code as they flow from handler proxy to
  runner (or test runner)

@jcredding ready for review.