### PR TITLE
urls: have `url_for` complain if passed empty values for named params

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -57,6 +57,8 @@ module Deas
         prepend_base_url(url.path_for(*args))
       rescue Deas::Url::NonHashParamsError => err
         raise ArgumentError, "url param values must be passed as a Hash"
+      rescue Deas::Url::EmptyNamedValueError => err
+        raise ArgumentError, err.message
       end
     end
 

--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -42,8 +42,12 @@ module Deas
     def set_named(path, params)
       params.inject(path) do |path_string, (name, value)|
         if path_string.include?(":#{name}")
+          if (v = value.to_s).empty?
+            raise EmptyNamedValueError , "an empty value (`#{value.inspect}`) " \
+                                         "was given for the `#{name}` url param"
+          end
           params.delete(name)
-          path_string.gsub(":#{name}", value.to_s)
+          path_string.gsub(":#{name}", v)
         else
           path_string
         end
@@ -60,7 +64,8 @@ module Deas
       anchor.to_s.empty? ? path : "#{path}##{anchor}"
     end
 
-    NonHashParamsError = Class.new(ArgumentError)
+    NonHashParamsError   = Class.new(ArgumentError)
+    EmptyNamedValueError = Class.new(ArgumentError)
 
   end
 

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -418,6 +418,12 @@ class Deas::Router
       end
     end
 
+    should "complain if given an empty named param value" do
+      assert_raises ArgumentError do
+        subject.url_for(:get_info, :for => [nil, ''].sample)
+      end
+    end
+
     should "complain if building a named url that hasn't been defined" do
       assert_raises ArgumentError do
         subject.url_for(:not_defined_url)

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -87,6 +87,32 @@ class Deas::Url
       })
     end
 
+    should "complain if given an empty named param value" do
+      params = {
+        'some' => 'a',
+        :thing => 'goose'
+      }
+      empty_param_name  = params.keys.sample
+      empty_param_value = [nil, ''].sample
+      params[empty_param_name] = empty_param_value
+
+      err = assert_raises EmptyNamedValueError do
+        subject.path_for(params)
+      end
+      exp = "an empty value (`#{empty_param_value.inspect}`) "\
+            "was given for the `#{empty_param_name}` url param"
+      assert_equal exp, err.message
+    end
+
+    should "not complain if given empty splat param values" do
+      exp_path = "/a/goose/"
+      assert_equal exp_path, subject.path_for({
+        'some'  => 'a',
+        :thing  => 'goose',
+        'splat' => [nil, '']
+      })
+    end
+
     should "append other (additional) params as query params" do
       exp_path = "/a/goose/cooked/well?aye=a&bee=b"
       assert_equal exp_path, subject.path_for({


### PR DESCRIPTION
Empty (ie `nil` or empty string) values aren't valid for named param
values as urls with named params are never matched on empty values
(the route just won't match at all).  Therefore it is silly to
build urls with empty values as they will never be matched.

This switches the `url_for` method on the Router to now complain
if given an empty named param value.  The goal here is to give the
developer some warning that they are building a non-sensical url
value.  Note: this doesn't apply to splat param values or any "extra"
param values (which are added to the query string).  This only
applies to formally named params in the url path.

@jcredding ready for review.