### PR TITLE
manually handle the `method_override` server config

### DIFF
--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -4,8 +4,8 @@ require 'sinatra/base'
 module Deas
 
   module Logging
-    def self.middleware(verbose)
-      verbose ? VerboseLogging : SummaryLogging
+    def self.middleware_args(verbose)
+      verbose ? [VerboseLogging] : [SummaryLogging]
     end
   end
 

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -168,12 +168,19 @@ module Deas
         # validate the router
         self.router.validate!
 
+        # TODO: build final middleware stack when building the rack app, not here
+        # (once Sinatra is removed)
+
+        # prepend the method override middleware first.  This ensures that the
+        # it is run before any other middleware
+        self.middlewares.unshift([Rack::MethodOverride]) if self.method_override
+
         # append the show exceptions and logging middlewares last.  This ensures
         # that the logging and exception showing happens just before the app gets
         # the request and just after the app sends a response.
         self.middlewares << [Deas::ShowExceptions] if self.show_exceptions
-        logging_mw_args = [*Deas::Logging.middleware(self.verbose_logging)]
-        self.middlewares << logging_mw_args
+        self.middlewares << Deas::Logging.middleware_args(self.verbose_logging)
+        self.middlewares.freeze
 
         @valid = true # if it made it this far, its valid!
       end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -39,10 +39,6 @@ module Deas
         set :environment, server_config.env
         set :root,        server_config.root
 
-        # TODO: rework this and handle it when the router is reworked.  maybe
-        # turn on by default and have setting to force on/off???
-        set :method_override, server_config.method_override
-
         # TODO: sucks to have to do this but b/c of Rack there is no better way
         # to make the server data available to middleware.  We should remove this
         # once we remove Sinatra.  Whatever rack app implemenation will needs to
@@ -55,6 +51,7 @@ module Deas
         set :views,            server_config.root
         set :public_folder,    server_config.root
         set :default_encoding, 'utf-8'
+        set :method_override,  false
         set :reload_templates, false
         set :static,           false
         set :sessions,         false

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -7,11 +7,11 @@ module Deas::Logging
     desc "Deas::Logging"
     subject{ Deas::Logging }
 
-    should have_imeths :middleware
+    should have_imeths :middleware_args
 
-    should "return a middleware class given a verbose flag" do
-      assert_equal Deas::VerboseLogging, subject.middleware(true)
-      assert_equal Deas::SummaryLogging, subject.middleware(false)
+    should "return middleware args given a verbose flag" do
+      assert_equal [Deas::VerboseLogging], subject.middleware_args(true)
+      assert_equal [Deas::SummaryLogging], subject.middleware_args(false)
     end
 
   end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -54,9 +54,8 @@ module Deas::SinatraApp
     should "have it's configuration set based on the server config or defaults" do
       s = subject.settings
 
-      assert_equal @config.env,              s.environment
-      assert_equal @config.root,             s.root
-      assert_equal @config.method_override,  s.method_override
+      assert_equal @config.env,  s.environment
+      assert_equal @config.root, s.root
 
       exp = Deas::ServerData.new({
         :error_procs     => @config.error_procs,
@@ -70,8 +69,9 @@ module Deas::SinatraApp
       assert_equal @config.root, s.public_folder
       assert_equal 'utf-8',      s.default_encoding
 
-      assert_false s.static
+      assert_false s.method_override
       assert_false s.reload_templates
+      assert_false s.static
       assert_false s.sessions
       assert_false s.protection
       assert_false s.raise_errors


### PR DESCRIPTION
This is prep for removing Sinatra.  All Sinatra did was add
`Rack::MethodOverride` to the middleware stack if the option was
set.  This does the same thing, prepending it as Sinatra did.

@jcredding ready for review.