### PR TITLE
server: demeter config values that aren't directly set

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -53,9 +53,17 @@ module Deas
         self.config.views_path
       end
 
+      def views_root
+        self.config.views_root
+      end
+
       def public_path(value = nil)
         self.config.public_path = value if !value.nil?
         self.config.public_path
+      end
+
+      def public_root
+        self.config.public_root
       end
 
       def default_encoding(value = nil)
@@ -65,6 +73,10 @@ module Deas
 
       def set(name, value)
         self.config.settings[name.to_sym] = value
+      end
+
+      def settings
+        self.config.settings
       end
 
       def template_helpers(*helper_modules)
@@ -80,12 +92,24 @@ module Deas
         self.config.middlewares << args
       end
 
+      def middlewares
+        self.config.middlewares
+      end
+
       def init(&block)
         self.config.init_procs << block
       end
 
+      def init_procs
+        self.config.init_procs
+      end
+
       def error(&block)
         self.config.error_procs << block
+      end
+
+      def error_procs
+        self.config.error_procs
       end
 
       def template_source(value = nil)

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -20,10 +20,11 @@ module Deas::Server
 
     should have_imeths :new, :config
 
-    should have_imeths :env, :root, :views_path, :public_path, :default_encoding
-    should have_imeths :set, :template_helpers, :template_helper?, :use
-    should have_imeths :init, :error, :template_source, :logger, :router
-    should have_imeths :url_for
+    should have_imeths :env, :root, :views_path, :views_root
+    should have_imeths :public_path, :public_root, :default_encoding
+    should have_imeths :set, :settings, :template_helpers, :template_helper?
+    should have_imeths :use, :middlewares, :init, :init_procs, :error, :error_procs
+    should have_imeths :template_source, :logger, :router, :url_for
 
     should have_imeths :dump_errors, :method_override, :reload_templates
     should have_imeths :sessions, :show_exceptions, :static_files
@@ -111,6 +112,15 @@ module Deas::Server
       exp = Factory.boolean
       subject.verbose_logging exp
       assert_equal exp, config.verbose_logging
+    end
+
+    should "demeter its config values that aren't directly set" do
+      assert_equal subject.config.views_root,  subject.views_root
+      assert_equal subject.config.public_root, subject.public_root
+      assert_equal subject.config.settings,    subject.settings
+      assert_equal subject.config.middlewares, subject.middlewares
+      assert_equal subject.config.init_procs,  subject.init_procs
+      assert_equal subject.config.error_procs, subject.error_procs
     end
 
     should "add and query helper modules" do


### PR DESCRIPTION
This allows for reading config values via the server directly as
the server tries to abstract its config.  Since the other DSL
methods map one-to-one with their config values, they are their
own readers.  This covers the config settings that aren't driven
by a direct DSL method.

@jcredding ready for review.  This came up when testing Deas in our apps.