### PR TITLE
parse splat values from the PATH_INFO and route path data

### DIFF
--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -16,20 +16,17 @@ module Deas
     end
 
     def run(server_data, request_data)
-      # captures are not part of Deas' intended behavior and route matching
+      # captures are not part of Deas' intended behavior and route matching -
       # they are a side-effect of using Sinatra.  remove them so they won't
-      # be relied upon in Deas apps.
+      # be relied upon in Deas apps.  Remove all of this when Sinatra is removed.
       request_data.params.delete(:captures)
       request_data.params.delete('captures')
 
-      # splat will be provided to the handlers via a special `splat` helper.
-      # only single splat values are allowed (see router `url` method).  this
-      # takes the last splat value from Sinatra and provides it standalone to
-      # the runner.
-      # TODO: make runner parse from route path (don't rely on Sinatra)
-      splat_sym_param    = request_data.params.delete(:splat)
-      splat_string_param = request_data.params.delete('splat')
-      splat_value        = (splat_sym_param || splat_string_param || []).last
+      # splats that Sinatra provides aren't used by Deas - they are a
+      # side-effect of using Sinatra.  remove them so they won't be relied upon
+      # in Deas apps.  Remove all of this when Sinatra is removed.
+      request_data.params.delete(:splat)
+      request_data.params.delete('splat')
 
       runner = DeasRunner.new(self.handler_class, {
         :logger          => server_data.logger,
@@ -37,8 +34,7 @@ module Deas
         :template_source => server_data.template_source,
         :request         => request_data.request,
         :params          => request_data.params,
-        :route_path      => request_data.route_path,
-        :splat           => splat_value # TODO: make handlers parse from route path
+        :route_path      => request_data.route_path
       })
 
       runner.request.env.tap do |env|

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -15,7 +15,7 @@ module Deas
 
     attr_reader :handler_class, :handler
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :params, :route_path, :splat
+    attr_reader :request, :params, :route_path
 
     def initialize(handler_class, args = nil)
       @status, @headers, @body = nil, Rack::Utils::HeaderHash.new, nil
@@ -27,10 +27,13 @@ module Deas
       @request         = args[:request]
       @params          = args[:params]          || {}
       @route_path      = args[:route_path].to_s
-      @splat           = args[:splat] # TODO: lazily parse from route path
 
       @handler_class = handler_class
       @handler = @handler_class.new(self)
+    end
+
+    def splat
+      @splat ||= parse_splat_value
     end
 
     def run
@@ -136,6 +139,46 @@ module Deas
     def get_absolute_url(url)
       return url if url =~ /\A[A-z][A-z0-9\+\.\-]*:/
       File.join("#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}", url)
+    end
+
+    def parse_splat_value
+      return nil if request.nil? || (path_info = request.env['PATH_INFO']).nil?
+
+      regex = splat_value_parse_regex
+      match = regex.match(path_info)
+      if match.nil?
+        raise SplatParseError, "could not parse the splat value: " \
+                               "the PATH_INFO, `#{path_info.inspect}`, " \
+                               "doesn't match " \
+                               "the route, `#{self.route_path.inspect}`, " \
+                               "using the route regex, `#{regex.inspect}`"
+      end
+      match.captures.first
+    end
+
+    SplatParseError = Class.new(RuntimeError)
+
+    def splat_value_parse_regex
+      # `sub` should suffice as only a single trailing splat is allowed. Replace
+      # any splat with a capture placholder so we can extract the splat value.
+      /^#{route_path_with_regex_placeholders.sub('*', '(.+?)')}$/
+    end
+
+    def route_path_with_regex_placeholders
+      # Replace param values with regex placeholders b/c we don't care what
+      # the values are just that "a param value goes here".  Use gsub in the odd
+      # case a placeholder is used more than once in a route.  This is to help
+      # ensure matching and capturing splats even on nonsense paths.
+      sorted_param_names.inject(self.route_path) do |path, name|
+        path.gsub(":#{name}", '.+?')
+      end
+    end
+
+    def sorted_param_names
+      # Sort longer key names first so they will be processed first.  This
+      # ensures that shorter param names that compose longer param names won't
+      # be subbed in the longer param name's place.
+      self.params.keys.sort{ |a, b| b.size <=> a.size }
     end
 
     class NormalizedParams

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -28,14 +28,15 @@ module Deas
         :template_source => a.delete(:template_source),
         :request         => a.delete(:request),
         :params          => NormalizedParams.new(a.delete(:params) || {}).value,
-        :route_path      => a.delete(:route_path),
-        :splat           => a.delete(:splat)
+        :route_path      => a.delete(:route_path)
       })
+      @splat = a.delete(:splat)
       a.each{|key, value| self.handler.send("#{key}=", value) }
 
       catch(:halt){ self.handler.deas_init }
     end
 
+    def splat;   @splat;  end
     def halted?; @halted; end
 
     def run

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -38,13 +38,10 @@ class Deas::HandlerProxy
 
       Assert.stub(@proxy, :handler_class){ EmptyViewHandler }
 
-      @splat_sym_param    = Factory.string
-      @splat_string_param = Factory.string
-
       @server_data  = Factory.server_data
       @request_data = Factory.request_data(:params => {
-        :splat     => [@splat_sym_param],
-        'splat'    => [@splat_string_param],
+        :splat     => [Factory.string],
+        'splat'    => [Factory.string],
         :captures  => [Factory.string],
         'captures' => [Factory.string]
       })
@@ -66,22 +63,11 @@ class Deas::HandlerProxy
         :template_source => @server_data.template_source,
         :request         => @request_data.request,
         :params          => @request_data.params,
-        :route_path      => @request_data.route_path,
-        :splat           => @splat_sym_param
+        :route_path      => @request_data.route_path
       }
       assert_equal exp_args, @runner_spy.args
 
       assert_true @runner_spy.run_called
-    end
-
-    should "prefer splat sym params over splat string params" do
-      assert_equal @splat_sym_param, @runner_spy.args[:splat]
-
-      @request_data.params['splat'] = [@splat_string_param]
-      proxy = Deas::HandlerProxy.new('EmptyViewHandler')
-      Assert.stub(proxy, :handler_class){ EmptyViewHandler }
-      proxy.run(@server_data, @request_data)
-      assert_equal @splat_string_param, @runner_spy.args[:splat]
     end
 
     should "add data to the request env to make it available to Rack" do
@@ -134,8 +120,11 @@ class Deas::HandlerProxy
       @template_source = args[:template_source]
       @request         = args[:request]
       @params          = args[:params]
-      @splat           = args[:splat]
       @route_path      = args[:route_path]
+
+      # runners parse the splat value from the PATH_INFO and route path. just
+      # use a placeholder value for the spy.
+      @splat = Factory.string
     end
 
     def run

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -49,7 +49,7 @@ class Deas::TestRunner
     subject{ @runner }
 
     should have_readers :content_type_args
-    should have_imeths :halted?, :run
+    should have_imeths :splat, :halted?, :run
 
     should "raise an invalid error when passed a non view handler" do
       assert_raises(Deas::InvalidViewHandlerError) do
@@ -64,7 +64,10 @@ class Deas::TestRunner
       assert_equal @args[:request],         subject.request
       assert_equal @args[:params],          subject.params
       assert_equal @args[:route_path],      subject.route_path
-      assert_equal @args[:splat],           subject.splat
+    end
+
+    should "know its splat value" do
+      assert_equal @args[:splat], subject.splat
     end
 
     should "call to normalize its params" do


### PR DESCRIPTION
This is prep for removing Sinatra from Deas.  We no longer want
to rely on Sinatra to parse splat values for us.  This switches
to manually parsing it using request data.  This also means the
base runner is no longer given a splat value.  The test runner
however continues using its given splat value similar to how it
uses any given params value.

Note: this may be altered if our custom router someday parses
splats for us.

@jcredding ready for review.