### PR TITLE
test runner: capture content type args

### DIFF
--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -9,6 +9,8 @@ module Deas
 
   class TestRunner < Runner
 
+    attr_reader :content_type_args
+
     def initialize(handler_class, args = nil)
       if !handler_class.include?(Deas::ViewHandler)
         raise InvalidViewHandlerError, "#{handler_class.inspect} is not a " \
@@ -26,8 +28,10 @@ module Deas
       })
       a.each{|key, value| self.handler.send("#{key}=", value) }
 
-      @run_return_value = nil
-      @halted = false
+      @run_return_value  = nil
+      @content_type_args = nil
+      @halted            = false
+
       catch(:halt){ self.handler.deas_init }
     end
 
@@ -39,6 +43,11 @@ module Deas
     end
 
     # helpers
+
+    def content_type(extname, params = nil)
+      @content_type_args = ContentTypeArgs.new(extname, params)
+      super
+    end
 
     def halt(*args)
       @halted = true
@@ -69,6 +78,8 @@ module Deas
       super
       RenderArgs.new(source, template_name, locals)
     end
+
+    ContentTypeArgs = Struct.new(:extname, :params)
 
     class HaltArgs < Struct.new(:status, :headers, :body)
       def initialize(args)

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -47,6 +47,7 @@ class Deas::TestRunner
     end
     subject{ @runner }
 
+    should have_readers :content_type_args
     should have_imeths :halted?, :run
 
     should "raise an invalid error when passed a non view handler" do
@@ -97,6 +98,10 @@ class Deas::TestRunner
       assert_nil subject.run
     end
 
+    should "have no content type args by default" do
+      assert_nil subject.content_type_args
+    end
+
     should "not be halted by default" do
       assert_false subject.halted?
     end
@@ -112,6 +117,30 @@ class Deas::TestRunner
       catch(:halt){ subject.halt }
       return_val = subject.run
       assert_kind_of HaltArgs, return_val
+    end
+
+  end
+
+  class ContentTypeTests < InitTests
+    desc "the `content_type` method"
+    setup do
+      @extname = ".#{Factory.string}"
+      @params  = { Factory.string => Factory.string }
+      @runner.content_type(@extname, @params)
+    end
+
+    should "set content type args" do
+      args = subject.content_type_args
+
+      assert_kind_of ContentTypeArgs, args
+      assert_equal @extname, args.extname
+      assert_equal @params,  args.params
+    end
+
+    should "super to the base runner" do
+      e = @extname; p = @params
+      exp = subject.instance_eval{ get_content_type(e, p) }
+      assert_equal exp, subject.headers['Content-Type']
     end
 
   end
@@ -284,6 +313,25 @@ class Deas::TestRunner
 
     should "not affect the run return val" do
       assert_nil subject.run
+    end
+
+  end
+
+  class ContentTypeArgsTests < UnitTests
+    desc "ContentTypeArgs"
+    setup do
+      @extname = ".#{Factory.string}"
+      @params  = { Factory.string => Factory.string }
+
+      @args = ContentTypeArgs.new(@extname, @params)
+    end
+    subject{ @args }
+
+    should have_imeths :extname, :params
+
+    should "know its attrs" do
+      assert_equal @extname, subject.extname
+      assert_equal @params,  subject.params
     end
 
   end


### PR DESCRIPTION
This allows you to test that your handler called `content_type`
without having to worry about the details of what calling content
type does.  This essentially spies on content type calls.

This came up when testing the latest Deas changes in deas-json.  That
gem sets `.json` content type and needs to test that this has been
done.

@jcredding ready for review.