### PR TITLE
view handler: namespace non-user-facing methods

### DIFF
--- a/lib/deas/deas_runner.rb
+++ b/lib/deas/deas_runner.rb
@@ -15,9 +15,9 @@ module Deas
 
     def run
       catch(:halt) do
-        self.handler.instance_eval{ run_callback 'before' }
-        catch(:halt){ self.handler.init; self.handler.run }
-        self.handler.instance_eval{ run_callback 'after' }
+        self.handler.deas_run_callback 'before'
+        catch(:halt){ self.handler.deas_init; self.handler.deas_run }
+        self.handler.deas_run_callback 'after'
       end
 
       self.to_rack.tap do |(status, headers, body)|

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -28,13 +28,13 @@ module Deas
 
       @run_return_value = nil
       @halted = false
-      catch(:halt){ self.handler.init }
+      catch(:halt){ self.handler.deas_init }
     end
 
     def halted?; @halted; end
 
     def run
-      catch(:halt){ self.handler.run } if !self.halted?
+      catch(:halt){ self.handler.deas_run } if !self.halted?
       @run_return_value
     end
 

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -17,19 +17,19 @@ module Deas
         @deas_runner = runner
       end
 
-      def init
-        run_callback 'before_init'
+      def deas_init
+        self.deas_run_callback 'before_init'
         self.init!
-        run_callback 'after_init'
+        self.deas_run_callback 'after_init'
       end
 
       def init!
       end
 
-      def run
-        run_callback 'before_run'
+      def deas_run
+        self.deas_run_callback 'before_run'
         data = self.run!
-        run_callback 'after_run'
+        self.deas_run_callback 'after_run'
         data
       end
 
@@ -38,6 +38,12 @@ module Deas
 
       def layouts
         self.class.layouts.map{ |proc| self.instance_eval(&proc) }
+      end
+
+      def deas_run_callback(callback)
+        (self.class.send("#{callback}_callbacks") || []).each do |callback|
+          self.instance_eval(&callback)
+        end
       end
 
       def inspect
@@ -50,12 +56,6 @@ module Deas
       end
 
       private
-
-      def run_callback(callback)
-        (self.class.send("#{callback}_callbacks") || []).each do |callback|
-          self.instance_eval(&callback)
-        end
-      end
 
       # Helpers
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -43,8 +43,8 @@ module Deas::ViewHandler
     end
     subject{ @handler }
 
-    should have_imeths :init, :init!, :run, :run!
-    should have_imeths :layouts
+    should have_imeths :deas_init, :init!, :deas_run, :run!
+    should have_imeths :layouts, :deas_run_callback
 
     should "have called `init!` and it's callbacks" do
       assert_equal true, subject.before_init_called
@@ -57,6 +57,11 @@ module Deas::ViewHandler
       assert_nil subject.before_run_called
       assert_nil subject.run_bang_called
       assert_nil subject.after_run_called
+    end
+
+    should "run its callbacks with `deas_run_callback`" do
+      subject.deas_run_callback 'before_run'
+      assert_equal true, subject.before_run_called
     end
 
     should "know if it is equal to another view handler" do
@@ -73,7 +78,7 @@ module Deas::ViewHandler
     desc "and run"
 
     should "call `run!` and it's callbacks" do
-      subject.run
+      subject.deas_run
       assert_equal true, subject.before_run_called
       assert_equal true, subject.run_bang_called
       assert_equal true, subject.after_run_called


### PR DESCRIPTION
Since view handlers are intended to run user code, we want to be
careful to not "pollute" the handler scope with our own methods
that will break in spectacular ways if the user happens to override
them.

This switches all the internal methods (ie methods not intended to
be called or used by users) to be prefixed with `deas_`.  This not
only marks them as internal "deas" methods but also makes it more
difficult to accidentally override in custom user handlers.

In addition, now that the methods are namespaced, I have no problem
making the `deas_run_callback` method public.  This allows the
deas runner to call the method directly instead of instance eval
calling it (which feels unnecessarily hackish).

@jcredding ready for review.