### PR TITLE
templates: don't reject unregistered exts if they are the last ext on the file

### DIFF
--- a/lib/deas/template_source.rb
+++ b/lib/deas/template_source.rb
@@ -66,8 +66,18 @@ module Deas
         raise ArgumentError, "#{template_name.inspect} matches more than one " \
                              "file, consider using a more specific template name"
       end
-      File.basename(paths.first.to_s).split('.').drop(1).reverse.reject do |ext|
-        !self.engine_for?(ext)
+      get_ext_list(paths.first.to_s)
+    end
+
+    def get_ext_list(path)
+      # get the base name of the path (file name plus extensions).  Split on the
+      # periods and drop the first value (the file name).  reverse the list b/c
+      # we process exts right-to-left.  reject any unnecessary exts.
+      File.basename(path).split('.').drop(1).reverse.reject.each_with_index do |e, i|
+        # keep the first ext (for initial render from source) and any registered
+        # exts.  remove any non-first non-registered exts so you don't have the
+        # overhead of running through the null engine for each.
+        i != 0 && !self.engine_for?(e)
       end
     end
 

--- a/test/support/template-compiled3.foo.json
+++ b/test/support/template-compiled3.foo.json
@@ -1,0 +1,1 @@
+This is a json template for use in template source/engine tests.

--- a/test/support/template-compiled4.json.foo
+++ b/test/support/template-compiled4.json.foo
@@ -1,0 +1,1 @@
+This is a json template for use in template source/engine tests.

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -106,6 +106,13 @@ class Deas::TemplateSource
 
       exp = "render-test-engine on template-compiled2\ncompile-json-engine"
       assert_equal exp, subject.render('template-compiled2', @v, @l)
+
+      exp = "render-json-engine on template-compiled3\n"
+      assert_equal exp, subject.render('template-compiled3', @v, @l)
+
+      exp = "This is a json template for use in template source/engine tests.\n"\
+            "compile-json-engine"
+      assert_equal exp, subject.render('template-compiled4', @v, @l)
     end
 
     should "complain if the given template name matches multiple templates" do


### PR DESCRIPTION
Previously, we just blindly rejected all un-registered template exts.
This is nice b/c it means we don't incur the overhead of running
through the null engine repeatedly for the un-registered exts.

However, some engines require that source files end in their configured
ext when doing the initial render.  For example, say you have a template
named `template.erb.foo`.  The erb engine requires that its source
files end in `.erb`.  Without this change, `.foo` would get rejected
and the erb engine would be used to source render the file.  But the
engine would error b/c the file doesn't end in `.erb`.  None of this
makes sense to the user who just expects Deas to "ignore" unregistered
extensions.

With this change, the `.foo` ext in the example above is not rejected
which means the null template engine will source the file and pass
the contents off to the erb engine `compile` method (which imposes
no restrictions on the source file).  The erb engine compiles the
content and everything works as intended.

This change is the "best of both worlds": the edge-case scenario
above is handled as expected while useless unregistered exts like
`.html` in `template.html.erb` are ignored without having to run
through the null template engine compile method.

@jcredding ready for review.