### PR TITLE
remove Sinatra settings we don't want to support going forward

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -53,36 +53,19 @@ module Deas
         self.config.root
       end
 
-      def views_path(value = nil)
-        self.config.views_path = value if !value.nil?
-        self.config.views_path
+      def method_override(value = nil)
+        self.config.method_override = value if !value.nil?
+        self.config.method_override
       end
 
-      def views_root
-        self.config.views_root
+      def show_exceptions(value = nil)
+        self.config.show_exceptions = value if !value.nil?
+        self.config.show_exceptions
       end
 
-      def public_path(value = nil)
-        self.config.public_path = value if !value.nil?
-        self.config.public_path
-      end
-
-      def public_root
-        self.config.public_root
-      end
-
-      def default_encoding(value = nil)
-        self.config.default_encoding = value if !value.nil?
-        self.config.default_encoding
-      end
-
-      def template_helpers(*helper_modules)
-        helper_modules.each{ |m| self.config.template_helpers << m }
-        self.config.template_helpers
-      end
-
-      def template_helper?(helper_module)
-        self.config.template_helpers.include?(helper_module)
+      def verbose_logging(value = nil)
+        self.config.verbose_logging = value if !value.nil?
+        self.config.verbose_logging
       end
 
       def use(*args)
@@ -129,85 +112,31 @@ module Deas
 
       def url_for(*args, &block); self.router.url_for(*args, &block); end
 
-      # flags
-
-      def dump_errors(value = nil)
-        self.config.dump_errors = value if !value.nil?
-        self.config.dump_errors
-      end
-
-      def method_override(value = nil)
-        self.config.method_override = value if !value.nil?
-        self.config.method_override
-      end
-
-      def reload_templates(value = nil)
-        self.config.reload_templates = value if !value.nil?
-        self.config.reload_templates
-      end
-
-      def show_exceptions(value = nil)
-        self.config.show_exceptions = value if !value.nil?
-        self.config.show_exceptions
-      end
-
-      def static_files(value = nil)
-        self.config.static_files = value if !value.nil?
-        self.config.static_files
-      end
-
-      def verbose_logging(value = nil)
-        self.config.verbose_logging = value if !value.nil?
-        self.config.verbose_logging
-      end
-
     end
 
     class Config
 
-      DEFAULT_ENV         = 'development'.freeze
-      DEFAULT_VIEWS_PATH  = 'views'.freeze
-      DEFAULT_PUBLIC_PATH = 'public'.freeze
-      DEFAULT_ENCODING    = 'utf-8'.freeze
+      DEFAULT_ENV = 'development'.freeze
 
-      attr_accessor :env, :root, :views_path, :public_path, :default_encoding
-      attr_accessor :template_helpers, :middlewares
-      attr_accessor :init_procs, :error_procs, :template_source, :logger, :router
-
-      attr_accessor :dump_errors, :method_override, :reload_templates
-      attr_accessor :show_exceptions, :static_files
-      attr_accessor :verbose_logging
+      attr_accessor :env, :root
+      attr_accessor :method_override, :show_exceptions, :verbose_logging
+      attr_accessor :middlewares, :init_procs, :error_procs
+      attr_accessor :template_source, :logger, :router
 
       def initialize
-        @env              = DEFAULT_ENV
-        @root             = ENV['PWD']
-        @views_path       = DEFAULT_VIEWS_PATH
-        @public_path      = DEFAULT_PUBLIC_PATH
-        @default_encoding = DEFAULT_ENCODING
-        @template_helpers = []
-        @middlewares      = []
-        @init_procs       = []
-        @error_procs      = []
-        @template_source  = nil
-        @logger           = Deas::NullLogger.new
-        @router           = Deas::Router.new
-
-        @dump_errors      = false
-        @method_override  = true
-        @reload_templates = false
-        @show_exceptions  = false
-        @static_files     = true
-        @verbose_logging  = true
+        @env             = DEFAULT_ENV
+        @root            = ENV['PWD']
+        @method_override = true
+        @show_exceptions = false
+        @verbose_logging = true
+        @middlewares     = []
+        @init_procs      = []
+        @error_procs     = []
+        @template_source = nil
+        @logger          = Deas::NullLogger.new
+        @router          = Deas::Router.new
 
         @valid = nil
-      end
-
-      def views_root
-        File.expand_path(@views_path.to_s, @root.to_s)
-      end
-
-      def public_root
-        File.expand_path(@public_path.to_s, @root.to_s)
       end
 
       def template_source

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -33,17 +33,15 @@ module Deas
       })
 
       Sinatra.new do
-        # built-in settings
-        set :environment,      server_config.env
-        set :root,             server_config.root
-        set :views,            server_config.views_root
-        set :public_folder,    server_config.public_root
-        set :default_encoding, server_config.default_encoding
-        set :dump_errors,      server_config.dump_errors
-        set :method_override,  server_config.method_override
-        set :reload_templates, server_config.reload_templates
-        set :static,           server_config.static_files
-        set :sessions,         false
+        # unifying settings - these are used by Deas so extensions can have a
+        # common way to identify these low-level settings.  Deas does not use
+        # them directly
+        set :environment, server_config.env
+        set :root,        server_config.root
+
+        # TODO: rework this and handle it when the router is reworked.  maybe
+        # turn on by default and have setting to force on/off???
+        set :method_override, server_config.method_override
 
         # TODO: sucks to have to do this but b/c of Rack there is no better way
         # to make the server data available to middleware.  We should remove this
@@ -52,12 +50,26 @@ module Deas
         # Not sure right now, just jotting down notes.
         set :deas_server_data, server_data
 
+        # static settings - Deas doesn't care about these anymore so just
+        # use some intelligent defaults
+        set :views,            server_config.root
+        set :public_folder,    server_config.root
+        set :default_encoding, 'utf-8'
+        set :reload_templates, false
+        set :static,           false
+        set :sessions,         false
+
+        # Turn this off b/c Deas won't auto provide it.  We may add an extension
+        # gem or something??
+        disable :protection
+
         # raise_errors and show_exceptions prevent Deas error handlers from being
         # called and Deas' logging doesn't finish. They should always be false.
         set :raise_errors,     false
         set :show_exceptions,  false
 
-        # turn off logging b/c Deas handles its own logging logic
+        # turn off logging, dump_errors b/c Deas handles its own logging logic
+        set :dump_errors,      false
         set :logging,          false
 
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -20,15 +20,11 @@ module Deas::Server
 
     should have_imeths :new, :config
 
-    should have_imeths :env, :root, :views_path, :views_root
-    should have_imeths :public_path, :public_root, :default_encoding
-    should have_imeths :template_helpers, :template_helper?
-    should have_imeths :use, :middlewares, :init, :init_procs, :error, :error_procs
+    should have_imeths :env, :root
+    should have_imeths :method_override, :show_exceptions, :verbose_logging
+    should have_imeths :use, :middlewares
+    should have_imeths :init, :init_procs, :error, :error_procs
     should have_imeths :template_source, :logger, :router, :url_for
-
-    should have_imeths :dump_errors, :method_override, :reload_templates
-    should have_imeths :show_exceptions, :static_files
-    should have_imeths :verbose_logging
 
     should "use much-plugin" do
       assert_includes MuchPlugin, Deas::Server
@@ -45,17 +41,17 @@ module Deas::Server
       subject.root exp
       assert_equal exp, config.root
 
-      exp = Factory.path
-      subject.views_path exp
-      assert_equal exp, config.views_path
+      exp = Factory.boolean
+      subject.method_override exp
+      assert_equal exp, config.method_override
 
-      exp = Factory.path
-      subject.public_path exp
-      assert_equal exp, config.public_path
+      exp = Factory.boolean
+      subject.show_exceptions exp
+      assert_equal exp, config.show_exceptions
 
-      exp = Factory.string
-      subject.default_encoding exp
-      assert_equal exp, config.default_encoding
+      exp = Factory.boolean
+      subject.verbose_logging exp
+      assert_equal exp, config.verbose_logging
 
       exp = ['MyMiddleware', Factory.string]
       subject.use *exp
@@ -80,43 +76,12 @@ module Deas::Server
       exp = Logger.new(STDOUT)
       subject.logger exp
       assert_equal exp, config.logger
-
-      exp = Factory.boolean
-      subject.dump_errors exp
-      assert_equal exp, config.dump_errors
-
-      exp = Factory.boolean
-      subject.method_override exp
-      assert_equal exp, config.method_override
-
-      exp = Factory.boolean
-      subject.reload_templates exp
-      assert_equal exp, config.reload_templates
-
-      exp = Factory.boolean
-      subject.show_exceptions exp
-      assert_equal exp, config.show_exceptions
-
-      exp = Factory.boolean
-      subject.static_files exp
-      assert_equal exp, config.static_files
-
-      exp = Factory.boolean
-      subject.verbose_logging exp
-      assert_equal exp, config.verbose_logging
     end
 
-    should "demeter its config values that aren't directly set" do
-      assert_equal subject.config.views_root,  subject.views_root
-      assert_equal subject.config.public_root, subject.public_root
+    should "demeter its config values that aren't set directly" do
       assert_equal subject.config.middlewares, subject.middlewares
       assert_equal subject.config.init_procs,  subject.init_procs
       assert_equal subject.config.error_procs, subject.error_procs
-    end
-
-    should "add and query helper modules" do
-      subject.template_helpers(helper_module = Module.new)
-      assert_true subject.template_helper?(helper_module)
     end
 
     should "have a router by default and allow overriding it" do
@@ -159,22 +124,16 @@ module Deas::Server
     end
     subject{ @config }
 
-    should have_accessors :env, :root, :views_path, :public_path, :default_encoding
-    should have_accessors :template_helpers, :middlewares
-    should have_accessors :init_procs, :error_procs, :template_source, :logger, :router
+    should have_accessors :env, :root
+    should have_accessors :method_override, :show_exceptions, :verbose_logging
+    should have_accessors :middlewares, :init_procs, :error_procs
+    should have_accessors :template_source, :logger, :router
 
-    should have_accessors :dump_errors, :method_override, :reload_templates
-    should have_accessors :show_exceptions, :static_files
-    should have_accessors :verbose_logging
-
-    should have_imeths :views_root, :public_root, :urls, :routes
+    should have_imeths :urls, :routes
     should have_imeths :valid?, :validate!
 
-    should "know its default attr values" do
+    should "know its default env" do
       assert_equal 'development', @config_class::DEFAULT_ENV
-      assert_equal 'views',       @config_class::DEFAULT_VIEWS_PATH
-      assert_equal 'public',      @config_class::DEFAULT_PUBLIC_PATH
-      assert_equal 'utf-8',       @config_class::DEFAULT_ENCODING
     end
 
     should "default its attrs" do
@@ -184,16 +143,10 @@ module Deas::Server
       exp = ENV['PWD']
       assert_equal exp, subject.root
 
-      exp = @config_class::DEFAULT_VIEWS_PATH
-      assert_equal exp, subject.views_path
+      assert_equal true,  subject.method_override
+      assert_equal false, subject.show_exceptions
+      assert_equal true,  subject.verbose_logging
 
-      exp = @config_class::DEFAULT_PUBLIC_PATH
-      assert_equal exp, subject.public_path
-
-      exp = @config_class::DEFAULT_ENCODING
-      assert_equal exp, subject.default_encoding
-
-      assert_equal [], subject.template_helpers
       assert_equal [], subject.middlewares
       assert_equal [], subject.init_procs
       assert_equal [], subject.error_procs
@@ -203,21 +156,6 @@ module Deas::Server
 
       assert_instance_of Deas::NullLogger, subject.logger
       assert_instance_of Deas::Router,     subject.router
-
-      assert_equal false, subject.dump_errors
-      assert_equal true,  subject.method_override
-      assert_equal false, subject.reload_templates
-      assert_equal false, subject.show_exceptions
-      assert_equal true,  subject.static_files
-      assert_equal true,  subject.verbose_logging
-    end
-
-    should "know its views root and public root" do
-      exp = File.expand_path(subject.views_path.to_s, subject.root.to_s)
-      assert_equal exp, subject.views_root
-
-      exp = File.expand_path(subject.public_path.to_s, subject.root.to_s)
-      assert_equal exp, subject.public_root
     end
 
     should "demeter its router" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -47,27 +47,16 @@ module Deas::SinatraApp
       assert @config.valid?
     end
 
-    should "be a kind of Sinatra::Base" do
+    should "be a kind of Sinatra::Base app" do
       assert_equal Sinatra::Base, subject.superclass
     end
 
-    should "have it's configuration set based on the server config" do
+    should "have it's configuration set based on the server config or defaults" do
       s = subject.settings
 
       assert_equal @config.env,              s.environment
       assert_equal @config.root,             s.root
-      assert_equal @config.views_root,       s.views
-      assert_equal @config.public_root,      s.public_folder
-      assert_equal @config.default_encoding, s.default_encoding
-      assert_equal @config.dump_errors,      s.dump_errors
       assert_equal @config.method_override,  s.method_override
-      assert_equal @config.reload_templates, s.reload_templates
-      assert_equal @config.static_files,     s.static
-
-      assert_false s.sessions
-      assert_false s.raise_errors
-      assert_false s.show_exceptions
-      assert_false s.logging
 
       exp = Deas::ServerData.new({
         :error_procs     => @config.error_procs,
@@ -76,6 +65,19 @@ module Deas::SinatraApp
         :template_source => @config.template_source
       })
       assert_equal exp, s.deas_server_data
+
+      assert_equal @config.root, s.views
+      assert_equal @config.root, s.public_folder
+      assert_equal 'utf-8',      s.default_encoding
+
+      assert_false s.static
+      assert_false s.reload_templates
+      assert_false s.sessions
+      assert_false s.protection
+      assert_false s.raise_errors
+      assert_false s.show_exceptions
+      assert_false s.dump_errors
+      assert_false s.logging
     end
 
     should "define Sinatra routes for every route in the configuration" do


### PR DESCRIPTION
This is part of prepping Deas to remove Sinatra.  This removes
some configs and changes others to disable most of Sinatra's
default behavior.  This is to ensure we aren't unknowingly relying
on Sinatra prior to removing it.

A few notes:

* I kept the `env` and `root` settings.  The root setting is used
  by Deas to default the template source, but more importantly,
  these provide a nice common interface to this data for gems that
  extend deas behavior.
* I am keeping the `method_override` setting b/c I'm not sure how
  I want to handle this in Deas once Sinatra is gone.  The behavior
  most likely will need to be manually implemented so it seems
  likely we'll want to be able to turn it off/on.
* I chose to set the `views` and `public_folder` setting to the
  root just b/c they make nice benign defaults.  Deas should not
  be using these anymore.
* I turned off the `static` setting - users will need to bring in
  the `Rack::Static` middleware on a 'public' dir if they need
  this behavior.
* I disabled the `protection` setting - users will need to bring in
  `Rack::Protection` going forward if this is needed.

@jcredding ready for review.