### PR TITLE
Allow adding before/after route run procs

### DIFF
--- a/lib/deas/route.rb
+++ b/lib/deas/route.rb
@@ -17,11 +17,18 @@ module Deas
     end
 
     def run(server_data, request_data)
+      server_data.before_route_run_procs.each do |c|
+        c.call(server_data, request_data)
+      end
       request_type_name = server_data.router.request_type_name(request_data.request)
       begin
         @handler_proxies[request_type_name].run(server_data, request_data)
       rescue HandlerProxyNotFound
         [404, Rack::Utils::HeaderHash.new, []]
+      ensure
+        server_data.after_route_run_procs.each do |c|
+          c.call(server_data, request_data)
+        end
       end
     end
 

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -92,6 +92,22 @@ module Deas
         self.config.error_procs
       end
 
+      def before_route_run(&block)
+        self.config.before_route_run_procs << block
+      end
+
+      def before_route_run_procs
+        self.config.before_route_run_procs
+      end
+
+      def after_route_run(&block)
+        self.config.after_route_run_procs << block
+      end
+
+      def after_route_run_procs
+        self.config.after_route_run_procs
+      end
+
       def template_source(value = nil)
         self.config.template_source = value if !value.nil?
         self.config.template_source
@@ -121,20 +137,23 @@ module Deas
       attr_accessor :env, :root
       attr_accessor :method_override, :show_exceptions, :verbose_logging
       attr_accessor :middlewares, :init_procs, :error_procs
+      attr_accessor :before_route_run_procs, :after_route_run_procs
       attr_accessor :template_source, :logger, :router
 
       def initialize
-        @env             = DEFAULT_ENV
-        @root            = ENV['PWD']
-        @method_override = true
-        @show_exceptions = false
-        @verbose_logging = true
-        @middlewares     = []
-        @init_procs      = []
-        @error_procs     = []
-        @template_source = nil
-        @logger          = Deas::NullLogger.new
-        @router          = Deas::Router.new
+        @env                    = DEFAULT_ENV
+        @root                   = ENV['PWD']
+        @method_override        = true
+        @show_exceptions        = false
+        @verbose_logging        = true
+        @middlewares            = []
+        @init_procs             = []
+        @error_procs            = []
+        @before_route_run_procs = []
+        @after_route_run_procs  = []
+        @template_source        = nil
+        @logger                 = Deas::NullLogger.new
+        @router                 = Deas::Router.new
 
         @valid = nil
       end

--- a/lib/deas/server_data.rb
+++ b/lib/deas/server_data.rb
@@ -7,22 +7,27 @@ module Deas
     # to provide these with a simplified interface with the minimal data needed
     # and to decouple the configuration from each thing that needs its data.
 
-    attr_reader :error_procs, :template_source, :logger, :router
+    attr_reader :error_procs, :before_route_run_procs, :after_route_run_procs
+    attr_reader :template_source, :logger, :router
 
     def initialize(args)
       args ||= {}
-      @error_procs     = args[:error_procs] || []
-      @template_source = args[:template_source]
-      @logger          = args[:logger]
-      @router          = args[:router]
+      @error_procs            = args[:error_procs] || []
+      @before_route_run_procs = args[:before_route_run_procs] || []
+      @after_route_run_procs  = args[:after_route_run_procs] || []
+      @template_source        = args[:template_source]
+      @logger                 = args[:logger]
+      @router                 = args[:router]
     end
 
     def ==(other_server_data)
       if other_server_data.kind_of?(ServerData)
-        self.error_procs     == other_server_data.error_procs     &&
-        self.template_source == other_server_data.template_source &&
-        self.logger          == other_server_data.logger          &&
-        self.router          == other_server_data.router
+        self.before_route_run_procs == other_server_data.before_route_run_procs &&
+        self.after_route_run_procs  == other_server_data.after_route_run_procs  &&
+        self.error_procs            == other_server_data.error_procs            &&
+        self.template_source        == other_server_data.template_source        &&
+        self.logger                 == other_server_data.logger                 &&
+        self.router                 == other_server_data.router
       else
         super
       end

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -27,10 +27,12 @@ module Deas
       # server's initialization logic more like Sanford does.
       server_config.validate!
       server_data = ServerData.new({
-        :error_procs     => server_config.error_procs,
-        :logger          => server_config.logger,
-        :router          => server_config.router,
-        :template_source => server_config.template_source
+        :error_procs            => server_config.error_procs,
+        :before_route_run_procs => server_config.before_route_run_procs,
+        :after_route_run_procs  => server_config.after_route_run_procs,
+        :logger                 => server_config.logger,
+        :router                 => server_config.router,
+        :template_source        => server_config.template_source
       })
 
       Sinatra.new do

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -40,7 +40,28 @@ class Deas::Route
   class RunTests < UnitTests
     desc "when run"
     setup do
-      @server_data  = Factory.server_data
+      @before_route_run_procs_called_with = nil
+      @before_route_run_procs_called      = 0
+      @before_route_run_procs = Factory.integer(3).times.map do
+        proc do |*args|
+          @before_route_run_procs_called_with = args
+          @before_route_run_procs_called += 1
+        end
+      end
+
+      @after_route_run_procs_called_with = nil
+      @after_route_run_procs_called      = 0
+      @after_route_run_procs = Factory.integer(3).times.map do
+        proc do |*args|
+          @after_route_run_procs_called_with = args
+          @after_route_run_procs_called += 1
+        end
+      end
+
+      @server_data = Factory.server_data({
+        :before_route_run_procs => @before_route_run_procs,
+        :after_route_run_procs  => @after_route_run_procs
+      })
       @request_data = Factory.request_data
     end
 
@@ -50,9 +71,33 @@ class Deas::Route
       ){ @req_type_name }
 
       @route.run(@server_data, @request_data)
+
+      assert_equal @before_route_run_procs.size, @before_route_run_procs_called
+      exp = [@server_data, @request_data]
+      assert_equal exp, @before_route_run_procs_called_with
+
       assert_true @proxy.run_called
-      assert_equal @server_data, @proxy.server_data
+      assert_equal @server_data,  @proxy.server_data
       assert_equal @request_data, @proxy.request_data
+
+      assert_equal @after_route_run_procs.size, @after_route_run_procs_called
+      exp = [@server_data, @request_data]
+      assert_equal exp, @after_route_run_procs_called_with
+    end
+
+    should "run after route run procs even if the proxy errored" do
+      Assert.stub(@server_data.router, :request_type_name).with(
+        @request_data.request
+      ){ @req_type_name }
+      exception = Factory.exception
+      Assert.stub(@proxy, :run){ raise exception }
+
+      raised = assert_raises{ @route.run(@server_data, @request_data) }
+      assert_equal exception, raised
+
+      assert_equal @after_route_run_procs.size, @after_route_run_procs_called
+      exp = [@server_data, @request_data]
+      assert_equal exp, @after_route_run_procs_called_with
     end
 
     should "halt 404 if it can't find a proxy for the given request type name" do

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -6,33 +6,42 @@ class Deas::ServerData
   class UnitTests < Assert::Context
     desc "Deas::ServerData"
     setup do
-      @error_procs     = Factory.integer(3).times.map{ proc{} }
-      @logger          = Factory.string
-      @router          = Factory.string
-      @template_source = Factory.string
+      @error_procs            = Factory.integer(3).times.map{ proc{ Factory.string } }
+      @before_route_run_procs = Factory.integer(3).times.map{ proc{ Factory.string } }
+      @after_route_run_procs  = Factory.integer(3).times.map{ proc{ Factory.string } }
+      @logger                 = Factory.string
+      @router                 = Factory.string
+      @template_source        = Factory.string
 
       @server_data = Deas::ServerData.new({
-        :error_procs     => @error_procs,
-        :logger          => @logger,
-        :router          => @router,
-        :template_source => @template_source
+        :error_procs            => @error_procs,
+        :before_route_run_procs => @before_route_run_procs,
+        :after_route_run_procs  => @after_route_run_procs,
+        :logger                 => @logger,
+        :router                 => @router,
+        :template_source        => @template_source
       })
     end
     subject{ @server_data }
 
-    should have_readers :error_procs, :logger, :router, :template_source
+    should have_readers :error_procs, :before_route_run_procs, :after_route_run_procs
+    should have_readers :logger, :router, :template_source
 
     should "know its attributes" do
-      assert_equal @error_procs,     subject.error_procs
-      assert_equal @logger,          subject.logger
-      assert_equal @router,          subject.router
-      assert_equal @template_source, subject.template_source
+      assert_equal @error_procs,            subject.error_procs
+      assert_equal @before_route_run_procs, subject.before_route_run_procs
+      assert_equal @after_route_run_procs,  subject.after_route_run_procs
+      assert_equal @logger,                 subject.logger
+      assert_equal @router,                 subject.router
+      assert_equal @template_source,        subject.template_source
     end
 
     should "default its attributes when they aren't provided" do
       server_data = Deas::ServerData.new({})
 
       assert_equal [], server_data.error_procs
+      assert_equal [], server_data.before_route_run_procs
+      assert_equal [], server_data.after_route_run_procs
       assert_nil server_data.logger
       assert_nil server_data.router
       assert_nil server_data.template_source
@@ -40,10 +49,12 @@ class Deas::ServerData
 
     should "know if it is equal to another server data" do
       server_data = Deas::ServerData.new({
-        :error_procs     => @error_procs,
-        :logger          => @logger,
-        :router          => @router,
-        :template_source => @template_source
+        :error_procs            => @error_procs,
+        :before_route_run_procs => @before_route_run_procs,
+        :after_route_run_procs  => @after_route_run_procs,
+        :logger                 => @logger,
+        :router                 => @router,
+        :template_source        => @template_source
       })
       assert_equal server_data, subject
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -69,6 +69,18 @@ module Deas::Server
       assert_equal 1, config.error_procs.size
       assert_equal exp, config.error_procs.first
 
+      exp = proc{ }
+      assert_equal 0, config.before_route_run_procs.size
+      subject.before_route_run(&exp)
+      assert_equal 1, config.before_route_run_procs.size
+      assert_equal exp, config.before_route_run_procs.first
+
+      exp = proc{ }
+      assert_equal 0, config.after_route_run_procs.size
+      subject.after_route_run(&exp)
+      assert_equal 1, config.after_route_run_procs.size
+      assert_equal exp, config.after_route_run_procs.first
+
       exp = Deas::TemplateSource.new(Factory.path)
       subject.template_source exp
       assert_equal exp, config.template_source
@@ -127,6 +139,7 @@ module Deas::Server
     should have_accessors :env, :root
     should have_accessors :method_override, :show_exceptions, :verbose_logging
     should have_accessors :middlewares, :init_procs, :error_procs
+    should have_accessors :before_route_run_procs, :after_route_run_procs
     should have_accessors :template_source, :logger, :router
 
     should have_imeths :urls, :routes
@@ -150,6 +163,8 @@ module Deas::Server
       assert_equal [], subject.middlewares
       assert_equal [], subject.init_procs
       assert_equal [], subject.error_procs
+      assert_equal [], subject.before_route_run_procs
+      assert_equal [], subject.after_route_run_procs
 
       assert_instance_of Deas::NullTemplateSource, subject.template_source
       assert_equal subject.root, subject.template_source.path

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -36,8 +36,15 @@ module Deas::SinatraApp
       @router.get('/something', 'EmptyViewHandler')
       @router.validate!
 
-      @config = Deas::Server::Config.new
-      @config.router = @router
+      # set config attributes to make sure they are passed to the `ServerData`
+      @config = Deas::Server::Config.new.tap do |c|
+        c.error_procs            = Factory.integer(3).times.map{ proc{ Factory.string } },
+        c.before_route_run_procs = Factory.integer(3).times.map{ proc{ Factory.string } },
+        c.after_route_run_procs  = Factory.integer(3).times.map{ proc{ Factory.string } },
+        c.template_source        = Factory.string,
+        c.logger                 = Factory.string,
+        c.router                 = @router
+      end
 
       @sinatra_app = Deas::SinatraApp.new(@config)
     end
@@ -58,10 +65,12 @@ module Deas::SinatraApp
       assert_equal @config.root, s.root
 
       exp = Deas::ServerData.new({
-        :error_procs     => @config.error_procs,
-        :logger          => @config.logger,
-        :router          => @config.router,
-        :template_source => @config.template_source
+        :error_procs            => @config.error_procs,
+        :before_route_run_procs => @config.before_route_run_procs,
+        :after_route_run_procs  => @config.after_route_run_procs,
+        :logger                 => @config.logger,
+        :router                 => @config.router,
+        :template_source        => @config.template_source
       })
       assert_equal exp, s.deas_server_data
 


### PR DESCRIPTION
This allows adding before/after route run procs when configuring
a server. These are needed for logic that you want to run before
or after every route but not run for every request via a
middleware. These will also run even if there is an exception.
This is specifically useful for adding logic to check in
activerecord connections after a route has been run in a threaded
environment. This doesn't need to run for requests that are
terminated by a middleware that never uses activerecord but it
needs to run for every route which has a high chance of using
activerecord.

A `Route` will now call before and after route run procs when its
run. It gets the procs from its `ServerData` and uses an `ensure`
to run the after procs. This means the procs will run even if an
exception occurs while running the handler proxy. The route also
passes the server data and request data to the procs. The `Server`
was also updated to have DSL methods for adding before and after
route run procs. These are passed to its server data which is how
the route gets the configured procs.

@kellyredding - Ready for review.