### PR TITLE
update router route error checking to be more thorough

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -43,15 +43,15 @@ module Deas
     end
 
     def url(name, path, options = nil)
+      if !name.kind_of?(::Symbol)
+        raise ArgumentError, "invalid name `#{name.inspect}` - "\
+                             "named urls must be defined with Symbol names"
+      end
       if !path.kind_of?(::String)
         raise ArgumentError, "invalid path `#{path.inspect}` - "\
                              "named urls must be defined with String paths"
       end
-      if path =~ /\*(?!$)/ # splat not at end of path
-        raise ArgumentError, "invalid path `#{path.inspect}` - "\
-                             "named urls can only have a single splat at the end of the path"
-      end
-      add_url(name.to_sym, path, options || {})
+      add_url(name, path, options || {})
     end
 
     def url_for(name, *args)
@@ -179,6 +179,10 @@ module Deas
     end
 
     def add_route(http_method, path, proxies)
+      if path =~ /\*(?!$)/ # splat not at end of path
+        raise ArgumentError, "invalid path `#{path.inspect}` - "\
+                             "routes can only have a single splat at the end of their path"
+      end
       proxies = HandlerProxies.new(proxies, self.default_request_type_name)
       require 'deas/route'
       Deas::Route.new(http_method, path, proxies).tap{ |r| self.routes.push(r) }


### PR DESCRIPTION
Back in PR 217, Deas was updated to restrict splats in route path
definitions to only allow trailing splats.  In that effort the
check was applied to named urls that were defined but if the route
didn't use a named url, the check was missed.  This moves that
error check to where the routes are added.  This way, no matter
where the path comes from, the check will be performed.

This also adds a new check to ensure named urls are defined with
symbols.  Before, any given name would be turned into a symbol
so if you defined a named route with a string you'd have to know
to refer to it with a symbol.  This removes that magic knowledge
requirement and just warns you if you aren't using symbols when
defining named urls so there won't be any confusion when you go
to use that named url.

See #217 for reference.

@jcredding ready for review.