### PR TITLE
remove the settings Server API

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -71,14 +71,6 @@ module Deas
         self.config.default_encoding
       end
 
-      def set(name, value)
-        self.config.settings[name.to_sym] = value
-      end
-
-      def settings
-        self.config.settings
-      end
-
       def template_helpers(*helper_modules)
         helper_modules.each{ |m| self.config.template_helpers << m }
         self.config.template_helpers
@@ -174,7 +166,7 @@ module Deas
       DEFAULT_ENCODING    = 'utf-8'.freeze
 
       attr_accessor :env, :root, :views_path, :public_path, :default_encoding
-      attr_accessor :settings, :template_helpers, :middlewares
+      attr_accessor :template_helpers, :middlewares
       attr_accessor :init_procs, :error_procs, :template_source, :logger, :router
 
       attr_accessor :dump_errors, :method_override, :reload_templates
@@ -187,7 +179,6 @@ module Deas
         @views_path       = DEFAULT_VIEWS_PATH
         @public_path      = DEFAULT_PUBLIC_PATH
         @default_encoding = DEFAULT_ENCODING
-        @settings         = {}
         @template_helpers = []
         @middlewares      = []
         @init_procs       = []
@@ -236,7 +227,7 @@ module Deas
       def validate!
         return @valid if !@valid.nil?  # only need to run this once per config
 
-        # ensure all user and plugin configs/settings are applied
+        # ensure all user and plugin configs are applied
         self.init_procs.each(&:call)
         raise Deas::ServerRootError if self.root.nil?
 

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -66,7 +66,6 @@ module Deas
         # ["application/javascript", "application/xml", "application/xhtml+xml", /^text\//]
         settings.add_charset << "application/json"
 
-        server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }
 
         # routes

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -8,8 +8,6 @@ class DeasTestServer
   logger TEST_LOGGER
   verbose_logging Factory.boolean
 
-  set :a_setting, 'something'
-
   error do |exception, context|
     case exception
     when Deas::NotFound

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -43,7 +43,7 @@ class Deas::Router
     should have_imeths :route, :redirect, :not_found
     should have_imeths :apply_definitions!, :validate!
 
-    should "default its settings" do
+    should "default its attrs" do
       router = @router_class.new
       assert_nil router.view_handler_ns
       assert_nil router.base_url

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -22,7 +22,7 @@ module Deas::Server
 
     should have_imeths :env, :root, :views_path, :views_root
     should have_imeths :public_path, :public_root, :default_encoding
-    should have_imeths :set, :settings, :template_helpers, :template_helper?
+    should have_imeths :template_helpers, :template_helper?
     should have_imeths :use, :middlewares, :init, :init_procs, :error, :error_procs
     should have_imeths :template_source, :logger, :router, :url_for
 
@@ -56,10 +56,6 @@ module Deas::Server
       exp = Factory.string
       subject.default_encoding exp
       assert_equal exp, config.default_encoding
-
-      exp = { Factory.string.to_sym => Factory.string }
-      subject.set exp.keys.first, exp.values.first
-      assert_equal exp, config.settings
 
       exp = ['MyMiddleware', Factory.string]
       subject.use *exp
@@ -113,7 +109,6 @@ module Deas::Server
     should "demeter its config values that aren't directly set" do
       assert_equal subject.config.views_root,  subject.views_root
       assert_equal subject.config.public_root, subject.public_root
-      assert_equal subject.config.settings,    subject.settings
       assert_equal subject.config.middlewares, subject.middlewares
       assert_equal subject.config.init_procs,  subject.init_procs
       assert_equal subject.config.error_procs, subject.error_procs
@@ -165,7 +160,7 @@ module Deas::Server
     subject{ @config }
 
     should have_accessors :env, :root, :views_path, :public_path, :default_encoding
-    should have_accessors :settings, :template_helpers, :middlewares
+    should have_accessors :template_helpers, :middlewares
     should have_accessors :init_procs, :error_procs, :template_source, :logger, :router
 
     should have_accessors :dump_errors, :method_override, :reload_templates
@@ -198,11 +193,10 @@ module Deas::Server
       exp = @config_class::DEFAULT_ENCODING
       assert_equal exp, subject.default_encoding
 
-      assert_equal Hash.new, subject.settings
-      assert_equal [],       subject.template_helpers
-      assert_equal [],       subject.middlewares
-      assert_equal [],       subject.init_procs
-      assert_equal [],       subject.error_procs
+      assert_equal [], subject.template_helpers
+      assert_equal [], subject.middlewares
+      assert_equal [], subject.init_procs
+      assert_equal [], subject.error_procs
 
       assert_instance_of Deas::NullTemplateSource, subject.template_source
       assert_equal subject.root, subject.template_source.path


### PR DESCRIPTION
This is not something we want to support going forward.  The only
reason we supported it in the first place is b/c we originally
based Deas on Sinatra and Sinatra supported it.  This is prep
for removing Sinatra from Deas.

@jcredding ready for review.