### PR TITLE
take over error handling fully from Sinatra

### DIFF
--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -14,7 +14,7 @@ class DeasTestServer
     case exception
     when Deas::NotFound
       [404, "Couldn't be found"]
-    when Exception
+    when *Deas::SinatraApp::STANDARD_ERROR_CLASSES
       [500, "Oops, something went wrong"]
     end
   end
@@ -157,7 +157,7 @@ class ErrorHandler
   include Deas::ViewHandler
 
   def run!
-    raise 'test'
+    raise Deas::SinatraApp::STANDARD_ERROR_CLASSES.sample, 'sinatra app standard error'
   end
 
 end

--- a/test/system/deas_tests.rb
+++ b/test/system/deas_tests.rb
@@ -160,7 +160,7 @@ module Deas
 
       assert_equal 500, last_response.status
       assert_equal "text/plain", last_response.headers['Content-Type']
-      assert_match "RuntimeError: test", last_response.body
+      assert_match "sinatra app standard error", last_response.body
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -14,6 +14,23 @@ module Deas::SinatraApp
 
   class UnitTests < Assert::Context
     desc "Deas::SinatraApp"
+    subject{ Deas::SinatraApp }
+
+    should have_imeths :new
+
+    should "know its default error response status" do
+      assert_equal 500, subject::DEFAULT_ERROR_RESPONSE_STATUS
+    end
+
+    should "know its standard error classes" do
+      exp = [StandardError, LoadError, NotImplementedError, Timeout::Error]
+      assert_equal exp, subject::STANDARD_ERROR_CLASSES
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
     setup do
       @router = Deas::Router.new
       @router.get('/something', 'EmptyViewHandler')


### PR DESCRIPTION
This is prep for removing Sinatra in a future effort.  This
switches to rescuing StandardError on route runs instead of
configuring a sinatra error handler.  This takes Sinatra out of
the error handling logic.  Sinatra had already been removed from
the error handler class itself so this change is fairly trivial.

There is one small side-effect of this change: only a set of
"standard error" exceptions are rescued (which is different than
Sinatra's default of all exceptions).  The intent is that any
errors you would handle should already be StandardErrors as non
standard errors include system interrupts etc which are dangerous
to rescue as this may alter system behavior.  We include a few
common non-standard errors that can be expected to occur.  The
system tests have been updated to account for this; otherwise
they remain unchanged and valid.

@jcredding ready for review. 