### PR TITLE
add splat value to middlewares and error handler context info

### DIFF
--- a/lib/deas/error_handler.rb
+++ b/lib/deas/error_handler.rb
@@ -36,26 +36,28 @@ module Deas
 
       attr_reader :server_data
       attr_reader :request, :response, :handler_class, :handler
-      attr_reader :params, :route_path
+      attr_reader :params, :splat, :route_path
 
       def initialize(args)
-        @server_data   = args[:server_data]
-        @request       = args[:request]
-        @response      = args[:response]
-        @handler_class = args[:handler_class]
-        @handler       = args[:handler]
-        @params        = args[:params]
-        @route_path    = args[:route_path]
+        @server_data   = args.fetch(:server_data)
+        @request       = args.fetch(:request)
+        @response      = args.fetch(:response)
+        @handler_class = args.fetch(:handler_class)
+        @handler       = args.fetch(:handler)
+        @params        = args.fetch(:params)
+        @splat         = args.fetch(:splat)
+        @route_path    = args.fetch(:route_path)
       end
 
       def ==(other)
         if other.kind_of?(self.class)
-          self.server_data   == other.server_data &&
+          self.server_data   == other.server_data   &&
           self.handler_class == other.handler_class &&
-          self.request       == other.request &&
-          self.response      == other.response &&
-          self.handler       == other.handler &&
-          self.params        == other.params &&
+          self.request       == other.request       &&
+          self.response      == other.response      &&
+          self.handler       == other.handler       &&
+          self.params        == other.params        &&
+          self.splat         == other.splat         &&
           self.route_path    == other.route_path
         else
           super

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -49,13 +49,14 @@ module Deas
         env['deas.handler_class'] = self.handler_class
         env['deas.handler']       = runner.handler
         env['deas.params']        = runner.params
-        # TODO: add runner.splat as deas.splat env value
+        env['deas.splat']         = runner.splat
         env['deas.route_path']    = runner.route_path
 
         # this handles the verbose logging (it is a no-op if summary logging)
         env['deas.logging'].call "  Handler: #{self.handler_class.name}"
         env['deas.logging'].call "  Params:  #{runner.params.inspect}"
         env['deas.logging'].call "  Splat:   #{runner.splat.inspect}" if !runner.splat.nil?
+        env['deas.logging'].call "  Route:   #{runner.route_path.inspect}"
       end
 
       runner.run

--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -102,6 +102,7 @@ module Deas
         'method'  => request.request_method,
         'path'    => request.path,
         'params'  => env['deas.params'],
+        'splat'   => env['deas.splat'],
         'time'    => env['deas.time_taken'],
         'status'  => status
       }
@@ -119,7 +120,7 @@ module Deas
 
   module SummaryLine
     def self.keys
-      %w{time status method path handler params redir}
+      %w{time status method path handler params splat redir}
     end
     def self.new(line_attrs)
       self.keys.select{ |k| line_attrs.key?(k) }.

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -92,6 +92,7 @@ module Deas
                 :handler_class => request.env['deas.handler_class'],
                 :handler       => request.env['deas.handler'],
                 :params        => request.env['deas.params'],
+                :splat         => request.env['deas.splat'],
                 :route_path    => request.env['deas.route_path']
               })
             end
@@ -112,11 +113,13 @@ module Deas
             end
             ErrorHandler.run(env['deas.error'], {
               :server_data   => server_data,
-              :request       => self.request,
-              :response      => self.response,
-              :handler_class => self.request.env['deas.handler_class'],
-              :handler       => self.request.env['deas.handler'],
-              :params        => self.request.env['deas.params'],
+              :request       => request,
+              :response      => response,
+              :handler_class => request.env['deas.handler_class'],
+              :handler       => request.env['deas.handler'],
+              :params        => request.env['deas.params'],
+              :splat         => request.env['deas.splat'],
+              :route_path    => request.env['deas.route_path']
             })
           end
         end

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -12,9 +12,10 @@ class Deas::ErrorHandler
       @server_data      = Factory.server_data(:error_procs => @error_proc_spies)
       @request          = Factory.string
       @response         = Factory.string
-      @handler_class    = Factory.string
+      @handler_class    = Deas::ErrorHandler
       @handler          = Factory.string
       @params           = Factory.string
+      @splat            = Factory.string
       @route_path       = Factory.string
 
       @context_hash = {
@@ -24,10 +25,9 @@ class Deas::ErrorHandler
         :handler_class => @handler_class,
         :handler       => @handler,
         :params        => @params,
+        :splat         => @splat,
         :route_path    => @route_path
       }
-
-      @handler_class = Deas::ErrorHandler
     end
     subject{ @handler_class }
 
@@ -116,7 +116,7 @@ class Deas::ErrorHandler
 
     should have_readers :server_data
     should have_readers :request, :response, :handler_class, :handler
-    should have_readers :params, :route_path
+    should have_readers :params, :splat, :route_path
 
     should "know its attributes" do
       assert_equal @context_hash[:server_data],   subject.server_data
@@ -125,6 +125,7 @@ class Deas::ErrorHandler
       assert_equal @context_hash[:handler_class], subject.handler_class
       assert_equal @context_hash[:handler],       subject.handler
       assert_equal @context_hash[:params],        subject.params
+      assert_equal @context_hash[:splat],         subject.splat
       assert_equal @context_hash[:route_path],    subject.route_path
     end
 
@@ -132,7 +133,16 @@ class Deas::ErrorHandler
       exp = Context.new(@context_hash)
       assert_equal exp, subject
 
-      exp = Context.new({})
+      exp = Context.new({
+        :server_data   => Factory.server_data,
+        :request       => Factory.string,
+        :response      => Factory.string,
+        :handler_class => Factory.string,
+        :handler       => Factory.string,
+        :params        => Factory.string,
+        :splat         => Factory.string,
+        :route_path    => Factory.string
+      })
       assert_not_equal exp, subject
     end
 

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -94,6 +94,9 @@ class Deas::HandlerProxy
       exp = @runner_spy.params
       assert_equal exp, @request_data.request.env['deas.params']
 
+      exp = @runner_spy.splat
+      assert_equal exp, @request_data.request.env['deas.splat']
+
       exp = @runner_spy.route_path
       assert_equal exp, @request_data.request.env['deas.route_path']
     end
@@ -102,7 +105,8 @@ class Deas::HandlerProxy
       exp_msgs = [
         "  Handler: #{subject.handler_class.name}",
         "  Params:  #{@runner_spy.params.inspect}",
-        "  Splat:   #{@runner_spy.splat.inspect}"
+        "  Splat:   #{@runner_spy.splat.inspect}",
+        "  Route:   #{@runner_spy.route_path.inspect}"
       ]
       assert_equal exp_msgs, @request_data.request.logging_msgs
     end
@@ -114,7 +118,7 @@ class Deas::HandlerProxy
     attr_reader :run_called
     attr_reader :handler_class, :handler, :args
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :params, :route_path, :splat
+    attr_reader :request, :params, :splat, :route_path
 
     def initialize
       @run_called = false
@@ -130,8 +134,8 @@ class Deas::HandlerProxy
       @template_source = args[:template_source]
       @request         = args[:request]
       @params          = args[:params]
-      @route_path      = args[:route_path]
       @splat           = args[:splat]
+      @route_path      = args[:route_path]
     end
 
     def run

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -205,9 +205,11 @@ module Deas::Logging
     desc "when init"
     setup do
       @params = { Factory.string => Factory.string }
+      @splat  = Factory.string
       @handler_class = TestHandler
       @env.merge!({
         'deas.params'        => @params,
+        'deas.splat'         => @splat,
         'deas.handler_class' => @handler_class
       })
 
@@ -237,6 +239,7 @@ module Deas::Logging
         'method'  => @env['REQUEST_METHOD'],
         'path'    => @env['PATH_INFO'],
         'params'  => @env['deas.params'],
+        'splat'   => @env['deas.splat'],
         'time'    => @env['deas.time_taken'],
         'status'  => @resp_status,
         'handler' => @handler_class.name,
@@ -253,6 +256,7 @@ module Deas::Logging
         'method'  => @env['REQUEST_METHOD'],
         'path'    => @env['PATH_INFO'],
         'params'  => @env['deas.params'],
+        'splat'   => @env['deas.splat'],
         'time'    => @env['deas.time_taken'],
         'status'  => @resp_status,
         'redir'   => @resp_headers['Location']
@@ -268,6 +272,7 @@ module Deas::Logging
         'method'  => @env['REQUEST_METHOD'],
         'path'    => @env['PATH_INFO'],
         'params'  => @env['deas.params'],
+        'splat'   => @env['deas.splat'],
         'time'    => @env['deas.time_taken'],
         'status'  => @resp_status,
         'handler' => @handler_class.name,
@@ -282,7 +287,7 @@ module Deas::Logging
     subject{ Deas::SummaryLine }
 
     should "output its attributes in a specific order" do
-      assert_equal %w{time status method path handler params redir}, subject.keys
+      assert_equal %w{time status method path handler params splat redir}, subject.keys
     end
 
     should "output its attributes in a single line" do
@@ -293,6 +298,7 @@ module Deas::Logging
         'path'    => 'pth',
         'handler' => 'h',
         'params'  => 'p',
+        'splat'   => 'spl',
         'redir'   => 'r'
       }
       exp_line = "time=\"t\" "\
@@ -301,6 +307,7 @@ module Deas::Logging
                  "path=\"pth\" "\
                  "handler=\"h\" "\
                  "params=\"p\" "\
+                 "splat=\"spl\" "\
                  "redir=\"r\""
       assert_equal exp_line, subject.new(line_attrs)
     end


### PR DESCRIPTION
This makes the splat value (if any) available to error handlers
as contextual info.  Since splats are no longer part of the params
we need a way to access this info in error handlers.

This also updates the handler proxy to store the splat value on
the request env.  This makes it available to middlewares.  The
also updates the logging (includeing the Logging middleware)to use
the splat info in their logs.  I chose to also log the route path
in the verbose logs for completeness (this should have been done
in previous efforts).

Note: I updated the error context to "fetch" its attrs from the
given args hash.  This is to enforce that if the context expects
a value the rack app supplies it.  This also closes a gap in our
tests and tests that the rack app is creating the context as
necessary.

See #217 - you could argue that this should have been done in that effort.

@jcredding ready for review.