### PR TITLE
default the config env to RACK ENV; fallback to 'development'

### DIFF
--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -124,7 +124,7 @@ module Deas
       attr_accessor :template_source, :logger, :router
 
       def initialize
-        @env             = DEFAULT_ENV
+        @env             = ENV['RACK_ENV'] || DEFAULT_ENV
         @root            = ENV['PWD']
         @method_override = true
         @show_exceptions = false

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -158,6 +158,13 @@ module Deas::Server
       assert_instance_of Deas::Router,     subject.router
     end
 
+    should "prefer RACK ENV over its default env" do
+      prev_env = ENV['RACK_ENV']
+      ENV['RACK_ENV'] = Factory.string
+      assert_equal ENV['RACK_ENV'], @config_class.new.env
+      ENV['RACK_ENV'] = prev_env
+    end
+
     should "demeter its router" do
       assert_equal subject.router.urls,   subject.urls
       assert_equal subject.router.routes, subject.routes


### PR DESCRIPTION
This allows the user to not have to config an env at all if they
intend on just setting `ENV['RACK_ENV']`.  I noticed this as I
was removing Sinatra as this is something it does.  Plus I feel
like this is being a "good citizen".

@jcredding ready for review.