### PR TITLE
add equality operator handling to ServerData and RequestData

### DIFF
--- a/lib/deas/request_data.rb
+++ b/lib/deas/request_data.rb
@@ -17,6 +17,17 @@ module Deas
       @route_path = args[:route_path]
     end
 
+    def ==(other_request_data)
+      if other_request_data.kind_of?(RequestData)
+        self.request    == other_request_data.request    &&
+        self.response   == other_request_data.response   &&
+        self.params     == other_request_data.params     &&
+        self.route_path == other_request_data.route_path
+      else
+        super
+      end
+    end
+
   end
 
 end

--- a/lib/deas/server_data.rb
+++ b/lib/deas/server_data.rb
@@ -9,12 +9,23 @@ module Deas
 
     attr_reader :error_procs, :template_source, :logger, :router
 
-    def initialize(args = nil)
+    def initialize(args)
       args ||= {}
       @error_procs     = args[:error_procs] || []
       @template_source = args[:template_source]
       @logger          = args[:logger]
       @router          = args[:router]
+    end
+
+    def ==(other_server_data)
+      if other_server_data.kind_of?(ServerData)
+        self.error_procs     == other_server_data.error_procs     &&
+        self.template_source == other_server_data.template_source &&
+        self.logger          == other_server_data.logger          &&
+        self.router          == other_server_data.router
+      else
+        super
+      end
     end
 
   end

--- a/test/unit/request_data_tests.rb
+++ b/test/unit/request_data_tests.rb
@@ -11,14 +11,14 @@ class Deas::RequestData
       @params     = Factory.string
       @route_path = Factory.string
 
-      @server_data = Deas::RequestData.new({
+      @request_data = Deas::RequestData.new({
         :request    => @request,
         :response   => @response,
         :params     => @params,
         :route_path => @route_path
       })
     end
-    subject{ @server_data }
+    subject{ @request_data }
 
     should have_readers :request, :response, :params, :route_path
 
@@ -37,6 +37,20 @@ class Deas::RequestData
       assert_nil request_data.params
       assert_nil request_data.route_path
     end
+
+    should "know if it is equal to another request data" do
+      request_data = Deas::RequestData.new({
+        :request    => @request,
+        :response   => @response,
+        :params     => @params,
+        :route_path => @route_path
+      })
+      assert_equal request_data, subject
+
+      request_data = Deas::RequestData.new({})
+      assert_not_equal request_data, subject
+    end
+
 
   end
 

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -30,12 +30,25 @@ class Deas::ServerData
     end
 
     should "default its attributes when they aren't provided" do
-      server_data = Deas::ServerData.new
+      server_data = Deas::ServerData.new({})
 
       assert_equal [], server_data.error_procs
       assert_nil server_data.logger
       assert_nil server_data.router
       assert_nil server_data.template_source
+    end
+
+    should "know if it is equal to another server data" do
+      server_data = Deas::ServerData.new({
+        :error_procs     => @error_procs,
+        :logger          => @logger,
+        :router          => @router,
+        :template_source => @template_source
+      })
+      assert_equal server_data, subject
+
+      server_data = Deas::ServerData.new({})
+      assert_not_equal server_data, subject
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -75,12 +75,7 @@ module Deas::SinatraApp
         :router          => @config.router,
         :template_source => @config.template_source
       })
-      sd = s.deas_server_data
-      assert_instance_of Deas::ServerData, sd
-      assert_instance_of exp.template_source.class, sd.template_source
-      assert_instance_of exp.logger.class, sd.logger
-      assert_equal exp.error_procs, sd.error_procs
-      assert_equal exp.router,      sd.router
+      assert_equal exp, s.deas_server_data
 
       assert_includes "application/json", s.add_charset
     end


### PR DESCRIPTION
This cleans up some tests in the SinatraApp.  I noticed this
while prepping to remove Sinatra.  The RequestData doesn't need
this logic right now but I'm adding it to be consistent.  I also
made the ServerData require args always be passed.  This is, again,
for consistency sake.

@jcredding ready for review.