### PR TITLE
Feature: Rework to only rely on Sinatra for basic Rack app and routing

### DIFF
--- a/deas.gemspec
+++ b/deas.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert-rack-test", ["~> 1.0.4"])
 
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
-  gem.add_dependency("rack",        ["~> 1.1"])
+  gem.add_dependency("rack",        ["~> 1.6.4"])
   gem.add_dependency("sinatra",     ["~> 1.2"])
 
 end

--- a/lib/deas/error_handler.rb
+++ b/lib/deas/error_handler.rb
@@ -35,7 +35,8 @@ module Deas
     class Context
 
       attr_reader :server_data
-      attr_reader :request, :response, :handler_class, :handler, :params
+      attr_reader :request, :response, :handler_class, :handler
+      attr_reader :params, :route_path
 
       def initialize(args)
         @server_data   = args[:server_data]
@@ -44,6 +45,7 @@ module Deas
         @handler_class = args[:handler_class]
         @handler       = args[:handler]
         @params        = args[:params]
+        @route_path    = args[:route_path]
       end
 
       def ==(other)
@@ -53,7 +55,8 @@ module Deas
           self.request       == other.request &&
           self.response      == other.response &&
           self.handler       == other.handler &&
-          self.params        == other.params
+          self.params        == other.params &&
+          self.route_path    == other.route_path
         else
           super
         end

--- a/lib/deas/error_handler.rb
+++ b/lib/deas/error_handler.rb
@@ -36,26 +36,28 @@ module Deas
 
       attr_reader :server_data
       attr_reader :request, :response, :handler_class, :handler
-      attr_reader :params, :route_path
+      attr_reader :params, :splat, :route_path
 
       def initialize(args)
-        @server_data   = args[:server_data]
-        @request       = args[:request]
-        @response      = args[:response]
-        @handler_class = args[:handler_class]
-        @handler       = args[:handler]
-        @params        = args[:params]
-        @route_path    = args[:route_path]
+        @server_data   = args.fetch(:server_data)
+        @request       = args.fetch(:request)
+        @response      = args.fetch(:response)
+        @handler_class = args.fetch(:handler_class)
+        @handler       = args.fetch(:handler)
+        @params        = args.fetch(:params)
+        @splat         = args.fetch(:splat)
+        @route_path    = args.fetch(:route_path)
       end
 
       def ==(other)
         if other.kind_of?(self.class)
-          self.server_data   == other.server_data &&
+          self.server_data   == other.server_data   &&
           self.handler_class == other.handler_class &&
-          self.request       == other.request &&
-          self.response      == other.response &&
-          self.handler       == other.handler &&
-          self.params        == other.params &&
+          self.request       == other.request       &&
+          self.response      == other.response      &&
+          self.handler       == other.handler       &&
+          self.params        == other.params        &&
+          self.splat         == other.splat         &&
           self.route_path    == other.route_path
         else
           super

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -15,29 +15,30 @@ module Deas
       raise NotImplementedError
     end
 
-    def run(server_data, sinatra_call)
+    def run(server_data, request_data)
       # captures are not part of Deas' intended behavior and route matching
-      # they are a side-effects of using Sinatra.  remove them so they won't
+      # they are a side-effect of using Sinatra.  remove them so they won't
       # be relied upon in Deas apps.
-      sinatra_call.params.delete(:captures)
-      sinatra_call.params.delete('captures')
+      request_data.params.delete(:captures)
+      request_data.params.delete('captures')
 
       # splat will be provided to the handlers via a special `splat` helper.
       # only single splat values are allowed (see router `url` method).  this
       # takes the last splat value from Sinatra and provides it standalone to
       # the runner.
-      splat_sym_param    = sinatra_call.params.delete(:splat)
-      splat_string_param = sinatra_call.params.delete('splat')
+      # TODO: make runner parse from route path (don't rely on Sinatra)
+      splat_sym_param    = request_data.params.delete(:splat)
+      splat_string_param = request_data.params.delete('splat')
       splat_value        = (splat_sym_param || splat_string_param || []).last
 
       runner = DeasRunner.new(self.handler_class, {
         :logger          => server_data.logger,
         :router          => server_data.router,
         :template_source => server_data.template_source,
-        :request         => sinatra_call.request,
-        :session         => sinatra_call.session,
-        :params          => sinatra_call.params,
-        :splat           => splat_value
+        :request         => request_data.request,
+        :params          => request_data.params,
+        :route_path      => request_data.route_path,
+        :splat           => splat_value # TODO: make handlers parse from route path
       })
 
       runner.request.env.tap do |env|
@@ -48,6 +49,8 @@ module Deas
         env['deas.handler_class'] = self.handler_class
         env['deas.handler']       = runner.handler
         env['deas.params']        = runner.params
+        # TODO: add runner.splat as deas.splat env value
+        env['deas.route_path']    = runner.route_path
 
         # this handles the verbose logging (it is a no-op if summary logging)
         env['deas.logging'].call "  Handler: #{self.handler_class.name}"

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -16,20 +16,17 @@ module Deas
     end
 
     def run(server_data, request_data)
-      # captures are not part of Deas' intended behavior and route matching
+      # captures are not part of Deas' intended behavior and route matching -
       # they are a side-effect of using Sinatra.  remove them so they won't
-      # be relied upon in Deas apps.
+      # be relied upon in Deas apps.  Remove all of this when Sinatra is removed.
       request_data.params.delete(:captures)
       request_data.params.delete('captures')
 
-      # splat will be provided to the handlers via a special `splat` helper.
-      # only single splat values are allowed (see router `url` method).  this
-      # takes the last splat value from Sinatra and provides it standalone to
-      # the runner.
-      # TODO: make runner parse from route path (don't rely on Sinatra)
-      splat_sym_param    = request_data.params.delete(:splat)
-      splat_string_param = request_data.params.delete('splat')
-      splat_value        = (splat_sym_param || splat_string_param || []).last
+      # splats that Sinatra provides aren't used by Deas - they are a
+      # side-effect of using Sinatra.  remove them so they won't be relied upon
+      # in Deas apps.  Remove all of this when Sinatra is removed.
+      request_data.params.delete(:splat)
+      request_data.params.delete('splat')
 
       runner = DeasRunner.new(self.handler_class, {
         :logger          => server_data.logger,
@@ -37,8 +34,7 @@ module Deas
         :template_source => server_data.template_source,
         :request         => request_data.request,
         :params          => request_data.params,
-        :route_path      => request_data.route_path,
-        :splat           => splat_value # TODO: make handlers parse from route path
+        :route_path      => request_data.route_path
       })
 
       runner.request.env.tap do |env|

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -49,13 +49,14 @@ module Deas
         env['deas.handler_class'] = self.handler_class
         env['deas.handler']       = runner.handler
         env['deas.params']        = runner.params
-        # TODO: add runner.splat as deas.splat env value
+        env['deas.splat']         = runner.splat
         env['deas.route_path']    = runner.route_path
 
         # this handles the verbose logging (it is a no-op if summary logging)
         env['deas.logging'].call "  Handler: #{self.handler_class.name}"
         env['deas.logging'].call "  Params:  #{runner.params.inspect}"
         env['deas.logging'].call "  Splat:   #{runner.splat.inspect}" if !runner.splat.nil?
+        env['deas.logging'].call "  Route:   #{runner.route_path.inspect}"
       end
 
       runner.run

--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -102,6 +102,7 @@ module Deas
         'method'  => request.request_method,
         'path'    => request.path,
         'params'  => env['deas.params'],
+        'splat'   => env['deas.splat'],
         'time'    => env['deas.time_taken'],
         'status'  => status
       }
@@ -119,7 +120,7 @@ module Deas
 
   module SummaryLine
     def self.keys
-      %w{time status method path handler params redir}
+      %w{time status method path handler params splat redir}
     end
     def self.new(line_attrs)
       self.keys.select{ |k| line_attrs.key?(k) }.

--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -4,8 +4,8 @@ require 'sinatra/base'
 module Deas
 
   module Logging
-    def self.middleware(verbose)
-      verbose ? VerboseLogging : SummaryLogging
+    def self.middleware_args(verbose)
+      verbose ? [VerboseLogging] : [SummaryLogging]
     end
   end
 

--- a/lib/deas/request_data.rb
+++ b/lib/deas/request_data.rb
@@ -1,0 +1,22 @@
+module Deas
+
+  class RequestData
+
+    # The rack app uses this to "compile" the request-related data. The goal
+    # here is to wrap up these (and any future) request objects into a struct
+    # object to make them available to the runner/handler.  This is also to
+    # decouple the rack app from the handlers (we can use any rack app as long
+    # as they provide this data).
+
+    attr_reader :route_path, :request, :response, :params
+
+    def initialize(args)
+      @route_path = args[:route_path]
+      @request    = args[:request]
+      @response   = args[:response]
+      @params     = args[:params]
+    end
+
+  end
+
+end

--- a/lib/deas/request_data.rb
+++ b/lib/deas/request_data.rb
@@ -17,6 +17,17 @@ module Deas
       @route_path = args[:route_path]
     end
 
+    def ==(other_request_data)
+      if other_request_data.kind_of?(RequestData)
+        self.request    == other_request_data.request    &&
+        self.response   == other_request_data.response   &&
+        self.params     == other_request_data.params     &&
+        self.route_path == other_request_data.route_path
+      else
+        super
+      end
+    end
+
   end
 
 end

--- a/lib/deas/request_data.rb
+++ b/lib/deas/request_data.rb
@@ -8,13 +8,13 @@ module Deas
     # decouple the rack app from the handlers (we can use any rack app as long
     # as they provide this data).
 
-    attr_reader :route_path, :request, :response, :params
+    attr_reader :request, :response, :params, :route_path
 
     def initialize(args)
-      @route_path = args[:route_path]
       @request    = args[:request]
       @response   = args[:response]
       @params     = args[:params]
+      @route_path = args[:route_path]
     end
 
   end

--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -16,15 +16,13 @@ module Deas
       end
     end
 
-    def run(server_data, sinatra_call)
-      type = server_data.router.request_type_name(sinatra_call.request)
-      proxy = begin
-        @handler_proxies[type]
+    def run(server_data, request_data)
+      request_type_name = server_data.router.request_type_name(request_data.request)
+      begin
+        @handler_proxies[request_type_name].run(server_data, request_data)
       rescue HandlerProxyNotFound
-        sinatra_call.halt(404)
+        [404, Rack::Utils::HeaderHash.new, []]
       end
-      # TODO: eventually stop sending sinatra call (part of phasing out Sinatra)
-      proxy.run(server_data, sinatra_call)
     end
 
   end

--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -43,15 +43,15 @@ module Deas
     end
 
     def url(name, path, options = nil)
+      if !name.kind_of?(::Symbol)
+        raise ArgumentError, "invalid name `#{name.inspect}` - "\
+                             "named urls must be defined with Symbol names"
+      end
       if !path.kind_of?(::String)
         raise ArgumentError, "invalid path `#{path.inspect}` - "\
                              "named urls must be defined with String paths"
       end
-      if path =~ /\*(?!$)/ # splat not at end of path
-        raise ArgumentError, "invalid path `#{path.inspect}` - "\
-                             "named urls can only have a single splat at the end of the path"
-      end
-      add_url(name.to_sym, path, options || {})
+      add_url(name, path, options || {})
     end
 
     def url_for(name, *args)
@@ -179,6 +179,10 @@ module Deas
     end
 
     def add_route(http_method, path, proxies)
+      if path =~ /\*(?!$)/ # splat not at end of path
+        raise ArgumentError, "invalid path `#{path.inspect}` - "\
+                             "routes can only have a single splat at the end of their path"
+      end
       proxies = HandlerProxies.new(proxies, self.default_request_type_name)
       require 'deas/route'
       Deas::Route.new(http_method, path, proxies).tap{ |r| self.routes.push(r) }

--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -179,14 +179,20 @@ module Deas
     end
 
     def add_route(http_method, path, proxies)
-      if path =~ /\*(?!$)/ # splat not at end of path
-        raise ArgumentError, "invalid path `#{path.inspect}` - "\
-                             "routes can only have a single splat at the end of their path"
+      # splat not at end of path OR
+      # at end of path without preceding forward slash
+      if path =~ /\*(?!$)|[^\/]\*/
+        raise InvalidSplatError, "invalid path `#{path.inspect}` - "\
+                                 "routes can only have a single splat and " \
+                                 "it must be the last path segment " \
+                                 "(ie '/something/*')"
       end
       proxies = HandlerProxies.new(proxies, self.default_request_type_name)
       require 'deas/route'
       Deas::Route.new(http_method, path, proxies).tap{ |r| self.routes.push(r) }
     end
+
+    InvalidSplatError = Class.new(ArgumentError)
 
     class HandlerProxies
 

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -15,7 +15,7 @@ module Deas
 
     attr_reader :handler_class, :handler
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :params, :route_path, :splat
+    attr_reader :request, :params, :route_path
 
     def initialize(handler_class, args = nil)
       @status, @headers, @body = nil, Rack::Utils::HeaderHash.new, nil
@@ -27,10 +27,13 @@ module Deas
       @request         = args[:request]
       @params          = args[:params]          || {}
       @route_path      = args[:route_path].to_s
-      @splat           = args[:splat] # TODO: lazily parse from route path
 
       @handler_class = handler_class
       @handler = @handler_class.new(self)
+    end
+
+    def splat
+      @splat ||= parse_splat_value
     end
 
     def run
@@ -136,6 +139,46 @@ module Deas
     def get_absolute_url(url)
       return url if url =~ /\A[A-z][A-z0-9\+\.\-]*:/
       File.join("#{request.env['rack.url_scheme']}://#{request.env['HTTP_HOST']}", url)
+    end
+
+    def parse_splat_value
+      return nil if request.nil? || (path_info = request.env['PATH_INFO']).nil?
+
+      regex = splat_value_parse_regex
+      match = regex.match(path_info)
+      if match.nil?
+        raise SplatParseError, "could not parse the splat value: " \
+                               "the PATH_INFO, `#{path_info.inspect}`, " \
+                               "doesn't match " \
+                               "the route, `#{self.route_path.inspect}`, " \
+                               "using the route regex, `#{regex.inspect}`"
+      end
+      match.captures.first
+    end
+
+    SplatParseError = Class.new(RuntimeError)
+
+    def splat_value_parse_regex
+      # `sub` should suffice as only a single trailing splat is allowed. Replace
+      # any splat with a capture placholder so we can extract the splat value.
+      /^#{route_path_with_regex_placeholders.sub('*', '(.+?)')}$/
+    end
+
+    def route_path_with_regex_placeholders
+      # Replace param values with regex placeholders b/c we don't care what
+      # the values are just that "a param value goes here".  Use gsub in the odd
+      # case a placeholder is used more than once in a route.  This is to help
+      # ensure matching and capturing splats even on nonsense paths.
+      sorted_param_names.inject(self.route_path) do |path, name|
+        path.gsub(":#{name}", '.+?')
+      end
+    end
+
+    def sorted_param_names
+      # Sort longer key names first so they will be processed first.  This
+      # ensures that shorter param names that compose longer param names won't
+      # be subbed in the longer param name's place.
+      self.params.keys.sort{ |a, b| b.size <=> a.size }
     end
 
     class NormalizedParams

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -15,19 +15,19 @@ module Deas
 
     attr_reader :handler_class, :handler
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :session, :params, :splat
+    attr_reader :request, :params, :route_path, :splat
 
     def initialize(handler_class, args = nil)
       @status, @headers, @body = nil, Rack::Utils::HeaderHash.new, nil
 
       args ||= {}
-      @logger          = args[:logger] || Deas::NullLogger.new
-      @router          = args[:router] || Deas::Router.new
+      @logger          = args[:logger]          || Deas::NullLogger.new
+      @router          = args[:router]          || Deas::Router.new
       @template_source = args[:template_source] || Deas::NullTemplateSource.new
       @request         = args[:request]
-      @session         = args[:session]
-      @params          = args[:params] || {}
-      @splat           = args[:splat]
+      @params          = args[:params]          || {}
+      @route_path      = args[:route_path].to_s
+      @splat           = args[:splat] # TODO: lazily parse from route path
 
       @handler_class = handler_class
       @handler = @handler_class.new(self)

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -168,12 +168,19 @@ module Deas
         # validate the router
         self.router.validate!
 
+        # TODO: build final middleware stack when building the rack app, not here
+        # (once Sinatra is removed)
+
+        # prepend the method override middleware first.  This ensures that the
+        # it is run before any other middleware
+        self.middlewares.unshift([Rack::MethodOverride]) if self.method_override
+
         # append the show exceptions and logging middlewares last.  This ensures
         # that the logging and exception showing happens just before the app gets
         # the request and just after the app sends a response.
         self.middlewares << [Deas::ShowExceptions] if self.show_exceptions
-        logging_mw_args = [*Deas::Logging.middleware(self.verbose_logging)]
-        self.middlewares << logging_mw_args
+        self.middlewares << Deas::Logging.middleware_args(self.verbose_logging)
+        self.middlewares.freeze
 
         @valid = true # if it made it this far, its valid!
       end

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -53,36 +53,19 @@ module Deas
         self.config.root
       end
 
-      def views_path(value = nil)
-        self.config.views_path = value if !value.nil?
-        self.config.views_path
+      def method_override(value = nil)
+        self.config.method_override = value if !value.nil?
+        self.config.method_override
       end
 
-      def views_root
-        self.config.views_root
+      def show_exceptions(value = nil)
+        self.config.show_exceptions = value if !value.nil?
+        self.config.show_exceptions
       end
 
-      def public_path(value = nil)
-        self.config.public_path = value if !value.nil?
-        self.config.public_path
-      end
-
-      def public_root
-        self.config.public_root
-      end
-
-      def default_encoding(value = nil)
-        self.config.default_encoding = value if !value.nil?
-        self.config.default_encoding
-      end
-
-      def template_helpers(*helper_modules)
-        helper_modules.each{ |m| self.config.template_helpers << m }
-        self.config.template_helpers
-      end
-
-      def template_helper?(helper_module)
-        self.config.template_helpers.include?(helper_module)
+      def verbose_logging(value = nil)
+        self.config.verbose_logging = value if !value.nil?
+        self.config.verbose_logging
       end
 
       def use(*args)
@@ -129,85 +112,31 @@ module Deas
 
       def url_for(*args, &block); self.router.url_for(*args, &block); end
 
-      # flags
-
-      def dump_errors(value = nil)
-        self.config.dump_errors = value if !value.nil?
-        self.config.dump_errors
-      end
-
-      def method_override(value = nil)
-        self.config.method_override = value if !value.nil?
-        self.config.method_override
-      end
-
-      def reload_templates(value = nil)
-        self.config.reload_templates = value if !value.nil?
-        self.config.reload_templates
-      end
-
-      def show_exceptions(value = nil)
-        self.config.show_exceptions = value if !value.nil?
-        self.config.show_exceptions
-      end
-
-      def static_files(value = nil)
-        self.config.static_files = value if !value.nil?
-        self.config.static_files
-      end
-
-      def verbose_logging(value = nil)
-        self.config.verbose_logging = value if !value.nil?
-        self.config.verbose_logging
-      end
-
     end
 
     class Config
 
-      DEFAULT_ENV         = 'development'.freeze
-      DEFAULT_VIEWS_PATH  = 'views'.freeze
-      DEFAULT_PUBLIC_PATH = 'public'.freeze
-      DEFAULT_ENCODING    = 'utf-8'.freeze
+      DEFAULT_ENV = 'development'.freeze
 
-      attr_accessor :env, :root, :views_path, :public_path, :default_encoding
-      attr_accessor :template_helpers, :middlewares
-      attr_accessor :init_procs, :error_procs, :template_source, :logger, :router
-
-      attr_accessor :dump_errors, :method_override, :reload_templates
-      attr_accessor :show_exceptions, :static_files
-      attr_accessor :verbose_logging
+      attr_accessor :env, :root
+      attr_accessor :method_override, :show_exceptions, :verbose_logging
+      attr_accessor :middlewares, :init_procs, :error_procs
+      attr_accessor :template_source, :logger, :router
 
       def initialize
-        @env              = DEFAULT_ENV
-        @root             = ENV['PWD']
-        @views_path       = DEFAULT_VIEWS_PATH
-        @public_path      = DEFAULT_PUBLIC_PATH
-        @default_encoding = DEFAULT_ENCODING
-        @template_helpers = []
-        @middlewares      = []
-        @init_procs       = []
-        @error_procs      = []
-        @template_source  = nil
-        @logger           = Deas::NullLogger.new
-        @router           = Deas::Router.new
-
-        @dump_errors      = false
-        @method_override  = true
-        @reload_templates = false
-        @show_exceptions  = false
-        @static_files     = true
-        @verbose_logging  = true
+        @env             = DEFAULT_ENV
+        @root            = ENV['PWD']
+        @method_override = true
+        @show_exceptions = false
+        @verbose_logging = true
+        @middlewares     = []
+        @init_procs      = []
+        @error_procs     = []
+        @template_source = nil
+        @logger          = Deas::NullLogger.new
+        @router          = Deas::Router.new
 
         @valid = nil
-      end
-
-      def views_root
-        File.expand_path(@views_path.to_s, @root.to_s)
-      end
-
-      def public_root
-        File.expand_path(@public_path.to_s, @root.to_s)
       end
 
       def template_source

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -149,11 +149,6 @@ module Deas
         self.config.reload_templates
       end
 
-      def sessions(value = nil)
-        self.config.sessions = value if !value.nil?
-        self.config.sessions
-      end
-
       def show_exceptions(value = nil)
         self.config.show_exceptions = value if !value.nil?
         self.config.show_exceptions
@@ -183,7 +178,7 @@ module Deas
       attr_accessor :init_procs, :error_procs, :template_source, :logger, :router
 
       attr_accessor :dump_errors, :method_override, :reload_templates
-      attr_accessor :sessions, :show_exceptions, :static_files
+      attr_accessor :show_exceptions, :static_files
       attr_accessor :verbose_logging
 
       def initialize
@@ -204,7 +199,6 @@ module Deas
         @dump_errors      = false
         @method_override  = true
         @reload_templates = false
-        @sessions         = false
         @show_exceptions  = false
         @static_files     = true
         @verbose_logging  = true

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -71,14 +71,6 @@ module Deas
         self.config.default_encoding
       end
 
-      def set(name, value)
-        self.config.settings[name.to_sym] = value
-      end
-
-      def settings
-        self.config.settings
-      end
-
       def template_helpers(*helper_modules)
         helper_modules.each{ |m| self.config.template_helpers << m }
         self.config.template_helpers
@@ -174,7 +166,7 @@ module Deas
       DEFAULT_ENCODING    = 'utf-8'.freeze
 
       attr_accessor :env, :root, :views_path, :public_path, :default_encoding
-      attr_accessor :settings, :template_helpers, :middlewares
+      attr_accessor :template_helpers, :middlewares
       attr_accessor :init_procs, :error_procs, :template_source, :logger, :router
 
       attr_accessor :dump_errors, :method_override, :reload_templates
@@ -187,7 +179,6 @@ module Deas
         @views_path       = DEFAULT_VIEWS_PATH
         @public_path      = DEFAULT_PUBLIC_PATH
         @default_encoding = DEFAULT_ENCODING
-        @settings         = {}
         @template_helpers = []
         @middlewares      = []
         @init_procs       = []
@@ -236,7 +227,7 @@ module Deas
       def validate!
         return @valid if !@valid.nil?  # only need to run this once per config
 
-        # ensure all user and plugin configs/settings are applied
+        # ensure all user and plugin configs are applied
         self.init_procs.each(&:call)
         raise Deas::ServerRootError if self.root.nil?
 

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -31,7 +31,12 @@ module Deas
       # TODO: needed while Deas is powered by Sinatra
       # eventually do an initialize method more like Sanford does
       def new
-        Deas::SinatraApp.new(self.config)
+        begin
+          Deas::SinatraApp.new(self.config)
+        rescue Router::InvalidSplatError => e
+          # reset the exception backtrace to hide Deas internals
+          raise e.class, e.message, caller
+        end
       end
 
       def config

--- a/lib/deas/server_data.rb
+++ b/lib/deas/server_data.rb
@@ -9,12 +9,23 @@ module Deas
 
     attr_reader :error_procs, :template_source, :logger, :router
 
-    def initialize(args = nil)
+    def initialize(args)
       args ||= {}
       @error_procs     = args[:error_procs] || []
       @template_source = args[:template_source]
       @logger          = args[:logger]
       @router          = args[:router]
+    end
+
+    def ==(other_server_data)
+      if other_server_data.kind_of?(ServerData)
+        self.error_procs     == other_server_data.error_procs     &&
+        self.template_source == other_server_data.template_source &&
+        self.logger          == other_server_data.logger          &&
+        self.router          == other_server_data.router
+      else
+        super
+      end
     end
 
   end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 require 'deas/error_handler'
 require 'deas/exceptions'
+require 'deas/request_data'
 require 'deas/server_data'
 
 module Deas

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -33,17 +33,15 @@ module Deas
       })
 
       Sinatra.new do
-        # built-in settings
-        set :environment,      server_config.env
-        set :root,             server_config.root
-        set :views,            server_config.views_root
-        set :public_folder,    server_config.public_root
-        set :default_encoding, server_config.default_encoding
-        set :dump_errors,      server_config.dump_errors
-        set :method_override,  server_config.method_override
-        set :reload_templates, server_config.reload_templates
-        set :static,           server_config.static_files
-        set :sessions,         false
+        # unifying settings - these are used by Deas so extensions can have a
+        # common way to identify these low-level settings.  Deas does not use
+        # them directly
+        set :environment, server_config.env
+        set :root,        server_config.root
+
+        # TODO: rework this and handle it when the router is reworked.  maybe
+        # turn on by default and have setting to force on/off???
+        set :method_override, server_config.method_override
 
         # TODO: sucks to have to do this but b/c of Rack there is no better way
         # to make the server data available to middleware.  We should remove this
@@ -52,12 +50,26 @@ module Deas
         # Not sure right now, just jotting down notes.
         set :deas_server_data, server_data
 
+        # static settings - Deas doesn't care about these anymore so just
+        # use some intelligent defaults
+        set :views,            server_config.root
+        set :public_folder,    server_config.root
+        set :default_encoding, 'utf-8'
+        set :reload_templates, false
+        set :static,           false
+        set :sessions,         false
+
+        # Turn this off b/c Deas won't auto provide it.  We may add an extension
+        # gem or something??
+        disable :protection
+
         # raise_errors and show_exceptions prevent Deas error handlers from being
         # called and Deas' logging doesn't finish. They should always be false.
         set :raise_errors,     false
         set :show_exceptions,  false
 
-        # turn off logging b/c Deas handles its own logging logic
+        # turn off logging, dump_errors b/c Deas handles its own logging logic
+        set :dump_errors,      false
         set :logging,          false
 
         server_config.middlewares.each{ |use_args| use *use_args }

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -66,7 +66,6 @@ module Deas
         # ["application/javascript", "application/xml", "application/xhtml+xml", /^text\//]
         settings.add_charset << "application/json"
 
-        server_config.settings.each{ |set_args| set *set_args }
         server_config.middlewares.each{ |use_args| use *use_args }
 
         # routes

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -39,10 +39,6 @@ module Deas
         set :environment, server_config.env
         set :root,        server_config.root
 
-        # TODO: rework this and handle it when the router is reworked.  maybe
-        # turn on by default and have setting to force on/off???
-        set :method_override, server_config.method_override
-
         # TODO: sucks to have to do this but b/c of Rack there is no better way
         # to make the server data available to middleware.  We should remove this
         # once we remove Sinatra.  Whatever rack app implemenation will needs to
@@ -55,6 +51,7 @@ module Deas
         set :views,            server_config.root
         set :public_folder,    server_config.root
         set :default_encoding, 'utf-8'
+        set :method_override,  false
         set :reload_templates, false
         set :static,           false
         set :sessions,         false

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -60,12 +60,6 @@ module Deas
         # turn off logging b/c Deas handles its own logging logic
         set :logging,          false
 
-        # TODO: rework with `server_config.default_encoding` once we move off of using Sinatra
-        # TODO: could maybe move into a deas-json mixin once off of Sinatra
-        # Add charset to json content type responses - by default only added to these:
-        # ["application/javascript", "application/xml", "application/xhtml+xml", /^text\//]
-        settings.add_charset << "application/json"
-
         server_config.middlewares.each{ |use_args| use *use_args }
 
         # routes
@@ -97,8 +91,6 @@ module Deas
             end
           end
         end
-
-        # error handling
 
         not_found do
           # `self` is the sinatra call in this context

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -92,6 +92,7 @@ module Deas
                 :handler_class => request.env['deas.handler_class'],
                 :handler       => request.env['deas.handler'],
                 :params        => request.env['deas.params'],
+                :splat         => request.env['deas.splat'],
                 :route_path    => request.env['deas.route_path']
               })
             end
@@ -112,11 +113,13 @@ module Deas
             end
             ErrorHandler.run(env['deas.error'], {
               :server_data   => server_data,
-              :request       => self.request,
-              :response      => self.response,
-              :handler_class => self.request.env['deas.handler_class'],
-              :handler       => self.request.env['deas.handler'],
-              :params        => self.request.env['deas.params'],
+              :request       => request,
+              :response      => response,
+              :handler_class => request.env['deas.handler_class'],
+              :handler       => request.env['deas.handler'],
+              :params        => request.env['deas.params'],
+              :splat         => request.env['deas.splat'],
+              :route_path    => request.env['deas.route_path']
             })
           end
         end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -76,10 +76,10 @@ module Deas
               route.run(
                 server_data,
                 RequestData.new({
-                  :route_path => route.path,
                   :request    => request,
                   :response   => response,
-                  :params     => params
+                  :params     => params,
+                  :route_path => route.path
                 })
               )
             rescue *STANDARD_ERROR_CLASSES => err
@@ -92,6 +92,7 @@ module Deas
                 :handler_class => request.env['deas.handler_class'],
                 :handler       => request.env['deas.handler'],
                 :params        => request.env['deas.params'],
+                :route_path    => request.env['deas.route_path']
               })
             end
           end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -27,8 +27,8 @@ module Deas
         :router          => a.delete(:router),
         :template_source => a.delete(:template_source),
         :request         => a.delete(:request),
-        :session         => a.delete(:session),
         :params          => NormalizedParams.new(a.delete(:params) || {}).value,
+        :route_path      => a.delete(:route_path),
         :splat           => a.delete(:splat)
       })
       a.each{|key, value| self.handler.send("#{key}=", value) }

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -28,14 +28,15 @@ module Deas
         :template_source => a.delete(:template_source),
         :request         => a.delete(:request),
         :params          => NormalizedParams.new(a.delete(:params) || {}).value,
-        :route_path      => a.delete(:route_path),
-        :splat           => a.delete(:splat)
+        :route_path      => a.delete(:route_path)
       })
+      @splat = a.delete(:splat)
       a.each{|key, value| self.handler.send("#{key}=", value) }
 
       catch(:halt){ self.handler.deas_init }
     end
 
+    def splat;   @splat;  end
     def halted?; @halted; end
 
     def run

--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -38,16 +38,20 @@ module Deas
     end
 
     def set_named(path, params)
-      params.inject(path) do |path_string, (name, value)|
-        if path_string.include?(":#{name}")
-          if (v = value.to_s).empty?
-            raise EmptyNamedValueError , "an empty value (`#{value.inspect}`) " \
-                                         "was given for the `#{name}` url param"
+      # Process longer param names first. This ensures that shorter names that
+      # compose longer names won't be set as a part of the longer name.
+      params.keys.sort{ |a, b| b.to_s.size <=> a.to_s.size }.inject(path) do |p, name|
+        if p.include?(":#{name}")
+          if (v = params[name].to_s).empty?
+            raise EmptyNamedValueError , "an empty value, " \
+                                         "`#{params[name].inspect}`, " \
+                                         "was given for the " \
+                                         "`#{name.inspect}` url param"
           end
           params.delete(name)
-          path_string.gsub(":#{name}", v)
+          p.gsub(":#{name}", v)
         else
-          path_string
+          p
         end
       end
     end

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -65,7 +65,6 @@ module Deas
 
       # request
       def request; @deas_runner.request; end
-      def session; @deas_runner.session; end
       def params;  @deas_runner.params;  end
       def splat;   @deas_runner.splat;   end
 
@@ -131,7 +130,6 @@ module Deas
       def test_runner(handler_class, args = nil)
         args ||= {}
         args[:request] ||= Rack::Request.new({})
-        args[:session] ||= args[:request].session
         TestRunner.new(handler_class, args)
       end
 

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,9 +1,11 @@
 require 'assert/factory'
 require 'deas/logger'
+require 'deas/request_data'
 require 'deas/router'
 require 'deas/server_data'
 require 'deas/template_source'
 require 'test/support/fake_request'
+require 'test/support/fake_response'
 require 'test/support/fake_sinatra_call'
 
 module Factory
@@ -28,6 +30,20 @@ module Factory
 
   def self.request(args = nil)
     FakeRequest.new(args)
+  end
+
+  def self.response(args = nil)
+    FakeResponse.new(args)
+  end
+
+  def self.request_data(args = nil)
+    args ||= {}
+    Deas::RequestData.new({
+      :route_path => args[:route_path] || Factory.string,
+      :request    => args[:request]    || Factory.request,
+      :response   => args[:response]   || Factory.response,
+      :params     => args[:params]     || { Factory.string => Factory.string }
+    })
   end
 
   def self.sinatra_call(settings = nil)

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -39,10 +39,10 @@ module Factory
   def self.request_data(args = nil)
     args ||= {}
     Deas::RequestData.new({
-      :route_path => args[:route_path] || Factory.string,
       :request    => args[:request]    || Factory.request,
       :response   => args[:response]   || Factory.response,
-      :params     => args[:params]     || { Factory.string => Factory.string }
+      :params     => args[:params]     || { Factory.string => Factory.string },
+      :route_path => args[:route_path] || Factory.string
     })
   end
 

--- a/test/support/fake_request.rb
+++ b/test/support/fake_request.rb
@@ -1,6 +1,7 @@
 require 'ostruct'
 
 class FakeRequest < Struct.new(:http_method, :path, :params, :session, :env)
+
   alias :request_method :http_method
 
   attr_reader :logging_msgs

--- a/test/support/fake_response.rb
+++ b/test/support/fake_response.rb
@@ -1,0 +1,12 @@
+class FakeResponse < Struct.new(:status, :headers, :body)
+
+  def initialize(args = nil)
+    args ||= {}
+    super(*[
+      args[:status]  || Factory.integer,
+      args[:headers] || Rack::Utils::HeaderHash.new,
+      args[:body]    || [Factory.text]
+    ])
+  end
+
+end

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -1,4 +1,5 @@
 require 'test/support/fake_request'
+require 'test/support/fake_response'
 
 class FakeSinatraCall
 
@@ -67,15 +68,4 @@ class FakeSinatraCall
   end
   SendFileArgs = Struct.new(:file_path, :options, :block_call_result)
 
-end
-
-class FakeResponse < Struct.new(:status, :headers, :body)
-  def initialize(args = nil)
-    args ||= {}
-    super(*[
-      args[:status]  || Factory.integer,
-      args[:headers] || {},
-      args[:body]    || [Factory.text]
-    ])
-  end
 end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -46,6 +46,10 @@ class DeasTestServer
     redirect('/:prefix/redirect'){ "/#{params['prefix']}/somewhere" }
   end
 
+  use Rack::Session::Cookie, :key          => 'my.session',
+                             :expire_after => Factory.integer,
+                             :secret       => Factory.string
+
 end
 
 class DeasDevServer
@@ -171,7 +175,7 @@ class SetSessionHandler
   include Deas::ViewHandler
 
   def run!
-    session[:secret] = 'session_secret'
+    request.session[:secret] = 'session_secret'
     redirect '/session'
   end
 
@@ -181,7 +185,7 @@ class UseSessionHandler
   include Deas::ViewHandler
 
   def run!
-    body session[:secret]
+    body request.session[:secret]
   end
 
 end
@@ -194,7 +198,6 @@ class HandlerTestsHandler
     set_data('logger_class_name'){ logger.class.name }
     set_data('request_method'){ request.request_method.to_s }
     set_data('params_a_param'){ params['a-param'] }
-    set_data('session_inspect'){ session.inspect }
   end
 
   def set_data(a, &block)

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -8,8 +8,6 @@ class DeasTestServer
   logger TEST_LOGGER
   verbose_logging Factory.boolean
 
-  set :a_setting, 'something'
-
   error do |exception, context|
     case exception
     when Deas::NotFound

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -14,7 +14,7 @@ class DeasTestServer
     case exception
     when Deas::NotFound
       [404, "Couldn't be found"]
-    when Exception
+    when *Deas::SinatraApp::STANDARD_ERROR_CLASSES
       [500, "Oops, something went wrong"]
     end
   end
@@ -157,7 +157,7 @@ class ErrorHandler
   include Deas::ViewHandler
 
   def run!
-    raise 'test'
+    raise Deas::SinatraApp::STANDARD_ERROR_CLASSES.sample, 'sinatra app standard error'
   end
 
 end

--- a/test/system/deas_tests.rb
+++ b/test/system/deas_tests.rb
@@ -111,14 +111,7 @@ module Deas
   end
 
   class SessionTests < RackTests
-    desc "with sessions enabled"
-    setup do
-      @orig_sessions = @app.settings.sessions
-      @app.set :sessions, true
-    end
-    teardown do
-      @app.set :sessions, @orig_sessions
-    end
+    desc "using sessions"
 
     should "return a 200 response and the session value" do
       post '/session'
@@ -141,8 +134,7 @@ module Deas
       exp = {
         'logger_class_name' => 'Logger',
         'request_method'    => 'GET',
-        'params_a_param'    => 'something',
-        'session_inspect'   => '{}'
+        'params_a_param'    => 'something'
       }
       assert_equal exp.inspect, @data_inspect
     end

--- a/test/system/deas_tests.rb
+++ b/test/system/deas_tests.rb
@@ -160,7 +160,7 @@ module Deas
 
       assert_equal 500, last_response.status
       assert_equal "text/plain", last_response.headers['Content-Type']
-      assert_match "RuntimeError: test", last_response.body
+      assert_match "sinatra app standard error", last_response.body
     end
 
   end

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -12,9 +12,10 @@ class Deas::ErrorHandler
       @server_data      = Factory.server_data(:error_procs => @error_proc_spies)
       @request          = Factory.string
       @response         = Factory.string
-      @handler_class    = Factory.string
+      @handler_class    = Deas::ErrorHandler
       @handler          = Factory.string
       @params           = Factory.string
+      @splat            = Factory.string
       @route_path       = Factory.string
 
       @context_hash = {
@@ -24,10 +25,9 @@ class Deas::ErrorHandler
         :handler_class => @handler_class,
         :handler       => @handler,
         :params        => @params,
+        :splat         => @splat,
         :route_path    => @route_path
       }
-
-      @handler_class = Deas::ErrorHandler
     end
     subject{ @handler_class }
 
@@ -116,7 +116,7 @@ class Deas::ErrorHandler
 
     should have_readers :server_data
     should have_readers :request, :response, :handler_class, :handler
-    should have_readers :params, :route_path
+    should have_readers :params, :splat, :route_path
 
     should "know its attributes" do
       assert_equal @context_hash[:server_data],   subject.server_data
@@ -125,6 +125,7 @@ class Deas::ErrorHandler
       assert_equal @context_hash[:handler_class], subject.handler_class
       assert_equal @context_hash[:handler],       subject.handler
       assert_equal @context_hash[:params],        subject.params
+      assert_equal @context_hash[:splat],         subject.splat
       assert_equal @context_hash[:route_path],    subject.route_path
     end
 
@@ -132,7 +133,16 @@ class Deas::ErrorHandler
       exp = Context.new(@context_hash)
       assert_equal exp, subject
 
-      exp = Context.new({})
+      exp = Context.new({
+        :server_data   => Factory.server_data,
+        :request       => Factory.string,
+        :response      => Factory.string,
+        :handler_class => Factory.string,
+        :handler       => Factory.string,
+        :params        => Factory.string,
+        :splat         => Factory.string,
+        :route_path    => Factory.string
+      })
       assert_not_equal exp, subject
     end
 

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -15,6 +15,7 @@ class Deas::ErrorHandler
       @handler_class    = Factory.string
       @handler          = Factory.string
       @params           = Factory.string
+      @route_path       = Factory.string
 
       @context_hash = {
         :server_data   => @server_data,
@@ -23,6 +24,7 @@ class Deas::ErrorHandler
         :handler_class => @handler_class,
         :handler       => @handler,
         :params        => @params,
+        :route_path    => @route_path
       }
 
       @handler_class = Deas::ErrorHandler
@@ -113,7 +115,8 @@ class Deas::ErrorHandler
     subject{ @context }
 
     should have_readers :server_data
-    should have_readers :request, :response, :handler_class, :handler, :params
+    should have_readers :request, :response, :handler_class, :handler
+    should have_readers :params, :route_path
 
     should "know its attributes" do
       assert_equal @context_hash[:server_data],   subject.server_data
@@ -122,6 +125,7 @@ class Deas::ErrorHandler
       assert_equal @context_hash[:handler_class], subject.handler_class
       assert_equal @context_hash[:handler],       subject.handler
       assert_equal @context_hash[:params],        subject.params
+      assert_equal @context_hash[:route_path],    subject.route_path
     end
 
     should "know if it equals another context" do

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -38,13 +38,10 @@ class Deas::HandlerProxy
 
       Assert.stub(@proxy, :handler_class){ EmptyViewHandler }
 
-      @splat_sym_param    = Factory.string
-      @splat_string_param = Factory.string
-
       @server_data  = Factory.server_data
       @request_data = Factory.request_data(:params => {
-        :splat     => [@splat_sym_param],
-        'splat'    => [@splat_string_param],
+        :splat     => [Factory.string],
+        'splat'    => [Factory.string],
         :captures  => [Factory.string],
         'captures' => [Factory.string]
       })
@@ -66,22 +63,11 @@ class Deas::HandlerProxy
         :template_source => @server_data.template_source,
         :request         => @request_data.request,
         :params          => @request_data.params,
-        :route_path      => @request_data.route_path,
-        :splat           => @splat_sym_param
+        :route_path      => @request_data.route_path
       }
       assert_equal exp_args, @runner_spy.args
 
       assert_true @runner_spy.run_called
-    end
-
-    should "prefer splat sym params over splat string params" do
-      assert_equal @splat_sym_param, @runner_spy.args[:splat]
-
-      @request_data.params['splat'] = [@splat_string_param]
-      proxy = Deas::HandlerProxy.new('EmptyViewHandler')
-      Assert.stub(proxy, :handler_class){ EmptyViewHandler }
-      proxy.run(@server_data, @request_data)
-      assert_equal @splat_string_param, @runner_spy.args[:splat]
     end
 
     should "add data to the request env to make it available to Rack" do
@@ -134,8 +120,11 @@ class Deas::HandlerProxy
       @template_source = args[:template_source]
       @request         = args[:request]
       @params          = args[:params]
-      @splat           = args[:splat]
       @route_path      = args[:route_path]
+
+      # runners parse the splat value from the PATH_INFO and route path. just
+      # use a placeholder value for the spy.
+      @splat = Factory.string
     end
 
     def run

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -38,23 +38,22 @@ class Deas::HandlerProxy
 
       Assert.stub(@proxy, :handler_class){ EmptyViewHandler }
 
-      @server_data        = Factory.server_data
-      @fake_sinatra_call  = Factory.sinatra_call
       @splat_sym_param    = Factory.string
       @splat_string_param = Factory.string
-      @fake_sinatra_call.params = {
+
+      @server_data  = Factory.server_data
+      @request_data = Factory.request_data(:params => {
         :splat     => [@splat_sym_param],
         'splat'    => [@splat_string_param],
         :captures  => [Factory.string],
         'captures' => [Factory.string]
-      }
-
-      @proxy.run(@server_data, @fake_sinatra_call)
+      })
+      @proxy.run(@server_data, @request_data)
     end
 
     should "remove any 'splat' or 'captures' params added by Sinatra's router" do
       [:splat, 'splat', :captures, 'captures'].each do |param_name|
-        assert_nil @fake_sinatra_call.params[param_name]
+        assert_nil @request_data.params[param_name]
       end
     end
 
@@ -65,9 +64,9 @@ class Deas::HandlerProxy
         :logger          => @server_data.logger,
         :router          => @server_data.router,
         :template_source => @server_data.template_source,
-        :request         => @fake_sinatra_call.request,
-        :session         => @fake_sinatra_call.session,
-        :params          => @fake_sinatra_call.params,
+        :request         => @request_data.request,
+        :params          => @request_data.params,
+        :route_path      => @request_data.route_path,
         :splat           => @splat_sym_param
       }
       assert_equal exp_args, @runner_spy.args
@@ -78,22 +77,25 @@ class Deas::HandlerProxy
     should "prefer splat sym params over splat string params" do
       assert_equal @splat_sym_param, @runner_spy.args[:splat]
 
-      @fake_sinatra_call.params['splat'] = [@splat_string_param]
+      @request_data.params['splat'] = [@splat_string_param]
       proxy = Deas::HandlerProxy.new('EmptyViewHandler')
       Assert.stub(proxy, :handler_class){ EmptyViewHandler }
-      proxy.run(@server_data, @fake_sinatra_call)
+      proxy.run(@server_data, @request_data)
       assert_equal @splat_string_param, @runner_spy.args[:splat]
     end
 
     should "add data to the request env to make it available to Rack" do
       exp = subject.handler_class
-      assert_equal exp, @fake_sinatra_call.request.env['deas.handler_class']
+      assert_equal exp, @request_data.request.env['deas.handler_class']
 
       exp = @runner_spy.handler
-      assert_equal exp, @fake_sinatra_call.request.env['deas.handler']
+      assert_equal exp, @request_data.request.env['deas.handler']
 
       exp = @runner_spy.params
-      assert_equal exp, @fake_sinatra_call.request.env['deas.params']
+      assert_equal exp, @request_data.request.env['deas.params']
+
+      exp = @runner_spy.route_path
+      assert_equal exp, @request_data.request.env['deas.route_path']
     end
 
     should "log the handler class name and the params" do
@@ -102,7 +104,7 @@ class Deas::HandlerProxy
         "  Params:  #{@runner_spy.params.inspect}",
         "  Splat:   #{@runner_spy.splat.inspect}"
       ]
-      assert_equal exp_msgs, @fake_sinatra_call.request.logging_msgs
+      assert_equal exp_msgs, @request_data.request.logging_msgs
     end
 
   end
@@ -112,7 +114,7 @@ class Deas::HandlerProxy
     attr_reader :run_called
     attr_reader :handler_class, :handler, :args
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :session, :params, :splat
+    attr_reader :request, :params, :route_path, :splat
 
     def initialize
       @run_called = false
@@ -127,8 +129,8 @@ class Deas::HandlerProxy
       @router          = args[:router]
       @template_source = args[:template_source]
       @request         = args[:request]
-      @session         = args[:session]
       @params          = args[:params]
+      @route_path      = args[:route_path]
       @splat           = args[:splat]
     end
 

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -94,6 +94,9 @@ class Deas::HandlerProxy
       exp = @runner_spy.params
       assert_equal exp, @request_data.request.env['deas.params']
 
+      exp = @runner_spy.splat
+      assert_equal exp, @request_data.request.env['deas.splat']
+
       exp = @runner_spy.route_path
       assert_equal exp, @request_data.request.env['deas.route_path']
     end
@@ -102,7 +105,8 @@ class Deas::HandlerProxy
       exp_msgs = [
         "  Handler: #{subject.handler_class.name}",
         "  Params:  #{@runner_spy.params.inspect}",
-        "  Splat:   #{@runner_spy.splat.inspect}"
+        "  Splat:   #{@runner_spy.splat.inspect}",
+        "  Route:   #{@runner_spy.route_path.inspect}"
       ]
       assert_equal exp_msgs, @request_data.request.logging_msgs
     end
@@ -114,7 +118,7 @@ class Deas::HandlerProxy
     attr_reader :run_called
     attr_reader :handler_class, :handler, :args
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :params, :route_path, :splat
+    attr_reader :request, :params, :splat, :route_path
 
     def initialize
       @run_called = false
@@ -130,8 +134,8 @@ class Deas::HandlerProxy
       @template_source = args[:template_source]
       @request         = args[:request]
       @params          = args[:params]
-      @route_path      = args[:route_path]
       @splat           = args[:splat]
+      @route_path      = args[:route_path]
     end
 
     def run

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -205,9 +205,11 @@ module Deas::Logging
     desc "when init"
     setup do
       @params = { Factory.string => Factory.string }
+      @splat  = Factory.string
       @handler_class = TestHandler
       @env.merge!({
         'deas.params'        => @params,
+        'deas.splat'         => @splat,
         'deas.handler_class' => @handler_class
       })
 
@@ -237,6 +239,7 @@ module Deas::Logging
         'method'  => @env['REQUEST_METHOD'],
         'path'    => @env['PATH_INFO'],
         'params'  => @env['deas.params'],
+        'splat'   => @env['deas.splat'],
         'time'    => @env['deas.time_taken'],
         'status'  => @resp_status,
         'handler' => @handler_class.name,
@@ -253,6 +256,7 @@ module Deas::Logging
         'method'  => @env['REQUEST_METHOD'],
         'path'    => @env['PATH_INFO'],
         'params'  => @env['deas.params'],
+        'splat'   => @env['deas.splat'],
         'time'    => @env['deas.time_taken'],
         'status'  => @resp_status,
         'redir'   => @resp_headers['Location']
@@ -268,6 +272,7 @@ module Deas::Logging
         'method'  => @env['REQUEST_METHOD'],
         'path'    => @env['PATH_INFO'],
         'params'  => @env['deas.params'],
+        'splat'   => @env['deas.splat'],
         'time'    => @env['deas.time_taken'],
         'status'  => @resp_status,
         'handler' => @handler_class.name,
@@ -282,7 +287,7 @@ module Deas::Logging
     subject{ Deas::SummaryLine }
 
     should "output its attributes in a specific order" do
-      assert_equal %w{time status method path handler params redir}, subject.keys
+      assert_equal %w{time status method path handler params splat redir}, subject.keys
     end
 
     should "output its attributes in a single line" do
@@ -293,6 +298,7 @@ module Deas::Logging
         'path'    => 'pth',
         'handler' => 'h',
         'params'  => 'p',
+        'splat'   => 'spl',
         'redir'   => 'r'
       }
       exp_line = "time=\"t\" "\
@@ -301,6 +307,7 @@ module Deas::Logging
                  "path=\"pth\" "\
                  "handler=\"h\" "\
                  "params=\"p\" "\
+                 "splat=\"spl\" "\
                  "redir=\"r\""
       assert_equal exp_line, subject.new(line_attrs)
     end

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -7,11 +7,11 @@ module Deas::Logging
     desc "Deas::Logging"
     subject{ Deas::Logging }
 
-    should have_imeths :middleware
+    should have_imeths :middleware_args
 
-    should "return a middleware class given a verbose flag" do
-      assert_equal Deas::VerboseLogging, subject.middleware(true)
-      assert_equal Deas::SummaryLogging, subject.middleware(false)
+    should "return middleware args given a verbose flag" do
+      assert_equal [Deas::VerboseLogging], subject.middleware_args(true)
+      assert_equal [Deas::SummaryLogging], subject.middleware_args(false)
     end
 
   end

--- a/test/unit/request_data_tests.rb
+++ b/test/unit/request_data_tests.rb
@@ -11,14 +11,14 @@ class Deas::RequestData
       @params     = Factory.string
       @route_path = Factory.string
 
-      @server_data = Deas::RequestData.new({
+      @request_data = Deas::RequestData.new({
         :request    => @request,
         :response   => @response,
         :params     => @params,
         :route_path => @route_path
       })
     end
-    subject{ @server_data }
+    subject{ @request_data }
 
     should have_readers :request, :response, :params, :route_path
 
@@ -37,6 +37,20 @@ class Deas::RequestData
       assert_nil request_data.params
       assert_nil request_data.route_path
     end
+
+    should "know if it is equal to another request data" do
+      request_data = Deas::RequestData.new({
+        :request    => @request,
+        :response   => @response,
+        :params     => @params,
+        :route_path => @route_path
+      })
+      assert_equal request_data, subject
+
+      request_data = Deas::RequestData.new({})
+      assert_not_equal request_data, subject
+    end
+
 
   end
 

--- a/test/unit/request_data_tests.rb
+++ b/test/unit/request_data_tests.rb
@@ -1,0 +1,43 @@
+require 'assert'
+require 'deas/request_data'
+
+class Deas::RequestData
+
+  class UnitTests < Assert::Context
+    desc "Deas::RequestData"
+    setup do
+      @route_path = Factory.string
+      @request    = Factory.string
+      @response   = Factory.string
+      @params     = Factory.string
+
+      @server_data = Deas::RequestData.new({
+        :route_path => @route_path,
+        :request    => @request,
+        :response   => @response,
+        :params     => @params
+      })
+    end
+    subject{ @server_data }
+
+    should have_readers :route_path, :request, :response, :params
+
+    should "know its attributes" do
+      assert_equal @route_path, subject.route_path
+      assert_equal @request,    subject.request
+      assert_equal @response,   subject.response
+      assert_equal @params,     subject.params
+    end
+
+    should "default its attributes when they aren't provided" do
+      request_data = Deas::RequestData.new({})
+
+      assert_nil request_data.route_path
+      assert_nil request_data.request
+      assert_nil request_data.response
+      assert_nil request_data.params
+    end
+
+  end
+
+end

--- a/test/unit/request_data_tests.rb
+++ b/test/unit/request_data_tests.rb
@@ -6,36 +6,36 @@ class Deas::RequestData
   class UnitTests < Assert::Context
     desc "Deas::RequestData"
     setup do
-      @route_path = Factory.string
       @request    = Factory.string
       @response   = Factory.string
       @params     = Factory.string
+      @route_path = Factory.string
 
       @server_data = Deas::RequestData.new({
-        :route_path => @route_path,
         :request    => @request,
         :response   => @response,
-        :params     => @params
+        :params     => @params,
+        :route_path => @route_path
       })
     end
     subject{ @server_data }
 
-    should have_readers :route_path, :request, :response, :params
+    should have_readers :request, :response, :params, :route_path
 
     should "know its attributes" do
-      assert_equal @route_path, subject.route_path
       assert_equal @request,    subject.request
       assert_equal @response,   subject.response
       assert_equal @params,     subject.params
+      assert_equal @route_path, subject.route_path
     end
 
     should "default its attributes when they aren't provided" do
       request_data = Deas::RequestData.new({})
 
-      assert_nil request_data.route_path
       assert_nil request_data.request
       assert_nil request_data.response
       assert_nil request_data.params
+      assert_nil request_data.route_path
     end
 
   end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -10,8 +10,8 @@ class Deas::Route
   class UnitTests < Assert::Context
     desc "Deas::Route"
     setup do
-      @req_type_name = Factory.string
-      @proxy = HandlerProxySpy.new
+      @req_type_name   = Factory.string
+      @proxy           = HandlerProxySpy.new
       @handler_proxies = Hash.new{ |h, k| raise(Deas::HandlerProxyNotFound) }.tap do |h|
         h[@req_type_name] = @proxy
       end
@@ -40,46 +40,46 @@ class Deas::Route
   class RunTests < UnitTests
     desc "when run"
     setup do
-      @server_data       = Factory.server_data
-      @fake_sinatra_call = Factory.sinatra_call
+      @server_data  = Factory.server_data
+      @request_data = Factory.request_data
     end
 
     should "run the proxy for the given request type name" do
       Assert.stub(@server_data.router, :request_type_name).with(
-        @fake_sinatra_call.request
+        @request_data.request
       ){ @req_type_name }
 
-      @route.run(@server_data, @fake_sinatra_call)
+      @route.run(@server_data, @request_data)
       assert_true @proxy.run_called
+      assert_equal @server_data, @proxy.server_data
+      assert_equal @request_data, @proxy.request_data
     end
 
     should "halt 404 if it can't find a proxy for the given request type name" do
-      halt_value = catch(:halt) do
-        @route.run(@server_data, @fake_sinatra_call)
-      end
-      assert_equal [404], halt_value
+      exp = [404, Rack::Utils::HeaderHash.new, []]
+      assert_equal exp, @route.run(@server_data, @request_data)
     end
 
   end
 
   class HandlerProxySpy
 
-    attr_reader :validate_called, :run_called, :server_data, :sinatra_call
+    attr_reader :validate_called, :run_called, :server_data, :request_data
 
     def initialize
       @run_called      = false
       @validate_called = false
       @server_data     = nil
-      @sinatra_call    = nil
+      @request_data    = nil
     end
 
     def validate!
       @validate_called = true
     end
 
-    def run(server_data, sinatra_call)
-      @server_data  = sinatra_call
-      @sinatra_call = sinatra_call
+    def run(server_data, request_data)
+      @server_data  = server_data
+      @request_data = request_data
       @run_called   = true
     end
 

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -371,12 +371,17 @@ class Deas::Router
     end
 
     should "complain if adding a route with invalid splats in its path" do
-      [ "/something/*/other/*",
+      [ "/something/other*/",
+        "/something/other*",
+        "/something/*other",
+        "/something*/other",
+        "/*something/other",
+        "/something/*/other/*",
         "/something/*/other",
         "/something/*/",
         "/*/something",
       ].each do |path|
-        assert_raises ArgumentError do
+        assert_raises InvalidSplatError do
           router = @router_class.new
           router.route(:get, path)
           router.apply_definitions!

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -43,7 +43,7 @@ class Deas::Router
     should have_imeths :route, :redirect, :not_found
     should have_imeths :apply_definitions!, :validate!
 
-    should "default its settings" do
+    should "default its attrs" do
       router = @router_class.new
       assert_nil router.view_handler_ns
       assert_nil router.base_url

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -45,7 +45,7 @@ class Deas::Runner
 
     should have_readers :handler_class, :handler
     should have_readers :logger, :router, :template_source
-    should have_readers :request, :session, :params, :splat
+    should have_readers :request, :params, :route_path, :splat
     should have_imeths :run, :to_rack
     should have_imeths :status, :headers, :body, :content_type
     should have_imeths :halt, :redirect, :send_file
@@ -63,20 +63,22 @@ class Deas::Runner
       assert_kind_of Deas::NullTemplateSource, runner.template_source
 
       assert_nil runner.request
-      assert_nil runner.session
 
-      assert_equal({}, runner.params)
+      assert_equal Hash.new, runner.params
+      assert_equal '',       runner.route_path
+
+      assert_nil runner.splat
     end
 
     should "know its attrs" do
       args = {
-        :logger          => 'a-logger',
-        :router          => 'a-router',
-        :template_source => 'a-source',
-        :request         => 'a-request',
-        :session         => 'a-session',
-        :params          => {},
-        :splat           => 'a-splat'
+        :logger          => Factory.string,
+        :router          => Factory.string,
+        :template_source => Factory.string,
+        :request         => Factory.request,
+        :params          => { Factory.string => Factory.string },
+        :route_path      => Factory.string,
+        :splat           => Factory.string
       }
 
       runner = @runner_class.new(@handler_class, args)
@@ -85,8 +87,8 @@ class Deas::Runner
       assert_equal args[:router],          runner.router
       assert_equal args[:template_source], runner.template_source
       assert_equal args[:request],         runner.request
-      assert_equal args[:session],         runner.session
       assert_equal args[:params],          runner.params
+      assert_equal args[:route_path],      runner.route_path
       assert_equal args[:splat],           runner.splat
     end
 

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -30,12 +30,25 @@ class Deas::ServerData
     end
 
     should "default its attributes when they aren't provided" do
-      server_data = Deas::ServerData.new
+      server_data = Deas::ServerData.new({})
 
       assert_equal [], server_data.error_procs
       assert_nil server_data.logger
       assert_nil server_data.router
       assert_nil server_data.template_source
+    end
+
+    should "know if it is equal to another server data" do
+      server_data = Deas::ServerData.new({
+        :error_procs     => @error_procs,
+        :logger          => @logger,
+        :router          => @router,
+        :template_source => @template_source
+      })
+      assert_equal server_data, subject
+
+      server_data = Deas::ServerData.new({})
+      assert_not_equal server_data, subject
     end
 
   end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -20,15 +20,11 @@ module Deas::Server
 
     should have_imeths :new, :config
 
-    should have_imeths :env, :root, :views_path, :views_root
-    should have_imeths :public_path, :public_root, :default_encoding
-    should have_imeths :template_helpers, :template_helper?
-    should have_imeths :use, :middlewares, :init, :init_procs, :error, :error_procs
+    should have_imeths :env, :root
+    should have_imeths :method_override, :show_exceptions, :verbose_logging
+    should have_imeths :use, :middlewares
+    should have_imeths :init, :init_procs, :error, :error_procs
     should have_imeths :template_source, :logger, :router, :url_for
-
-    should have_imeths :dump_errors, :method_override, :reload_templates
-    should have_imeths :show_exceptions, :static_files
-    should have_imeths :verbose_logging
 
     should "use much-plugin" do
       assert_includes MuchPlugin, Deas::Server
@@ -45,17 +41,17 @@ module Deas::Server
       subject.root exp
       assert_equal exp, config.root
 
-      exp = Factory.path
-      subject.views_path exp
-      assert_equal exp, config.views_path
+      exp = Factory.boolean
+      subject.method_override exp
+      assert_equal exp, config.method_override
 
-      exp = Factory.path
-      subject.public_path exp
-      assert_equal exp, config.public_path
+      exp = Factory.boolean
+      subject.show_exceptions exp
+      assert_equal exp, config.show_exceptions
 
-      exp = Factory.string
-      subject.default_encoding exp
-      assert_equal exp, config.default_encoding
+      exp = Factory.boolean
+      subject.verbose_logging exp
+      assert_equal exp, config.verbose_logging
 
       exp = ['MyMiddleware', Factory.string]
       subject.use *exp
@@ -80,43 +76,12 @@ module Deas::Server
       exp = Logger.new(STDOUT)
       subject.logger exp
       assert_equal exp, config.logger
-
-      exp = Factory.boolean
-      subject.dump_errors exp
-      assert_equal exp, config.dump_errors
-
-      exp = Factory.boolean
-      subject.method_override exp
-      assert_equal exp, config.method_override
-
-      exp = Factory.boolean
-      subject.reload_templates exp
-      assert_equal exp, config.reload_templates
-
-      exp = Factory.boolean
-      subject.show_exceptions exp
-      assert_equal exp, config.show_exceptions
-
-      exp = Factory.boolean
-      subject.static_files exp
-      assert_equal exp, config.static_files
-
-      exp = Factory.boolean
-      subject.verbose_logging exp
-      assert_equal exp, config.verbose_logging
     end
 
-    should "demeter its config values that aren't directly set" do
-      assert_equal subject.config.views_root,  subject.views_root
-      assert_equal subject.config.public_root, subject.public_root
+    should "demeter its config values that aren't set directly" do
       assert_equal subject.config.middlewares, subject.middlewares
       assert_equal subject.config.init_procs,  subject.init_procs
       assert_equal subject.config.error_procs, subject.error_procs
-    end
-
-    should "add and query helper modules" do
-      subject.template_helpers(helper_module = Module.new)
-      assert_true subject.template_helper?(helper_module)
     end
 
     should "have a router by default and allow overriding it" do
@@ -159,22 +124,16 @@ module Deas::Server
     end
     subject{ @config }
 
-    should have_accessors :env, :root, :views_path, :public_path, :default_encoding
-    should have_accessors :template_helpers, :middlewares
-    should have_accessors :init_procs, :error_procs, :template_source, :logger, :router
+    should have_accessors :env, :root
+    should have_accessors :method_override, :show_exceptions, :verbose_logging
+    should have_accessors :middlewares, :init_procs, :error_procs
+    should have_accessors :template_source, :logger, :router
 
-    should have_accessors :dump_errors, :method_override, :reload_templates
-    should have_accessors :show_exceptions, :static_files
-    should have_accessors :verbose_logging
-
-    should have_imeths :views_root, :public_root, :urls, :routes
+    should have_imeths :urls, :routes
     should have_imeths :valid?, :validate!
 
-    should "know its default attr values" do
+    should "know its default env" do
       assert_equal 'development', @config_class::DEFAULT_ENV
-      assert_equal 'views',       @config_class::DEFAULT_VIEWS_PATH
-      assert_equal 'public',      @config_class::DEFAULT_PUBLIC_PATH
-      assert_equal 'utf-8',       @config_class::DEFAULT_ENCODING
     end
 
     should "default its attrs" do
@@ -184,16 +143,10 @@ module Deas::Server
       exp = ENV['PWD']
       assert_equal exp, subject.root
 
-      exp = @config_class::DEFAULT_VIEWS_PATH
-      assert_equal exp, subject.views_path
+      assert_equal true,  subject.method_override
+      assert_equal false, subject.show_exceptions
+      assert_equal true,  subject.verbose_logging
 
-      exp = @config_class::DEFAULT_PUBLIC_PATH
-      assert_equal exp, subject.public_path
-
-      exp = @config_class::DEFAULT_ENCODING
-      assert_equal exp, subject.default_encoding
-
-      assert_equal [], subject.template_helpers
       assert_equal [], subject.middlewares
       assert_equal [], subject.init_procs
       assert_equal [], subject.error_procs
@@ -203,21 +156,6 @@ module Deas::Server
 
       assert_instance_of Deas::NullLogger, subject.logger
       assert_instance_of Deas::Router,     subject.router
-
-      assert_equal false, subject.dump_errors
-      assert_equal true,  subject.method_override
-      assert_equal false, subject.reload_templates
-      assert_equal false, subject.show_exceptions
-      assert_equal true,  subject.static_files
-      assert_equal true,  subject.verbose_logging
-    end
-
-    should "know its views root and public root" do
-      exp = File.expand_path(subject.views_path.to_s, subject.root.to_s)
-      assert_equal exp, subject.views_root
-
-      exp = File.expand_path(subject.public_path.to_s, subject.root.to_s)
-      assert_equal exp, subject.public_root
     end
 
     should "demeter its router" do

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -27,7 +27,7 @@ module Deas::Server
     should have_imeths :template_source, :logger, :router, :url_for
 
     should have_imeths :dump_errors, :method_override, :reload_templates
-    should have_imeths :sessions, :show_exceptions, :static_files
+    should have_imeths :show_exceptions, :static_files
     should have_imeths :verbose_logging
 
     should "use much-plugin" do
@@ -96,10 +96,6 @@ module Deas::Server
       exp = Factory.boolean
       subject.reload_templates exp
       assert_equal exp, config.reload_templates
-
-      exp = Factory.boolean
-      subject.sessions exp
-      assert_equal exp, config.sessions
 
       exp = Factory.boolean
       subject.show_exceptions exp
@@ -173,7 +169,7 @@ module Deas::Server
     should have_accessors :init_procs, :error_procs, :template_source, :logger, :router
 
     should have_accessors :dump_errors, :method_override, :reload_templates
-    should have_accessors :sessions, :show_exceptions, :static_files
+    should have_accessors :show_exceptions, :static_files
     should have_accessors :verbose_logging
 
     should have_imeths :views_root, :public_root, :urls, :routes
@@ -217,7 +213,6 @@ module Deas::Server
       assert_equal false, subject.dump_errors
       assert_equal true,  subject.method_override
       assert_equal false, subject.reload_templates
-      assert_equal false, subject.sessions
       assert_equal false, subject.show_exceptions
       assert_equal true,  subject.static_files
       assert_equal true,  subject.verbose_logging

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -22,7 +22,7 @@ module Deas::Server
 
     should have_imeths :env, :root, :views_path, :views_root
     should have_imeths :public_path, :public_root, :default_encoding
-    should have_imeths :set, :settings, :template_helpers, :template_helper?
+    should have_imeths :template_helpers, :template_helper?
     should have_imeths :use, :middlewares, :init, :init_procs, :error, :error_procs
     should have_imeths :template_source, :logger, :router, :url_for
 
@@ -56,10 +56,6 @@ module Deas::Server
       exp = Factory.string
       subject.default_encoding exp
       assert_equal exp, config.default_encoding
-
-      exp = { Factory.string.to_sym => Factory.string }
-      subject.set exp.keys.first, exp.values.first
-      assert_equal exp, config.settings
 
       exp = ['MyMiddleware', Factory.string]
       subject.use *exp
@@ -113,7 +109,6 @@ module Deas::Server
     should "demeter its config values that aren't directly set" do
       assert_equal subject.config.views_root,  subject.views_root
       assert_equal subject.config.public_root, subject.public_root
-      assert_equal subject.config.settings,    subject.settings
       assert_equal subject.config.middlewares, subject.middlewares
       assert_equal subject.config.init_procs,  subject.init_procs
       assert_equal subject.config.error_procs, subject.error_procs
@@ -165,7 +160,7 @@ module Deas::Server
     subject{ @config }
 
     should have_accessors :env, :root, :views_path, :public_path, :default_encoding
-    should have_accessors :settings, :template_helpers, :middlewares
+    should have_accessors :template_helpers, :middlewares
     should have_accessors :init_procs, :error_procs, :template_source, :logger, :router
 
     should have_accessors :dump_errors, :method_override, :reload_templates
@@ -198,11 +193,10 @@ module Deas::Server
       exp = @config_class::DEFAULT_ENCODING
       assert_equal exp, subject.default_encoding
 
-      assert_equal Hash.new, subject.settings
-      assert_equal [],       subject.template_helpers
-      assert_equal [],       subject.middlewares
-      assert_equal [],       subject.init_procs
-      assert_equal [],       subject.error_procs
+      assert_equal [], subject.template_helpers
+      assert_equal [], subject.middlewares
+      assert_equal [], subject.init_procs
+      assert_equal [], subject.error_procs
 
       assert_instance_of Deas::NullTemplateSource, subject.template_source
       assert_equal subject.root, subject.template_source.path

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -14,6 +14,23 @@ module Deas::SinatraApp
 
   class UnitTests < Assert::Context
     desc "Deas::SinatraApp"
+    subject{ Deas::SinatraApp }
+
+    should have_imeths :new
+
+    should "know its default error response status" do
+      assert_equal 500, subject::DEFAULT_ERROR_RESPONSE_STATUS
+    end
+
+    should "know its standard error classes" do
+      exp = [StandardError, LoadError, NotImplementedError, Timeout::Error]
+      assert_equal exp, subject::STANDARD_ERROR_CLASSES
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
     setup do
       @router = Deas::Router.new
       @router.get('/something', 'EmptyViewHandler')

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -75,12 +75,7 @@ module Deas::SinatraApp
         :router          => @config.router,
         :template_source => @config.template_source
       })
-      sd = s.deas_server_data
-      assert_instance_of Deas::ServerData, sd
-      assert_instance_of exp.template_source.class, sd.template_source
-      assert_instance_of exp.logger.class, sd.logger
-      assert_equal exp.error_procs, sd.error_procs
-      assert_equal exp.router,      sd.router
+      assert_equal exp, s.deas_server_data
 
       assert_includes "application/json", s.add_charset
     end

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -47,27 +47,16 @@ module Deas::SinatraApp
       assert @config.valid?
     end
 
-    should "be a kind of Sinatra::Base" do
+    should "be a kind of Sinatra::Base app" do
       assert_equal Sinatra::Base, subject.superclass
     end
 
-    should "have it's configuration set based on the server config" do
+    should "have it's configuration set based on the server config or defaults" do
       s = subject.settings
 
       assert_equal @config.env,              s.environment
       assert_equal @config.root,             s.root
-      assert_equal @config.views_root,       s.views
-      assert_equal @config.public_root,      s.public_folder
-      assert_equal @config.default_encoding, s.default_encoding
-      assert_equal @config.dump_errors,      s.dump_errors
       assert_equal @config.method_override,  s.method_override
-      assert_equal @config.reload_templates, s.reload_templates
-      assert_equal @config.static_files,     s.static
-
-      assert_false s.sessions
-      assert_false s.raise_errors
-      assert_false s.show_exceptions
-      assert_false s.logging
 
       exp = Deas::ServerData.new({
         :error_procs     => @config.error_procs,
@@ -76,6 +65,19 @@ module Deas::SinatraApp
         :template_source => @config.template_source
       })
       assert_equal exp, s.deas_server_data
+
+      assert_equal @config.root, s.views
+      assert_equal @config.root, s.public_folder
+      assert_equal 'utf-8',      s.default_encoding
+
+      assert_false s.static
+      assert_false s.reload_templates
+      assert_false s.sessions
+      assert_false s.protection
+      assert_false s.raise_errors
+      assert_false s.show_exceptions
+      assert_false s.dump_errors
+      assert_false s.logging
     end
 
     should "define Sinatra routes for every route in the configuration" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -76,8 +76,6 @@ module Deas::SinatraApp
         :template_source => @config.template_source
       })
       assert_equal exp, s.deas_server_data
-
-      assert_includes "application/json", s.add_charset
     end
 
     should "define Sinatra routes for every route in the configuration" do

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -54,9 +54,8 @@ module Deas::SinatraApp
     should "have it's configuration set based on the server config or defaults" do
       s = subject.settings
 
-      assert_equal @config.env,              s.environment
-      assert_equal @config.root,             s.root
-      assert_equal @config.method_override,  s.method_override
+      assert_equal @config.env,  s.environment
+      assert_equal @config.root, s.root
 
       exp = Deas::ServerData.new({
         :error_procs     => @config.error_procs,
@@ -70,8 +69,9 @@ module Deas::SinatraApp
       assert_equal @config.root, s.public_folder
       assert_equal 'utf-8',      s.default_encoding
 
-      assert_false s.static
+      assert_false s.method_override
       assert_false s.reload_templates
+      assert_false s.static
       assert_false s.sessions
       assert_false s.protection
       assert_false s.raise_errors

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -45,12 +45,12 @@ module Deas::SinatraApp
       assert_equal @config.dump_errors,      s.dump_errors
       assert_equal @config.method_override,  s.method_override
       assert_equal @config.reload_templates, s.reload_templates
-      assert_equal @config.sessions,         s.sessions
       assert_equal @config.static_files,     s.static
 
-      assert_equal false, s.raise_errors
-      assert_equal false, s.show_exceptions
-      assert_equal false, s.logging
+      assert_false s.sessions
+      assert_false s.raise_errors
+      assert_false s.show_exceptions
+      assert_false s.logging
 
       exp = Deas::ServerData.new({
         :error_procs     => @config.error_procs,
@@ -74,6 +74,8 @@ module Deas::SinatraApp
 
       assert_not_nil sinatra_routes.detect{ |r| r[0].match(router_route.path) }
     end
+
+    # System tests ensure that routes get applied to the sinatra app correctly.
 
   end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -33,8 +33,8 @@ class Deas::TestRunner
         :router          => Factory.string,
         :template_source => Factory.string,
         :request         => @request,
-        :session         => Factory.string,
         :params          => @params,
+        :route_path      => Factory.string,
         :splat           => Factory.path,
         :custom_value    => Factory.integer
       }
@@ -62,8 +62,8 @@ class Deas::TestRunner
       assert_equal @args[:router],          subject.router
       assert_equal @args[:template_source], subject.template_source
       assert_equal @args[:request],         subject.request
-      assert_equal @args[:session],         subject.session
       assert_equal @args[:params],          subject.params
+      assert_equal @args[:route_path],      subject.route_path
       assert_equal @args[:splat],           subject.splat
     end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -49,7 +49,7 @@ class Deas::TestRunner
     subject{ @runner }
 
     should have_readers :content_type_args
-    should have_imeths :halted?, :run
+    should have_imeths :splat, :halted?, :run
 
     should "raise an invalid error when passed a non view handler" do
       assert_raises(Deas::InvalidViewHandlerError) do
@@ -64,7 +64,10 @@ class Deas::TestRunner
       assert_equal @args[:request],         subject.request
       assert_equal @args[:params],          subject.params
       assert_equal @args[:route_path],      subject.route_path
-      assert_equal @args[:splat],           subject.splat
+    end
+
+    should "know its splat value" do
+      assert_equal @args[:splat], subject.splat
     end
 
     should "call to normalize its params" do

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -87,6 +87,17 @@ class Deas::Url
       })
     end
 
+    should "apply composed named params" do
+      url = Deas::Url.new(:some_thing, '/:some/:something/:something_else')
+
+      exp_path = '/a/goose/cooked'
+      assert_equal exp_path, url.path_for({
+        'some'           => 'a',
+        :something       => 'goose',
+        'something_else' => 'cooked'
+      })
+    end
+
     should "complain if given an empty named param value" do
       params = {
         'some' => 'a',
@@ -99,8 +110,8 @@ class Deas::Url
       err = assert_raises EmptyNamedValueError do
         subject.path_for(params)
       end
-      exp = "an empty value (`#{empty_param_value.inspect}`) "\
-            "was given for the `#{empty_param_name}` url param"
+      exp = "an empty value, `#{empty_param_value.inspect}`, "\
+            "was given for the `#{empty_param_name.inspect}` url param"
       assert_equal exp, err.message
     end
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -232,11 +232,6 @@ module Deas::ViewHandler
       assert_equal @runner.request, subject.instance_eval{ request }
     end
 
-    should "call to the runner for its session" do
-      stub_runner_with_something_for(:session)
-      assert_equal @runner.session, subject.instance_eval{ session }
-    end
-
     should "call to the runner for its params" do
       stub_runner_with_something_for(:params)
       assert_equal @runner.params, subject.instance_eval{ params }
@@ -391,8 +386,7 @@ module Deas::ViewHandler
       runner  = subject.test_runner(@handler_class)
 
       assert_kind_of ::Deas::TestRunner, runner
-      assert_kind_of Rack::Request,  runner.request
-      assert_equal runner.request.session, runner.session
+      assert_kind_of ::Rack::Request,    runner.request
     end
 
     should "return an initialized handler instance" do


### PR DESCRIPTION
This removes things that Deas won't support once Sinatra is removed.  This also reworks some features that were provided by Sinatra to be provided by Deas directly.

@jcredding FYI.