### PR TITLE
view handler: make default `run!` method a no-op

### DIFF
--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -34,7 +34,6 @@ module Deas
       end
 
       def run!
-        raise NotImplementedError
       end
 
       def layouts

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -79,10 +79,6 @@ module Deas::ViewHandler
       assert_equal true, subject.after_run_called
     end
 
-    should "complain if run! is not overwritten" do
-      assert_raises(NotImplementedError){ test_runner(EmptyViewHandler).run }
-    end
-
   end
 
   class PrivateHelpersTests < InitTests


### PR DESCRIPTION
This allows you to implement all run related behavior in callbacks
only if you choose.  This is ideal if you need to put run logic
into handler mixins but want to use callbacks b/c you aren't sure
what other handler mixins may be in play.

@jcredding ready for review.