### PR TITLE
template source: pass ext as an option to registered engines

### DIFF
--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -34,6 +34,7 @@ module Deas
                                         " engine extension."
       end
       engine_opts = @default_engine_opts.merge(registered_opts || {})
+      engine_opts['ext'] = input_ext.to_s
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
     end
 

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -48,38 +48,39 @@ class Deas::TemplateSource
     end
 
     should "register with default options" do
-      subject.engine 'test', @test_engine
-      exp_opts = {
-        'source_path'             => subject.path,
-        'logger'                  => @logger,
-        'default_template_source' => subject
-      }
-      assert_equal exp_opts, subject.engines['test'].opts
-
-      subject.engine 'test', @test_engine, 'an' => 'opt'
+      engine_ext = Factory.string
+      subject.engine engine_ext, @test_engine
       exp_opts = {
         'source_path'             => subject.path,
         'logger'                  => @logger,
         'default_template_source' => subject,
-        'an'                      => 'opt'
+        'ext'                     => engine_ext
       }
-      assert_equal exp_opts, subject.engines['test'].opts
+      assert_equal exp_opts, subject.engines[engine_ext].opts
 
-      subject.engine('test', @test_engine, {
-        'source_path'             => 'something',
-        'logger'                  => 'another',
-        'default_template_source' => 'tempsource'
-      })
+      custom_opts = { Factory.string => Factory.string }
+      subject.engine engine_ext, @test_engine, custom_opts
       exp_opts = {
+        'source_path'             => subject.path,
+        'logger'                  => @logger,
+        'default_template_source' => subject,
+        'ext'                     => engine_ext
+      }.merge(custom_opts)
+      assert_equal exp_opts, subject.engines[engine_ext].opts
+
+      custom_opts = {
         'source_path'             => 'something',
         'logger'                  => 'another',
-        'default_template_source' => 'tempsource'
+        'default_template_source' => 'tempsource',
+        'ext'                     => Factory.string
       }
-      assert_equal exp_opts, subject.engines['test'].opts
+      subject.engine(engine_ext, @test_engine, custom_opts)
+      exp_opts = custom_opts.merge('ext' => engine_ext)
+      assert_equal exp_opts, subject.engines[engine_ext].opts
 
       source = Deas::TemplateSource.new(@source_path)
-      source.engine('test', @test_engine)
-      assert_instance_of Deas::NullLogger, source.engines['test'].opts['logger']
+      source.engine(engine_ext, @test_engine)
+      assert_instance_of Deas::NullLogger, source.engines[engine_ext].opts['logger']
     end
 
     should "complain if registering a disallowed temp" do


### PR DESCRIPTION
This updates template sources to pass the extension that was used
to register an engine to the engine as an option. The goal is to
allow the engine to choose templates that match the extension that
was used when configuring the extension. This is also part of
fixing an issue with the engines not knowing which template file
to pick because they no longer hard-code an extension that the
templates have to use.

The template source now always sets an ext option and passes it
to the engines when they are registered. The ext will always be
set and can't be different from how the engine is registered. It
would be non-sensical to register with one engine ext and pass a
different engine ext as an option. Deas would either not use
the registered engine to render the template or the template
engine wouldn't find the file. Either case wouldn't produce the
desired result.

Specifically this helps address issues b/c Nm and deas-erubis no
longer expect specific file extensions but take optional file
extensions as arguments when looking up source files.  We want to
have the extension used to register the engine available to pass
in when they look up source files.

@jcredding ready for review.  I copied this heavily from redding/sanford#170 btw - thanks!