### PR TITLE
template source: minor optimization to private `compile` logic

### DIFF
--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -63,9 +63,8 @@ module Deas
     private
 
     def compile(name)
-      ext_list = @ext_lists[name].dup
-      ext_list.inject(yield @engines[ext_list.shift]) do |content, ext|
-        @engines[ext].compile(name, content)
+      @ext_lists[name].drop(1).inject(yield @engines[@ext_lists[name].first]) do |c, e|
+        @engines[e].compile(name, c)
       end
     end
 


### PR DESCRIPTION
The goal here is to create less objects and avoid having to modify
variable state.  This drops the `dup` and `shift` operations in
favor of more functional approaches using `drop(1)` and `first` to
get the necessary parts of the extension list.  I like this better
b/c it doesn't mutate state and doesn't require adding a local var.

The tests don't change and everything works as it did before.  There
doesn't seem to be any performance impact either.

@jcredding ready for review.  Are you cool with this change?  Am I missing anything about this that might impact performance or otherwise be problematic?