### PR TITLE
add the route path to the error handler context data

### DIFF
--- a/lib/deas/error_handler.rb
+++ b/lib/deas/error_handler.rb
@@ -35,7 +35,8 @@ module Deas
     class Context
 
       attr_reader :server_data
-      attr_reader :request, :response, :handler_class, :handler, :params
+      attr_reader :request, :response, :handler_class, :handler
+      attr_reader :params, :route_path
 
       def initialize(args)
         @server_data   = args[:server_data]
@@ -44,6 +45,7 @@ module Deas
         @handler_class = args[:handler_class]
         @handler       = args[:handler]
         @params        = args[:params]
+        @route_path    = args[:route_path]
       end
 
       def ==(other)
@@ -53,7 +55,8 @@ module Deas
           self.request       == other.request &&
           self.response      == other.response &&
           self.handler       == other.handler &&
-          self.params        == other.params
+          self.params        == other.params &&
+          self.route_path    == other.route_path
         else
           super
         end

--- a/lib/deas/request_data.rb
+++ b/lib/deas/request_data.rb
@@ -8,13 +8,13 @@ module Deas
     # decouple the rack app from the handlers (we can use any rack app as long
     # as they provide this data).
 
-    attr_reader :route_path, :request, :response, :params
+    attr_reader :request, :response, :params, :route_path
 
     def initialize(args)
-      @route_path = args[:route_path]
       @request    = args[:request]
       @response   = args[:response]
       @params     = args[:params]
+      @route_path = args[:route_path]
     end
 
   end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -76,10 +76,10 @@ module Deas
               route.run(
                 server_data,
                 RequestData.new({
-                  :route_path => route.path,
                   :request    => request,
                   :response   => response,
-                  :params     => params
+                  :params     => params,
+                  :route_path => route.path
                 })
               )
             rescue *STANDARD_ERROR_CLASSES => err
@@ -92,6 +92,7 @@ module Deas
                 :handler_class => request.env['deas.handler_class'],
                 :handler       => request.env['deas.handler'],
                 :params        => request.env['deas.params'],
+                :route_path    => request.env['deas.route_path']
               })
             end
           end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -39,10 +39,10 @@ module Factory
   def self.request_data(args = nil)
     args ||= {}
     Deas::RequestData.new({
-      :route_path => args[:route_path] || Factory.string,
       :request    => args[:request]    || Factory.request,
       :response   => args[:response]   || Factory.response,
-      :params     => args[:params]     || { Factory.string => Factory.string }
+      :params     => args[:params]     || { Factory.string => Factory.string },
+      :route_path => args[:route_path] || Factory.string
     })
   end
 

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -15,6 +15,7 @@ class Deas::ErrorHandler
       @handler_class    = Factory.string
       @handler          = Factory.string
       @params           = Factory.string
+      @route_path       = Factory.string
 
       @context_hash = {
         :server_data   => @server_data,
@@ -23,6 +24,7 @@ class Deas::ErrorHandler
         :handler_class => @handler_class,
         :handler       => @handler,
         :params        => @params,
+        :route_path    => @route_path
       }
 
       @handler_class = Deas::ErrorHandler
@@ -113,7 +115,8 @@ class Deas::ErrorHandler
     subject{ @context }
 
     should have_readers :server_data
-    should have_readers :request, :response, :handler_class, :handler, :params
+    should have_readers :request, :response, :handler_class, :handler
+    should have_readers :params, :route_path
 
     should "know its attributes" do
       assert_equal @context_hash[:server_data],   subject.server_data
@@ -122,6 +125,7 @@ class Deas::ErrorHandler
       assert_equal @context_hash[:handler_class], subject.handler_class
       assert_equal @context_hash[:handler],       subject.handler
       assert_equal @context_hash[:params],        subject.params
+      assert_equal @context_hash[:route_path],    subject.route_path
     end
 
     should "know if it equals another context" do

--- a/test/unit/request_data_tests.rb
+++ b/test/unit/request_data_tests.rb
@@ -6,36 +6,36 @@ class Deas::RequestData
   class UnitTests < Assert::Context
     desc "Deas::RequestData"
     setup do
-      @route_path = Factory.string
       @request    = Factory.string
       @response   = Factory.string
       @params     = Factory.string
+      @route_path = Factory.string
 
       @server_data = Deas::RequestData.new({
-        :route_path => @route_path,
         :request    => @request,
         :response   => @response,
-        :params     => @params
+        :params     => @params,
+        :route_path => @route_path
       })
     end
     subject{ @server_data }
 
-    should have_readers :route_path, :request, :response, :params
+    should have_readers :request, :response, :params, :route_path
 
     should "know its attributes" do
-      assert_equal @route_path, subject.route_path
       assert_equal @request,    subject.request
       assert_equal @response,   subject.response
       assert_equal @params,     subject.params
+      assert_equal @route_path, subject.route_path
     end
 
     should "default its attributes when they aren't provided" do
       request_data = Deas::RequestData.new({})
 
-      assert_nil request_data.route_path
       assert_nil request_data.request
       assert_nil request_data.response
       assert_nil request_data.params
+      assert_nil request_data.route_path
     end
 
   end


### PR DESCRIPTION
Since we are now passing this data to the runner/handler
(see PR 219), it would be nice to also make it available in the
error handler context data.  Some applications include getting
extra context on where params are coming from and knowing which
route caused the error (in the case where multiple route paths
route to the same handler).

Note: I reorder the route path in the request data and where it
is used to keep things more consistently ordered.

See #219 for reference.

@jcredding ready for review.