### PR TITLE
formalize restricted splat handling

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -45,7 +45,11 @@ module Deas
     def url(name, path, options = nil)
       if !path.kind_of?(::String)
         raise ArgumentError, "invalid path `#{path.inspect}` - "\
-                             "can only provide a url name with String paths"
+                             "named urls must be defined with String paths"
+      end
+      if path =~ /\*(?!$)/ # splat not at end of path
+        raise ArgumentError, "invalid path `#{path.inspect}` - "\
+                             "named urls can only have a single splat at the end of the path"
       end
       add_url(name.to_sym, path, options || {})
     end

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -15,7 +15,7 @@ module Deas
 
     attr_reader :handler_class, :handler
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :session, :params
+    attr_reader :request, :session, :params, :splat
 
     def initialize(handler_class, args = nil)
       @status, @headers, @body = nil, Rack::Utils::HeaderHash.new, nil
@@ -27,6 +27,7 @@ module Deas
       @request         = args[:request]
       @session         = args[:session]
       @params          = args[:params] || {}
+      @splat           = args[:splat]
 
       @handler_class = handler_class
       @handler = @handler_class.new(self)

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -28,7 +28,8 @@ module Deas
         :template_source => a.delete(:template_source),
         :request         => a.delete(:request),
         :session         => a.delete(:session),
-        :params          => NormalizedParams.new(a.delete(:params) || {}).value
+        :params          => NormalizedParams.new(a.delete(:params) || {}).value,
+        :splat           => a.delete(:splat)
       })
       a.each{|key, value| self.handler.send("#{key}=", value) }
 

--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -23,7 +23,7 @@ module Deas
 
       h = params.dup # don't alter the given params
       c = h.delete(:captures) || h.delete('captures') || []
-      s = h.delete(:splat)    || h.delete('splat')    || []
+      s = h.delete(:splat)    || h.delete('splat')    || nil
       a = h.delete(:'#')      || h.delete('#')        || nil
 
       # ignore captures when setting params
@@ -33,10 +33,8 @@ module Deas
 
     private
 
-    def set_splat(path, params)
-      params.inject(path) do |path_string, value|
-        path_string.sub(/\*+/, value.to_s)
-      end
+    def set_splat(path, value)
+      path.sub(/\*+/, value.to_s)
     end
 
     def set_named(path, params)

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -67,6 +67,7 @@ module Deas
       def request; @deas_runner.request; end
       def session; @deas_runner.session; end
       def params;  @deas_runner.params;  end
+      def splat;   @deas_runner.splat;   end
 
       # response
       def status(*args);       @deas_runner.status(*args);       end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -402,6 +402,27 @@ class Deas::Router
       end
     end
 
+    should "complain if defining a url with invalid splats" do
+      assert_raises ArgumentError do
+        subject.url(:get_info, "/something/*/other/*")
+      end
+      assert_raises ArgumentError do
+        subject.url(:get_info, "/something/*/other")
+      end
+      assert_raises ArgumentError do
+        subject.url(:get_info, "/something/*/")
+      end
+      assert_raises ArgumentError do
+        subject.url(:get_info, "/*/something")
+      end
+      assert_nothing_raised do
+        subject.url(:get_info, "/something/*")
+      end
+      assert_nothing_raised do
+        subject.url(:get_info, "/*")
+      end
+    end
+
     should "build a path for a url given params" do
       exp_path = subject.prepend_base_url("/info/now")
       assert_equal exp_path, subject.url_for(:get_info, :for => 'now')

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -45,7 +45,7 @@ class Deas::Runner
 
     should have_readers :handler_class, :handler
     should have_readers :logger, :router, :template_source
-    should have_readers :request, :session, :params
+    should have_readers :request, :session, :params, :splat
     should have_imeths :run, :to_rack
     should have_imeths :status, :headers, :body, :content_type
     should have_imeths :halt, :redirect, :send_file
@@ -75,7 +75,8 @@ class Deas::Runner
         :template_source => 'a-source',
         :request         => 'a-request',
         :session         => 'a-session',
-        :params          => {}
+        :params          => {},
+        :splat           => 'a-splat'
       }
 
       runner = @runner_class.new(@handler_class, args)
@@ -86,6 +87,7 @@ class Deas::Runner
       assert_equal args[:request],         runner.request
       assert_equal args[:session],         runner.session
       assert_equal args[:params],          runner.params
+      assert_equal args[:splat],           runner.splat
     end
 
     should "not implement its run method" do

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -35,6 +35,7 @@ class Deas::TestRunner
         :request         => @request,
         :session         => Factory.string,
         :params          => @params,
+        :splat           => Factory.path,
         :custom_value    => Factory.integer
       }
 
@@ -63,6 +64,7 @@ class Deas::TestRunner
       assert_equal @args[:request],         subject.request
       assert_equal @args[:session],         subject.session
       assert_equal @args[:params],          subject.params
+      assert_equal @args[:splat],           subject.splat
     end
 
     should "call to normalize its params" do

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -59,31 +59,31 @@ class Deas::Url
   class PathForTests < InitTests
     desc "when generating paths"
     setup do
-      @url = Deas::Url.new(:some_thing, '/:some/:thing/*/*')
-      @url_with_escape = Deas::Url.new(:some_thing, '/:some/:thing/*/*', {
+      @url = Deas::Url.new(:some_thing, '/:some/:thing/*')
+      @url_with_escape = Deas::Url.new(:some_thing, '/:some/:thing/*', {
         :escape_query_value => proc{ |v| Rack::Utils.escape(v) }
       })
     end
 
     should "generate given named params only" do
-      exp_path = "/a/goose/*/*"
+      exp_path = '/a/goose/'
       assert_equal exp_path, subject.path_for({
         'some' => 'a',
         :thing => 'goose'
       })
 
-      exp_path = "/a/goose/cooked-well/*"
+      exp_path = '/a/goose/cooked'
       assert_equal exp_path, subject.path_for({
         'some' => 'a',
         :thing => 'goose',
-        :splat => ['cooked-well']
+        :splat => 'cooked'
       })
 
-      exp_path = "/a/goose/cooked/well"
+      exp_path = '/a/goose/cooked'
       assert_equal exp_path, subject.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => ['cooked', 'well']
+        'splat' => 'cooked'
       })
     end
 
@@ -105,95 +105,86 @@ class Deas::Url
     end
 
     should "not complain if given empty splat param values" do
-      exp_path = "/a/goose/"
+      exp_path = '/a/goose/'
       assert_equal exp_path, subject.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => [nil, '']
+        'splat' => [nil, ''].sample
       })
     end
 
     should "append other (additional) params as query params" do
-      exp_path = "/a/goose/cooked/well?aye=a&bee=b"
+      exp_path = '/a/goose/cooked?aye=a&bee=b'
       assert_equal exp_path, subject.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => ['cooked', 'well'],
+        'splat' => 'cooked',
         'bee'   => 'b',
         :aye    => 'a'
       })
     end
 
     should "escape query values when built with an escape query value proc" do
-      exp_path = "/a/goose/cooked/well?aye=a?a&a"
+      exp_path = '/a/goose/cooked?aye=a?a&a'
       assert_equal exp_path, subject.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => ['cooked', 'well'],
+        'splat' => 'cooked',
         :aye    => 'a?a&a'
       })
 
-      exp_path = "/a/goose/cooked/well?aye=a%3Fa%26a"
+      exp_path = "/a/goose/cooked?aye=a%3Fa%26a"
       assert_equal exp_path, @url_with_escape.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => ['cooked', 'well'],
+        'splat' => 'cooked',
         :aye    => 'a?a&a'
       })
     end
 
     should "ignore any 'captures'" do
-      exp_path = "/a/goose/cooked/well"
+      exp_path = '/a/goose/cooked'
       assert_equal exp_path, subject.path_for({
-        'some'  => 'a',
-        :thing  => 'goose',
-        'splat' => ['cooked', 'well'],
+        'some'     => 'a',
+        :thing     => 'goose',
+        'splat'    => 'cooked',
         'captures' => 'some-captures'
       })
     end
 
     should "append anchors" do
-      exp_path = "/a/goose/cooked/well#an-anchor"
+      exp_path = '/a/goose/cooked#an-anchor'
       assert_equal exp_path, subject.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => ['cooked', 'well'],
+        'splat' => 'cooked',
         '#'     => 'an-anchor'
       })
     end
 
     should "ignore empty anchors" do
-      exp_path = "/a/goose/cooked/well"
+      exp_path = '/a/goose/cooked'
       assert_equal exp_path, subject.path_for({
         'some'  => 'a',
         :thing  => 'goose',
-        'splat' => ['cooked', 'well'],
-        '#'     => nil
-      })
-
-      exp_path = "/a/goose/cooked/well"
-      assert_equal exp_path, subject.path_for({
-        'some'  => 'a',
-        :thing  => 'goose',
-        'splat' => ['cooked', 'well'],
-        '#'     => ''
+        'splat' => 'cooked',
+        '#'     => [nil, ''].sample
       })
     end
 
     should "'squash' duplicate forward-slashes" do
-      exp_path = "/a/goose/cooked/well/"
+      exp_path = '/a/goose/cooked'
       assert_equal exp_path, subject.path_for({
         'some'  => '/a',
         :thing  => '/goose',
-        'splat' => ['///cooked', 'well//']
+        'splat' => '///cooked'
       })
     end
 
     should "not alter the given params" do
       params = {
         'some'    => 'thing',
-        :captures => ['captures'],
-        :splat    => ['splat'],
+        :splat    => 'splat',
         '#'       => 'anchor'
       }
       exp_params = params.dup

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -242,6 +242,11 @@ module Deas::ViewHandler
       assert_equal @runner.params, subject.instance_eval{ params }
     end
 
+    should "call to the runner for its splat" do
+      stub_runner_with_something_for(:splat)
+      assert_equal @runner.splat, subject.instance_eval{ splat }
+    end
+
     should "call to the runner for its status helper" do
       capture_runner_meth_args_for(:status)
       exp_args = @args


### PR DESCRIPTION
This reworks splat handling in Deas.  Originally, Deas handled
splats just as Sinatra would.  However, the plan was never to
support the full splat flexibility of Sinatra's splats in Deas'
upcoming Sinatra-free implementation.

So, back in PR 181, we removed both the splat and any "captures"
from the params Sinatra provided.  The router (being Sinatra's)
still honored splat routes but you couldn't access the splat
values in the params.  This was Step 1 in getting away from the
Sinatra splat implementation.

However, there are undeniable uses for splats and it was a little
naive to assume that no splat handling is acceptable for Deas.
This effort is an attempt to take the best parts of Sinatra's
splat handling and provide that in Deas.  This comes in the form
of two features:

* limit splats to just a single splat at the end of a url path
* captures the splat value and makes it available to view handlers
  as a `splat` helper method

The first feature above is an attempt to simplify router
requirements by only allowing splat parsing on the end of url
paths.  The second feature allows not limiting the param names
that can be used while still providing the parsed splat value.

The end result is the public API for splat handling.  As we remove
Sinatra in future efforts, these are the features we need to
continue supporting.

See #181 for reference.

@jcredding FYI.  I'm going to go ahead and merge this as I need for the project I'm doing at work.  Look over this and comment on everything and taking this approach.  If something doesn't feel right or you are uncomfortable with something in this, just comment and we'll discuss.  I'm going to push a major version update since this breaks backwards compatibility (b/c Deas will now complain if multi-splats are used).