### PR TITLE
updated body handling to better adhere to Rack standard

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert",           ["~> 2.16.0"])
+  gem.add_development_dependency("assert",           ["~> 2.16.1"])
   gem.add_development_dependency("assert-rack-test", ["~> 1.0.3"])
 
   gem.add_dependency("much-plugin", ["~> 0.1.0"])

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -52,11 +52,8 @@ module Deas
 
     def body(value = nil)
       if !value.nil?
-        unless value.respond_to?(:each)
-          raise ArgumentError, "this body value (class `#{value.class}`), does not "\
-                               "respond to `each`."
-        end
-        @body = value
+        # String#each is a thing in 1.8.7, so account for it here
+        @body = !value.respond_to?(:each) || value.kind_of?(String) ? [*value] : value
       end
       @body
     end
@@ -68,7 +65,7 @@ module Deas
     def halt(*args)
       self.status(args.shift)  if args.first.instance_of?(::Fixnum)
       self.headers(args.shift) if args.first.kind_of?(::Hash)
-      self.body(args.shift)    if args.first.respond_to?(:each)
+      self.body(args.shift)
       throw :halt
     end
 

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -87,7 +87,7 @@ module Deas
         super(*[
           a.first.instance_of?(::Fixnum) ? a.shift : nil,
           a.first.kind_of?(::Hash)       ? a.shift : nil,
-          a.first.respond_to?(:each)     ? a.shift : nil
+          a.shift
         ])
       end
     end

--- a/test/unit/respond_with_proxy_tests.rb
+++ b/test/unit/respond_with_proxy_tests.rb
@@ -12,7 +12,7 @@ class Deas::RespondWithProxy
     setup do
       @status  = Factory.integer
       @headers = { Factory.string => Factory.string }
-      @body    = Factory.string
+      @body    = [Factory.string]
       @proxy    = Deas::RespondWithProxy.new([@status, @headers, @body])
     end
     subject{ @proxy }

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -139,13 +139,12 @@ class Deas::Runner
     should "know and set its response body" do
       assert_nil subject.body
 
-      exp = Factory.string
+      exp = [Factory.string]
       subject.body exp
       assert_equal exp, subject.body
 
-      assert_raises(ArgumentError) do
-        subject.body Factory.integer
-      end
+      subject.body exp.first
+      assert_equal exp, subject.body
     end
 
     should "know and set its response content type header" do
@@ -463,7 +462,7 @@ class Deas::Runner
   class SourceRenderTests < RenderSetupTests
     desc "source render method"
     setup do
-      body = @body = Factory.text
+      body = @body = [Factory.text]
       @render_called_with = nil
       @source = Deas::TemplateSource.new(Factory.path)
       Assert.stub(@source, :render){ |*args| @render_called_with = args; body }

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -198,8 +198,8 @@ class Deas::Url
     should "not alter the given params" do
       params = {
         'some'    => 'thing',
-        :captures => 'captures',
-        :splat    => 'splat',
+        :captures => ['captures'],
+        :splat    => ['splat'],
         '#'       => 'anchor'
       }
       exp_params = params.dup


### PR DESCRIPTION
This is prep not only for removing Sinatra as a dependency but also
fixes some bugs in modern ruby versions (ie non-1.8.7).  In 1.8.7,
`String` responds to `each` but in modern versions it does not.  This
change now forces the body values to always respond to `each` (per
Rack spec) by forcing string bodies to be transformed to arrays. As
a side-effect, the `:each` check and custom exception was removed.

This also does a number of minor tweaks related to this change and
also to get the test suite passing in modern ruby versions:

* update to the latest assert patch - this version has a minor fix
  for modern ruby versions
* `halt` now *assumes* any arg after the status and headers checks
  is the body value - no need to perform the `:each` check as it
  is unreliable for string bodies
* the runner-related tests now expect array body values (per Rack
  spec)
* the url tests now build with arrays for both `:captures` and
  `:splat` params.  This should have been done originally as this
  is Sinatra spec, but `String#each` in 1.8.7 was hiding this.

@jcredding ready for review.  This gets Deas passing in both 1.8.7 and 2.3.1, FYI.