### PR TITLE
remove Sinatra from route/request handling

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert-rack-test", ["~> 1.0.4"])
 
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
-  gem.add_dependency("rack",        ["~> 1.1"])
+  gem.add_dependency("rack",        ["~> 1.6.4"])
   gem.add_dependency("sinatra",     ["~> 1.2"])
 
 end

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -15,29 +15,30 @@ module Deas
       raise NotImplementedError
     end
 
-    def run(server_data, sinatra_call)
+    def run(server_data, request_data)
       # captures are not part of Deas' intended behavior and route matching
-      # they are a side-effects of using Sinatra.  remove them so they won't
+      # they are a side-effect of using Sinatra.  remove them so they won't
       # be relied upon in Deas apps.
-      sinatra_call.params.delete(:captures)
-      sinatra_call.params.delete('captures')
+      request_data.params.delete(:captures)
+      request_data.params.delete('captures')
 
       # splat will be provided to the handlers via a special `splat` helper.
       # only single splat values are allowed (see router `url` method).  this
       # takes the last splat value from Sinatra and provides it standalone to
       # the runner.
-      splat_sym_param    = sinatra_call.params.delete(:splat)
-      splat_string_param = sinatra_call.params.delete('splat')
+      # TODO: make runner parse from route path (don't rely on Sinatra)
+      splat_sym_param    = request_data.params.delete(:splat)
+      splat_string_param = request_data.params.delete('splat')
       splat_value        = (splat_sym_param || splat_string_param || []).last
 
       runner = DeasRunner.new(self.handler_class, {
         :logger          => server_data.logger,
         :router          => server_data.router,
         :template_source => server_data.template_source,
-        :request         => sinatra_call.request,
-        :session         => sinatra_call.session,
-        :params          => sinatra_call.params,
-        :splat           => splat_value
+        :request         => request_data.request,
+        :params          => request_data.params,
+        :route_path      => request_data.route_path,
+        :splat           => splat_value # TODO: make handlers parse from route path
       })
 
       runner.request.env.tap do |env|
@@ -48,6 +49,8 @@ module Deas
         env['deas.handler_class'] = self.handler_class
         env['deas.handler']       = runner.handler
         env['deas.params']        = runner.params
+        # TODO: add runner.splat as deas.splat env value
+        env['deas.route_path']    = runner.route_path
 
         # this handles the verbose logging (it is a no-op if summary logging)
         env['deas.logging'].call "  Handler: #{self.handler_class.name}"

--- a/lib/deas/request_data.rb
+++ b/lib/deas/request_data.rb
@@ -1,0 +1,22 @@
+module Deas
+
+  class RequestData
+
+    # The rack app uses this to "compile" the request-related data. The goal
+    # here is to wrap up these (and any future) request objects into a struct
+    # object to make them available to the runner/handler.  This is also to
+    # decouple the rack app from the handlers (we can use any rack app as long
+    # as they provide this data).
+
+    attr_reader :route_path, :request, :response, :params
+
+    def initialize(args)
+      @route_path = args[:route_path]
+      @request    = args[:request]
+      @response   = args[:response]
+      @params     = args[:params]
+    end
+
+  end
+
+end

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -16,15 +16,13 @@ module Deas
       end
     end
 
-    def run(server_data, sinatra_call)
-      type = server_data.router.request_type_name(sinatra_call.request)
-      proxy = begin
-        @handler_proxies[type]
+    def run(server_data, request_data)
+      request_type_name = server_data.router.request_type_name(request_data.request)
+      begin
+        @handler_proxies[request_type_name].run(server_data, request_data)
       rescue HandlerProxyNotFound
-        sinatra_call.halt(404)
+        [404, Rack::Utils::HeaderHash.new, []]
       end
-      # TODO: eventually stop sending sinatra call (part of phasing out Sinatra)
-      proxy.run(server_data, sinatra_call)
     end
 
   end

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -15,19 +15,19 @@ module Deas
 
     attr_reader :handler_class, :handler
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :session, :params, :splat
+    attr_reader :request, :params, :route_path, :splat
 
     def initialize(handler_class, args = nil)
       @status, @headers, @body = nil, Rack::Utils::HeaderHash.new, nil
 
       args ||= {}
-      @logger          = args[:logger] || Deas::NullLogger.new
-      @router          = args[:router] || Deas::Router.new
+      @logger          = args[:logger]          || Deas::NullLogger.new
+      @router          = args[:router]          || Deas::Router.new
       @template_source = args[:template_source] || Deas::NullTemplateSource.new
       @request         = args[:request]
-      @session         = args[:session]
-      @params          = args[:params] || {}
-      @splat           = args[:splat]
+      @params          = args[:params]          || {}
+      @route_path      = args[:route_path].to_s
+      @splat           = args[:splat] # TODO: lazily parse from route path
 
       @handler_class = handler_class
       @handler = @handler_class.new(self)

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -149,11 +149,6 @@ module Deas
         self.config.reload_templates
       end
 
-      def sessions(value = nil)
-        self.config.sessions = value if !value.nil?
-        self.config.sessions
-      end
-
       def show_exceptions(value = nil)
         self.config.show_exceptions = value if !value.nil?
         self.config.show_exceptions
@@ -183,7 +178,7 @@ module Deas
       attr_accessor :init_procs, :error_procs, :template_source, :logger, :router
 
       attr_accessor :dump_errors, :method_override, :reload_templates
-      attr_accessor :sessions, :show_exceptions, :static_files
+      attr_accessor :show_exceptions, :static_files
       attr_accessor :verbose_logging
 
       def initialize
@@ -204,7 +199,6 @@ module Deas
         @dump_errors      = false
         @method_override  = true
         @reload_templates = false
-        @sessions         = false
         @show_exceptions  = false
         @static_files     = true
         @verbose_logging  = true

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -27,8 +27,8 @@ module Deas
         :router          => a.delete(:router),
         :template_source => a.delete(:template_source),
         :request         => a.delete(:request),
-        :session         => a.delete(:session),
         :params          => NormalizedParams.new(a.delete(:params) || {}).value,
+        :route_path      => a.delete(:route_path),
         :splat           => a.delete(:splat)
       })
       a.each{|key, value| self.handler.send("#{key}=", value) }

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -65,7 +65,6 @@ module Deas
 
       # request
       def request; @deas_runner.request; end
-      def session; @deas_runner.session; end
       def params;  @deas_runner.params;  end
       def splat;   @deas_runner.splat;   end
 
@@ -131,7 +130,6 @@ module Deas
       def test_runner(handler_class, args = nil)
         args ||= {}
         args[:request] ||= Rack::Request.new({})
-        args[:session] ||= args[:request].session
         TestRunner.new(handler_class, args)
       end
 

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,9 +1,11 @@
 require 'assert/factory'
 require 'deas/logger'
+require 'deas/request_data'
 require 'deas/router'
 require 'deas/server_data'
 require 'deas/template_source'
 require 'test/support/fake_request'
+require 'test/support/fake_response'
 require 'test/support/fake_sinatra_call'
 
 module Factory
@@ -28,6 +30,20 @@ module Factory
 
   def self.request(args = nil)
     FakeRequest.new(args)
+  end
+
+  def self.response(args = nil)
+    FakeResponse.new(args)
+  end
+
+  def self.request_data(args = nil)
+    args ||= {}
+    Deas::RequestData.new({
+      :route_path => args[:route_path] || Factory.string,
+      :request    => args[:request]    || Factory.request,
+      :response   => args[:response]   || Factory.response,
+      :params     => args[:params]     || { Factory.string => Factory.string }
+    })
   end
 
   def self.sinatra_call(settings = nil)

--- a/test/support/fake_request.rb
+++ b/test/support/fake_request.rb
@@ -1,6 +1,7 @@
 require 'ostruct'
 
 class FakeRequest < Struct.new(:http_method, :path, :params, :session, :env)
+
   alias :request_method :http_method
 
   attr_reader :logging_msgs

--- a/test/support/fake_response.rb
+++ b/test/support/fake_response.rb
@@ -1,0 +1,12 @@
+class FakeResponse < Struct.new(:status, :headers, :body)
+
+  def initialize(args = nil)
+    args ||= {}
+    super(*[
+      args[:status]  || Factory.integer,
+      args[:headers] || Rack::Utils::HeaderHash.new,
+      args[:body]    || [Factory.text]
+    ])
+  end
+
+end

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -1,4 +1,5 @@
 require 'test/support/fake_request'
+require 'test/support/fake_response'
 
 class FakeSinatraCall
 
@@ -67,15 +68,4 @@ class FakeSinatraCall
   end
   SendFileArgs = Struct.new(:file_path, :options, :block_call_result)
 
-end
-
-class FakeResponse < Struct.new(:status, :headers, :body)
-  def initialize(args = nil)
-    args ||= {}
-    super(*[
-      args[:status]  || Factory.integer,
-      args[:headers] || {},
-      args[:body]    || [Factory.text]
-    ])
-  end
 end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -46,6 +46,10 @@ class DeasTestServer
     redirect('/:prefix/redirect'){ "/#{params['prefix']}/somewhere" }
   end
 
+  use Rack::Session::Cookie, :key          => 'my.session',
+                             :expire_after => Factory.integer,
+                             :secret       => Factory.string
+
 end
 
 class DeasDevServer
@@ -171,7 +175,7 @@ class SetSessionHandler
   include Deas::ViewHandler
 
   def run!
-    session[:secret] = 'session_secret'
+    request.session[:secret] = 'session_secret'
     redirect '/session'
   end
 
@@ -181,7 +185,7 @@ class UseSessionHandler
   include Deas::ViewHandler
 
   def run!
-    body session[:secret]
+    body request.session[:secret]
   end
 
 end
@@ -194,7 +198,6 @@ class HandlerTestsHandler
     set_data('logger_class_name'){ logger.class.name }
     set_data('request_method'){ request.request_method.to_s }
     set_data('params_a_param'){ params['a-param'] }
-    set_data('session_inspect'){ session.inspect }
   end
 
   def set_data(a, &block)

--- a/test/system/deas_tests.rb
+++ b/test/system/deas_tests.rb
@@ -111,14 +111,7 @@ module Deas
   end
 
   class SessionTests < RackTests
-    desc "with sessions enabled"
-    setup do
-      @orig_sessions = @app.settings.sessions
-      @app.set :sessions, true
-    end
-    teardown do
-      @app.set :sessions, @orig_sessions
-    end
+    desc "using sessions"
 
     should "return a 200 response and the session value" do
       post '/session'
@@ -141,8 +134,7 @@ module Deas
       exp = {
         'logger_class_name' => 'Logger',
         'request_method'    => 'GET',
-        'params_a_param'    => 'something',
-        'session_inspect'   => '{}'
+        'params_a_param'    => 'something'
       }
       assert_equal exp.inspect, @data_inspect
     end

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -38,23 +38,22 @@ class Deas::HandlerProxy
 
       Assert.stub(@proxy, :handler_class){ EmptyViewHandler }
 
-      @server_data        = Factory.server_data
-      @fake_sinatra_call  = Factory.sinatra_call
       @splat_sym_param    = Factory.string
       @splat_string_param = Factory.string
-      @fake_sinatra_call.params = {
+
+      @server_data  = Factory.server_data
+      @request_data = Factory.request_data(:params => {
         :splat     => [@splat_sym_param],
         'splat'    => [@splat_string_param],
         :captures  => [Factory.string],
         'captures' => [Factory.string]
-      }
-
-      @proxy.run(@server_data, @fake_sinatra_call)
+      })
+      @proxy.run(@server_data, @request_data)
     end
 
     should "remove any 'splat' or 'captures' params added by Sinatra's router" do
       [:splat, 'splat', :captures, 'captures'].each do |param_name|
-        assert_nil @fake_sinatra_call.params[param_name]
+        assert_nil @request_data.params[param_name]
       end
     end
 
@@ -65,9 +64,9 @@ class Deas::HandlerProxy
         :logger          => @server_data.logger,
         :router          => @server_data.router,
         :template_source => @server_data.template_source,
-        :request         => @fake_sinatra_call.request,
-        :session         => @fake_sinatra_call.session,
-        :params          => @fake_sinatra_call.params,
+        :request         => @request_data.request,
+        :params          => @request_data.params,
+        :route_path      => @request_data.route_path,
         :splat           => @splat_sym_param
       }
       assert_equal exp_args, @runner_spy.args
@@ -78,22 +77,25 @@ class Deas::HandlerProxy
     should "prefer splat sym params over splat string params" do
       assert_equal @splat_sym_param, @runner_spy.args[:splat]
 
-      @fake_sinatra_call.params['splat'] = [@splat_string_param]
+      @request_data.params['splat'] = [@splat_string_param]
       proxy = Deas::HandlerProxy.new('EmptyViewHandler')
       Assert.stub(proxy, :handler_class){ EmptyViewHandler }
-      proxy.run(@server_data, @fake_sinatra_call)
+      proxy.run(@server_data, @request_data)
       assert_equal @splat_string_param, @runner_spy.args[:splat]
     end
 
     should "add data to the request env to make it available to Rack" do
       exp = subject.handler_class
-      assert_equal exp, @fake_sinatra_call.request.env['deas.handler_class']
+      assert_equal exp, @request_data.request.env['deas.handler_class']
 
       exp = @runner_spy.handler
-      assert_equal exp, @fake_sinatra_call.request.env['deas.handler']
+      assert_equal exp, @request_data.request.env['deas.handler']
 
       exp = @runner_spy.params
-      assert_equal exp, @fake_sinatra_call.request.env['deas.params']
+      assert_equal exp, @request_data.request.env['deas.params']
+
+      exp = @runner_spy.route_path
+      assert_equal exp, @request_data.request.env['deas.route_path']
     end
 
     should "log the handler class name and the params" do
@@ -102,7 +104,7 @@ class Deas::HandlerProxy
         "  Params:  #{@runner_spy.params.inspect}",
         "  Splat:   #{@runner_spy.splat.inspect}"
       ]
-      assert_equal exp_msgs, @fake_sinatra_call.request.logging_msgs
+      assert_equal exp_msgs, @request_data.request.logging_msgs
     end
 
   end
@@ -112,7 +114,7 @@ class Deas::HandlerProxy
     attr_reader :run_called
     attr_reader :handler_class, :handler, :args
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :session, :params, :splat
+    attr_reader :request, :params, :route_path, :splat
 
     def initialize
       @run_called = false
@@ -127,8 +129,8 @@ class Deas::HandlerProxy
       @router          = args[:router]
       @template_source = args[:template_source]
       @request         = args[:request]
-      @session         = args[:session]
       @params          = args[:params]
+      @route_path      = args[:route_path]
       @splat           = args[:splat]
     end
 

--- a/test/unit/request_data_tests.rb
+++ b/test/unit/request_data_tests.rb
@@ -1,0 +1,43 @@
+require 'assert'
+require 'deas/request_data'
+
+class Deas::RequestData
+
+  class UnitTests < Assert::Context
+    desc "Deas::RequestData"
+    setup do
+      @route_path = Factory.string
+      @request    = Factory.string
+      @response   = Factory.string
+      @params     = Factory.string
+
+      @server_data = Deas::RequestData.new({
+        :route_path => @route_path,
+        :request    => @request,
+        :response   => @response,
+        :params     => @params
+      })
+    end
+    subject{ @server_data }
+
+    should have_readers :route_path, :request, :response, :params
+
+    should "know its attributes" do
+      assert_equal @route_path, subject.route_path
+      assert_equal @request,    subject.request
+      assert_equal @response,   subject.response
+      assert_equal @params,     subject.params
+    end
+
+    should "default its attributes when they aren't provided" do
+      request_data = Deas::RequestData.new({})
+
+      assert_nil request_data.route_path
+      assert_nil request_data.request
+      assert_nil request_data.response
+      assert_nil request_data.params
+    end
+
+  end
+
+end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -10,8 +10,8 @@ class Deas::Route
   class UnitTests < Assert::Context
     desc "Deas::Route"
     setup do
-      @req_type_name = Factory.string
-      @proxy = HandlerProxySpy.new
+      @req_type_name   = Factory.string
+      @proxy           = HandlerProxySpy.new
       @handler_proxies = Hash.new{ |h, k| raise(Deas::HandlerProxyNotFound) }.tap do |h|
         h[@req_type_name] = @proxy
       end
@@ -40,46 +40,46 @@ class Deas::Route
   class RunTests < UnitTests
     desc "when run"
     setup do
-      @server_data       = Factory.server_data
-      @fake_sinatra_call = Factory.sinatra_call
+      @server_data  = Factory.server_data
+      @request_data = Factory.request_data
     end
 
     should "run the proxy for the given request type name" do
       Assert.stub(@server_data.router, :request_type_name).with(
-        @fake_sinatra_call.request
+        @request_data.request
       ){ @req_type_name }
 
-      @route.run(@server_data, @fake_sinatra_call)
+      @route.run(@server_data, @request_data)
       assert_true @proxy.run_called
+      assert_equal @server_data, @proxy.server_data
+      assert_equal @request_data, @proxy.request_data
     end
 
     should "halt 404 if it can't find a proxy for the given request type name" do
-      halt_value = catch(:halt) do
-        @route.run(@server_data, @fake_sinatra_call)
-      end
-      assert_equal [404], halt_value
+      exp = [404, Rack::Utils::HeaderHash.new, []]
+      assert_equal exp, @route.run(@server_data, @request_data)
     end
 
   end
 
   class HandlerProxySpy
 
-    attr_reader :validate_called, :run_called, :server_data, :sinatra_call
+    attr_reader :validate_called, :run_called, :server_data, :request_data
 
     def initialize
       @run_called      = false
       @validate_called = false
       @server_data     = nil
-      @sinatra_call    = nil
+      @request_data    = nil
     end
 
     def validate!
       @validate_called = true
     end
 
-    def run(server_data, sinatra_call)
-      @server_data  = sinatra_call
-      @sinatra_call = sinatra_call
+    def run(server_data, request_data)
+      @server_data  = server_data
+      @request_data = request_data
       @run_called   = true
     end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -45,7 +45,7 @@ class Deas::Runner
 
     should have_readers :handler_class, :handler
     should have_readers :logger, :router, :template_source
-    should have_readers :request, :session, :params, :splat
+    should have_readers :request, :params, :route_path, :splat
     should have_imeths :run, :to_rack
     should have_imeths :status, :headers, :body, :content_type
     should have_imeths :halt, :redirect, :send_file
@@ -63,20 +63,22 @@ class Deas::Runner
       assert_kind_of Deas::NullTemplateSource, runner.template_source
 
       assert_nil runner.request
-      assert_nil runner.session
 
-      assert_equal({}, runner.params)
+      assert_equal Hash.new, runner.params
+      assert_equal '',       runner.route_path
+
+      assert_nil runner.splat
     end
 
     should "know its attrs" do
       args = {
-        :logger          => 'a-logger',
-        :router          => 'a-router',
-        :template_source => 'a-source',
-        :request         => 'a-request',
-        :session         => 'a-session',
-        :params          => {},
-        :splat           => 'a-splat'
+        :logger          => Factory.string,
+        :router          => Factory.string,
+        :template_source => Factory.string,
+        :request         => Factory.request,
+        :params          => { Factory.string => Factory.string },
+        :route_path      => Factory.string,
+        :splat           => Factory.string
       }
 
       runner = @runner_class.new(@handler_class, args)
@@ -85,8 +87,8 @@ class Deas::Runner
       assert_equal args[:router],          runner.router
       assert_equal args[:template_source], runner.template_source
       assert_equal args[:request],         runner.request
-      assert_equal args[:session],         runner.session
       assert_equal args[:params],          runner.params
+      assert_equal args[:route_path],      runner.route_path
       assert_equal args[:splat],           runner.splat
     end
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -27,7 +27,7 @@ module Deas::Server
     should have_imeths :template_source, :logger, :router, :url_for
 
     should have_imeths :dump_errors, :method_override, :reload_templates
-    should have_imeths :sessions, :show_exceptions, :static_files
+    should have_imeths :show_exceptions, :static_files
     should have_imeths :verbose_logging
 
     should "use much-plugin" do
@@ -96,10 +96,6 @@ module Deas::Server
       exp = Factory.boolean
       subject.reload_templates exp
       assert_equal exp, config.reload_templates
-
-      exp = Factory.boolean
-      subject.sessions exp
-      assert_equal exp, config.sessions
 
       exp = Factory.boolean
       subject.show_exceptions exp
@@ -173,7 +169,7 @@ module Deas::Server
     should have_accessors :init_procs, :error_procs, :template_source, :logger, :router
 
     should have_accessors :dump_errors, :method_override, :reload_templates
-    should have_accessors :sessions, :show_exceptions, :static_files
+    should have_accessors :show_exceptions, :static_files
     should have_accessors :verbose_logging
 
     should have_imeths :views_root, :public_root, :urls, :routes
@@ -217,7 +213,6 @@ module Deas::Server
       assert_equal false, subject.dump_errors
       assert_equal true,  subject.method_override
       assert_equal false, subject.reload_templates
-      assert_equal false, subject.sessions
       assert_equal false, subject.show_exceptions
       assert_equal true,  subject.static_files
       assert_equal true,  subject.verbose_logging

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -45,12 +45,12 @@ module Deas::SinatraApp
       assert_equal @config.dump_errors,      s.dump_errors
       assert_equal @config.method_override,  s.method_override
       assert_equal @config.reload_templates, s.reload_templates
-      assert_equal @config.sessions,         s.sessions
       assert_equal @config.static_files,     s.static
 
-      assert_equal false, s.raise_errors
-      assert_equal false, s.show_exceptions
-      assert_equal false, s.logging
+      assert_false s.sessions
+      assert_false s.raise_errors
+      assert_false s.show_exceptions
+      assert_false s.logging
 
       exp = Deas::ServerData.new({
         :error_procs     => @config.error_procs,
@@ -74,6 +74,8 @@ module Deas::SinatraApp
 
       assert_not_nil sinatra_routes.detect{ |r| r[0].match(router_route.path) }
     end
+
+    # System tests ensure that routes get applied to the sinatra app correctly.
 
   end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -33,8 +33,8 @@ class Deas::TestRunner
         :router          => Factory.string,
         :template_source => Factory.string,
         :request         => @request,
-        :session         => Factory.string,
         :params          => @params,
+        :route_path      => Factory.string,
         :splat           => Factory.path,
         :custom_value    => Factory.integer
       }
@@ -62,8 +62,8 @@ class Deas::TestRunner
       assert_equal @args[:router],          subject.router
       assert_equal @args[:template_source], subject.template_source
       assert_equal @args[:request],         subject.request
-      assert_equal @args[:session],         subject.session
       assert_equal @args[:params],          subject.params
+      assert_equal @args[:route_path],      subject.route_path
       assert_equal @args[:splat],           subject.splat
     end
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -232,11 +232,6 @@ module Deas::ViewHandler
       assert_equal @runner.request, subject.instance_eval{ request }
     end
 
-    should "call to the runner for its session" do
-      stub_runner_with_something_for(:session)
-      assert_equal @runner.session, subject.instance_eval{ session }
-    end
-
     should "call to the runner for its params" do
       stub_runner_with_something_for(:params)
       assert_equal @runner.params, subject.instance_eval{ params }
@@ -391,8 +386,7 @@ module Deas::ViewHandler
       runner  = subject.test_runner(@handler_class)
 
       assert_kind_of ::Deas::TestRunner, runner
-      assert_kind_of Rack::Request,  runner.request
-      assert_equal runner.request.session, runner.session
+      assert_kind_of ::Rack::Request,    runner.request
     end
 
     should "return an initialized handler instance" do


### PR DESCRIPTION
This is prep for removing Sinatra as a dependency in the future.
This not only removes Sinatra from the request handling but also
decouples the rack app implementation from request handling by
introducing the concept of "request data" and passing that
between the rack endpoint and the runner/handler.

So, this creates a RequestData struct.  Right now the request data
consists of the request, response, params and route path.  The
route path is being added to not only have for logging/error usage
but to also use in a coming effort to take over splat handling.
I chose to remove manual session handling as you can access the
session info on the request and I don't want deas to support
manual session handling going forward.

Note: this removes `sessions` handling form the server api and
its config.  We seemed to not be explicitly testing this though
so no tests had to be changed.

Note: I chose to keep the session related system tests to prove
that removing session support from Deas doesn't mean you can't
use vanilla rack sessions in Deas apps.

Note: this updates to a more restrictive rack dependency.  I want
to limit this going forward to eliminate edge-cases but also b/c
this is the oldest version that works with Rack::App (which I
plan to replace Sinatra with in the future).

@jcredding note this is a duplicate of #218 but against a feature branch.  FYI.