### PR TITLE
update the `body` helper to properly implement the Rack spec

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -56,8 +56,10 @@ module Deas
 
     def body(value = nil)
       if !value.nil?
+        # http://www.rubydoc.info/github/rack/rack/master/file/SPEC#The_Body
+        # "The Body must respond to each and must only yield String values"
         # String#each is a thing in 1.8.7, so account for it here
-        @body = !value.respond_to?(:each) || value.kind_of?(String) ? [*value] : value
+        @body = !value.respond_to?(:each) || value.kind_of?(String) ? [*value.to_s] : value
       end
       @body
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -201,6 +201,10 @@ class Deas::Runner
 
       subject.body exp.first
       assert_equal exp, subject.body
+
+      exp = [Factory.integer.to_s]
+      subject.body exp.first.to_i
+      assert_equal exp, subject.body
     end
 
     should "know and set its response content type header" do


### PR DESCRIPTION
See www.rubydoc.info/github/rack/rack/master/file/SPEC#The_Body.
"The Body must respond to each and must only yield String values".
This is a minor tweak to for any single values into an array
*of strings* (since the body must yield strings).  We still want
to support allowing specifying bodies with single objects from the
Deas API point-of-view.  This just makes sure we are properly
adhering to Rack's spec.

I added comments to the code to help explain this so we are aware
in the future.

@jcredding ready for review.