### PR TITLE
update url generation to work with composed param names

### DIFF
--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -38,16 +38,20 @@ module Deas
     end
 
     def set_named(path, params)
-      params.inject(path) do |path_string, (name, value)|
-        if path_string.include?(":#{name}")
-          if (v = value.to_s).empty?
-            raise EmptyNamedValueError , "an empty value (`#{value.inspect}`) " \
-                                         "was given for the `#{name}` url param"
+      # Process longer param names first. This ensures that shorter names that
+      # compose longer names won't be set as a part of the longer name.
+      params.keys.sort{ |a, b| b.to_s.size <=> a.to_s.size }.inject(path) do |p, name|
+        if p.include?(":#{name}")
+          if (v = params[name].to_s).empty?
+            raise EmptyNamedValueError , "an empty value, " \
+                                         "`#{params[name].inspect}`, " \
+                                         "was given for the " \
+                                         "`#{name.inspect}` url param"
           end
           params.delete(name)
-          path_string.gsub(":#{name}", v)
+          p.gsub(":#{name}", v)
         else
-          path_string
+          p
         end
       end
     end

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -87,6 +87,17 @@ class Deas::Url
       })
     end
 
+    should "apply composed named params" do
+      url = Deas::Url.new(:some_thing, '/:some/:something/:something_else')
+
+      exp_path = '/a/goose/cooked'
+      assert_equal exp_path, url.path_for({
+        'some'           => 'a',
+        :something       => 'goose',
+        'something_else' => 'cooked'
+      })
+    end
+
     should "complain if given an empty named param value" do
       params = {
         'some' => 'a',
@@ -99,8 +110,8 @@ class Deas::Url
       err = assert_raises EmptyNamedValueError do
         subject.path_for(params)
       end
-      exp = "an empty value (`#{empty_param_value.inspect}`) "\
-            "was given for the `#{empty_param_name}` url param"
+      exp = "an empty value, `#{empty_param_value.inspect}`, "\
+            "was given for the `#{empty_param_name.inspect}` url param"
       assert_equal exp, err.message
     end
 


### PR DESCRIPTION
This fixes a bug where if you happen to define a url with param
names that compose another params' names, the url generation will
not set the param names correctly.  This updates the tests to
test this case and updates the implementation to apply longer
param names before shorter param names.

I discovered this problem while working on PR 224.

See #224 for reference.

@jcredding ready for review.