### PR TITLE
cleanup middleware args handling

### DIFF
--- a/lib/deas/error_handler.rb
+++ b/lib/deas/error_handler.rb
@@ -26,7 +26,7 @@ module Deas
           error_proc.call(@exception, @context)
         rescue StandardError => proc_exception
           @exception = proc_exception
-          response = nil # reset response
+          response   = nil # reset response
         end
         response || result
       end

--- a/lib/deas/logging.rb
+++ b/lib/deas/logging.rb
@@ -4,16 +4,16 @@ require 'sinatra/base'
 module Deas
 
   module Logging
-    def self.middleware_args(verbose)
-      verbose ? [VerboseLogging] : [SummaryLogging]
+    def self.middleware_type(verbose)
+      verbose ? VerboseLogging : SummaryLogging
     end
   end
 
   class BaseLogging
 
-    def initialize(app)
+    def initialize(app, logger)
       @app    = app
-      @logger = @app.settings.deas_server_data.logger
+      @logger = logger
     end
 
     # The Rack call interface. The receiver acts as a prototype and runs

--- a/lib/deas/server.rb
+++ b/lib/deas/server.rb
@@ -198,7 +198,11 @@ module Deas
         # that the logging and exception showing happens just before the app gets
         # the request and just after the app sends a response.
         self.middlewares << [Deas::ShowExceptions] if self.show_exceptions
-        self.middlewares << Deas::Logging.middleware_args(self.verbose_logging)
+        self.middlewares << [
+          Deas::Logging.middleware_type(self.verbose_logging),
+          self.logger
+        ]
+
         self.middlewares.freeze
 
         @valid = true # if it made it this far, its valid!

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -43,13 +43,6 @@ module Deas
         set :environment, server_config.env
         set :root,        server_config.root
 
-        # TODO: sucks to have to do this but b/c of Rack there is no better way
-        # to make the server data available to middleware.  We should remove this
-        # once we remove Sinatra.  Whatever rack app implemenation will needs to
-        # provide the server data or maybe the server data *will be* the rack app.
-        # Not sure right now, just jotting down notes.
-        set :deas_server_data, server_data
-
         # static settings - Deas doesn't care about these anymore so just
         # use some intelligent defaults
         set :views,            server_config.root

--- a/test/support/fake_sinatra_call.rb
+++ b/test/support/fake_sinatra_call.rb
@@ -22,9 +22,7 @@ class FakeSinatraCall
     @status       = 200
     @headers      = {}
 
-    @settings = OpenStruct.new({
-      :deas_server_data => Factory.server_data
-    }.merge(settings || {}))
+    @settings = OpenStruct.new(settings || {})
   end
 
   def call(env)

--- a/test/unit/logging_tests.rb
+++ b/test/unit/logging_tests.rb
@@ -7,11 +7,11 @@ module Deas::Logging
     desc "Deas::Logging"
     subject{ Deas::Logging }
 
-    should have_imeths :middleware_args
+    should have_imeths :middleware_type
 
     should "return middleware args given a verbose flag" do
-      assert_equal [Deas::VerboseLogging], subject.middleware_args(true)
-      assert_equal [Deas::SummaryLogging], subject.middleware_args(false)
+      assert_equal Deas::VerboseLogging, subject.middleware_type(true)
+      assert_equal Deas::SummaryLogging, subject.middleware_type(false)
     end
 
   end
@@ -19,9 +19,7 @@ module Deas::Logging
   class CallSetupTests < UnitTests
     setup do
       @logger = SpyLogger.new
-      @app = Factory.sinatra_call({
-        :deas_server_data => Factory.server_data(:logger => @logger)
-      })
+      @app    = Factory.sinatra_call
 
       @app_call_env = nil
       @resp_status  = Factory.integer
@@ -60,7 +58,7 @@ module Deas::Logging
         @benchmark
       end
 
-      @middleware = @middleware_class.new(@app)
+      @middleware = @middleware_class.new(@app, @logger)
     end
     subject{ @middleware }
 
@@ -131,7 +129,7 @@ module Deas::Logging
       @resp_status = @middleware_class::RESPONSE_STATUS_NAMES.keys.sample
       @app_response[0] = @resp_status
 
-      @middleware = Deas::VerboseLogging.new(@app)
+      @middleware = Deas::VerboseLogging.new(@app, @logger)
     end
     subject{ @middleware }
 
@@ -213,7 +211,7 @@ module Deas::Logging
         'deas.handler_class' => @handler_class
       })
 
-      @middleware = Deas::SummaryLogging.new(@app)
+      @middleware = Deas::SummaryLogging.new(@app, @logger)
     end
     subject{ @middleware }
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -248,7 +248,9 @@ module Deas::Server
       assert_equal (num_middlewares+3), subject.middlewares.size
       assert_equal [Rack::MethodOverride], subject.middlewares[0]
       assert_equal [Deas::ShowExceptions], subject.middlewares[-2]
-      assert_equal [Deas::VerboseLogging], subject.middlewares[-1]
+
+      exp = [Deas::VerboseLogging, subject.logger]
+      assert_equal exp, subject.middlewares[-1]
 
       assert_raises do
         subject.middlewares << [Factory.string]

--- a/test/unit/sinatra_app_tests.rb
+++ b/test/unit/sinatra_app_tests.rb
@@ -64,16 +64,6 @@ module Deas::SinatraApp
       assert_equal @config.env,  s.environment
       assert_equal @config.root, s.root
 
-      exp = Deas::ServerData.new({
-        :error_procs            => @config.error_procs,
-        :before_route_run_procs => @config.before_route_run_procs,
-        :after_route_run_procs  => @config.after_route_run_procs,
-        :logger                 => @config.logger,
-        :router                 => @config.router,
-        :template_source        => @config.template_source
-      })
-      assert_equal exp, s.deas_server_data
-
       assert_equal @config.root, s.views
       assert_equal @config.root, s.public_folder
       assert_equal 'utf-8',      s.default_encoding


### PR DESCRIPTION
So previously I had said that there was no good way to get server
config args to the middlewares except to store those on the
Sinatra app since this "app" was what was initialized with each
middleware.  Well, turns out I was wrong.

First off, the "app" initialized with each middleware is really
more like the "next upstream middleware or the end app".  I get
why the convention is to call it "app" b/c from the middleware's
point of view it might as well be the app, but this had confused
me.  Second, there is an interface for passing args to middlewares.
Sinatra's `use` takes the same `Rack::Builder` interface which
means both `*args` and a proc can be passed.  They just need to
be specified as addition params.

So, this switches to using this interface and also switches to
directly passing in the server's logger to the `Logging`
middleware.

This is a cleanup and is prep for adding a new optional middleware
for handling trailing slashes based on router settings.  It will
have to have the router passed in so it will init similar to how
the `Logging` middleware is init here.

@jcredding ready for review.