### PR TITLE
return the request method in Deas::NotFound error messages

### DIFF
--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -109,7 +109,7 @@ module Deas
           # `self` is the sinatra call in this context
           if env['sinatra.error']
             env['deas.error'] = if env['sinatra.error'].instance_of?(::Sinatra::NotFound)
-              Deas::NotFound.new(env['PATH_INFO']).tap do |e|
+              Deas::NotFound.new("#{env['REQUEST_METHOD']} #{env['PATH_INFO']}").tap do |e|
                 e.set_backtrace(env['sinatra.error'].backtrace)
               end
             else

--- a/test/system/deas_tests.rb
+++ b/test/system/deas_tests.rb
@@ -152,7 +152,7 @@ module Deas
 
       assert_equal 404, last_response.status
       assert_equal "text/plain", last_response.headers['Content-Type']
-      assert_match "Deas::NotFound: /not_defined", last_response.body
+      assert_match "Deas::NotFound: GET /not_defined", last_response.body
     end
 
     should "return a text/plain body when an exception occurs" do


### PR DESCRIPTION
This is to give more context on the error and why it is not found.
You may have routed the path but not with the method and that is
why it is not found.

The error looks something like this:

```
GET /not-found-path

(backtrace...)
```

@jcredding ready for review.