### PR TITLE
urls: stop taking ordered param values for the router's `url_for` method

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -53,7 +53,11 @@ module Deas
     def url_for(name, *args)
       url = self.urls[name.to_sym]
       raise ArgumentError, "no route named `#{name.to_sym.inspect}`" unless url
-      prepend_base_url(url.path_for(*args))
+      begin
+        prepend_base_url(url.path_for(*args))
+      rescue Deas::Url::NonHashParamsError => err
+        raise ArgumentError, "url param values must be passed as a Hash"
+      end
     end
 
     def default_request_type_name(value = nil)

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -405,18 +405,22 @@ class Deas::Router
     should "build a path for a url given params" do
       exp_path = subject.prepend_base_url("/info/now")
       assert_equal exp_path, subject.url_for(:get_info, :for => 'now')
-      assert_equal exp_path, subject.url_for(:get_info, 'now')
     end
 
     should "'squash' duplicate forward-slashes when building urls" do
       exp_path = subject.prepend_base_url("/info/now")
       assert_equal exp_path, subject.url_for(:get_info, :for => '/now')
-      assert_equal exp_path, subject.url_for(:get_info, '/now')
+    end
+
+    should "complain if buiding a named url with non-hash params" do
+      assert_raises ArgumentError do
+        subject.url_for(:get_info, ['now', :now, nil].sample)
+      end
     end
 
     should "complain if building a named url that hasn't been defined" do
       assert_raises ArgumentError do
-        subject.url_for(:get_all_info, 'now')
+        subject.url_for(:not_defined_url)
       end
     end
 

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -154,38 +154,6 @@ class Deas::Url
       })
     end
 
-    should "generate given ordered params only" do
-      exp_path = "/a/:thing/*/*"
-      assert_equal exp_path, subject.path_for('a')
-
-      exp_path = "/a/goose/*/*"
-      assert_equal exp_path, subject.path_for('a', 'goose')
-
-      exp_path = "/a/goose/cooked-well/*"
-      assert_equal exp_path, subject.path_for('a', 'goose', 'cooked-well')
-
-      exp_path = "/a/goose/cooked/well"
-      assert_equal exp_path, subject.path_for('a', 'goose', 'cooked', 'well')
-    end
-
-    should "generate given mixed ordered and named params" do
-      exp_path = "/:some/:thing/*/*"
-      assert_equal exp_path, subject.path_for
-
-      exp_path = "/a/goose/*/*"
-      assert_equal exp_path, subject.path_for('a', 'thing' => 'goose')
-
-      exp_path = "/goose/a/well/*"
-      assert_equal exp_path, subject.path_for('a', 'well', 'some' => 'goose')
-
-      exp_path = "/a/goose/cooked/well"
-      assert_equal exp_path, subject.path_for('ignore', 'these', 'params', {
-        'some'  => 'a',
-        :thing  => 'goose',
-        'splat' => ['cooked', 'well']
-      })
-    end
-
     should "'squash' duplicate forward-slashes" do
       exp_path = "/a/goose/cooked/well/"
       assert_equal exp_path, subject.path_for({
@@ -206,6 +174,12 @@ class Deas::Url
 
       subject.path_for(params)
       assert_equal exp_params, params
+    end
+
+    should "complain if given non-hash params" do
+      assert_raises NonHashParamsError do
+        subject.path_for([Factory.string, Factory.integer, nil].sample)
+      end
     end
 
   end


### PR DESCRIPTION
This is prep for a coming feature where the router's `url_for` method
will start complaining if "empty" param values are given.  We have
to first stop allowing ordered param values b/c when ordered values
are applied we don't know if they are being applied for a named
param or not.  This change breaks backwards compatibility.

This not only removes taking arbitrary ordered params in `url_for`,
it also makes the method complain if param values aren't given in
Hash form.  This new implementation would error in weird ways as
it expects a hash to be given.  This makes the error message more
friendly.

@jcredding ready for review.