### PR TITLE
update the router api for setting trailing slashes handling

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -6,10 +6,20 @@ module Deas
 
   class Router
 
-    DEFAULT_REQUEST_TYPE_NAME = 'default'.freeze
+    DEFAULT_REQUEST_TYPE_NAME   = 'default'.freeze
+    ALLOW_TRAILING_SLASHES      = 'allow-either'.freeze
+    REQUIRE_TRAILING_SLASHES    = 'require'.freeze
+    REQUIRE_NO_TRAILING_SLASHES = 'require-none'.freeze
+    SLASH                       = '/'.freeze
+
+    VALID_TRAILING_SLASHES_VALUES = [
+      ALLOW_TRAILING_SLASHES,
+      REQUIRE_TRAILING_SLASHES,
+      REQUIRE_NO_TRAILING_SLASHES
+    ].freeze
 
     attr_reader :request_types, :urls, :routes, :definitions
-    attr_reader :escape_query_value_proc
+    attr_reader :trailing_slashes, :escape_query_value_proc
 
     def initialize(&block)
       @request_types = []
@@ -22,6 +32,22 @@ module Deas
     def view_handler_ns(value = nil)
       @view_handler_ns = value if !value.nil?
       @view_handler_ns
+    end
+
+    def allow_trailing_slashes
+      @trailing_slashes = ALLOW_TRAILING_SLASHES
+    end
+
+    def require_trailing_slashes
+      @trailing_slashes = REQUIRE_TRAILING_SLASHES
+    end
+
+    def require_no_trailing_slashes
+      @trailing_slashes = REQUIRE_NO_TRAILING_SLASHES
+    end
+
+    def trailing_slashes_set?
+      VALID_TRAILING_SLASHES_VALUES.include?(@trailing_slashes)
     end
 
     def escape_query_value(&block)
@@ -109,9 +135,37 @@ module Deas
       true
     end
 
+    def validate_trailing_slashes!
+      if self.trailing_slashes == REQUIRE_TRAILING_SLASHES
+        paths = []
+        all_have = self.routes.inject(true) do |result, route|
+          paths << route.path if route.path[-1..-1] != SLASH
+          result && route.path[-1..-1] == SLASH
+        end
+        if !all_have
+          msg = "all route paths must end with a \"/\", but these do not:\n"\
+                "#{paths.join("\n")}"
+          raise TrailingSlashesError, msg
+        end
+      elsif self.trailing_slashes == REQUIRE_NO_TRAILING_SLASHES
+        paths = []
+        all_missing = self.routes.inject(true) do |result, route|
+          paths << route.path if route.path[-1..-1] == SLASH
+          result && route.path[-1..-1] != SLASH
+        end
+        if !all_missing
+          msg = "all route paths must *not* end with a \"/\", but these do:\n"\
+                "#{paths.join("\n")}"
+          raise TrailingSlashesError, msg
+        end
+      end
+      true
+    end
+
     def validate!
       self.apply_definitions!
       self.routes.each(&:validate!)
+      self.validate_trailing_slashes!
       true
     end
 
@@ -192,7 +246,8 @@ module Deas
       Deas::Route.new(http_method, path, proxies).tap{ |r| self.routes.push(r) }
     end
 
-    InvalidSplatError = Class.new(ArgumentError)
+    InvalidSplatError    = Class.new(ArgumentError)
+    TrailingSlashesError = Class.new(RuntimeError)
 
     class HandlerProxies
 

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -19,6 +19,13 @@ class Deas::Router
       assert_equal 'default', subject::DEFAULT_REQUEST_TYPE_NAME
     end
 
+    should "know its trailing slashes constants" do
+      assert_equal 'require',      subject::REQUIRE_TRAILING_SLASHES
+      assert_equal 'require-none', subject::REQUIRE_NO_TRAILING_SLASHES
+      assert_equal 'allow-either', subject::ALLOW_TRAILING_SLASHES
+      assert_equal '/',            subject::SLASH
+    end
+
   end
 
   class InitTests < UnitTests
@@ -32,9 +39,11 @@ class Deas::Router
     subject{ @router }
 
     should have_readers :request_types, :urls, :routes, :definitions
-    should have_readers :escape_query_value_proc
+    should have_readers :trailing_slashes, :escape_query_value_proc
 
-    should have_imeths :view_handler_ns, :escape_query_value
+    should have_imeths :view_handler_ns, :allow_trailing_slashes
+    should have_imeths :require_trailing_slashes, :require_no_trailing_slashes
+    should have_imeths :escape_query_value
     should have_imeths :base_url, :set_base_url, :prepend_base_url
     should have_imeths :url, :url_for
     should have_imeths :default_request_type_name, :add_request_type
@@ -42,10 +51,12 @@ class Deas::Router
     should have_imeths :get, :post, :put, :patch, :delete
     should have_imeths :route, :redirect, :not_found
     should have_imeths :apply_definitions!, :validate!
+    should have_imeths :validate_trailing_slashes!
 
     should "default its attrs" do
       router = @router_class.new
       assert_nil router.view_handler_ns
+      assert_nil router.trailing_slashes
       assert_nil router.base_url
       assert_empty router.request_types
       assert_empty router.urls
@@ -72,6 +83,17 @@ class Deas::Router
     should "set a view handler namespace" do
       subject.view_handler_ns(exp = Factory.string)
       assert_equal exp, subject.view_handler_ns
+    end
+
+    should "config trailing slash handling" do
+      subject.allow_trailing_slashes
+      assert_equal subject.class::ALLOW_TRAILING_SLASHES, subject.trailing_slashes
+
+      subject.require_trailing_slashes
+      assert_equal subject.class::REQUIRE_TRAILING_SLASHES, subject.trailing_slashes
+
+      subject.require_no_trailing_slashes
+      assert_equal subject.class::REQUIRE_NO_TRAILING_SLASHES, subject.trailing_slashes
     end
 
     should "allow configuring a custom escape query value proc" do
@@ -158,21 +180,111 @@ class Deas::Router
       assert_equal path1, nf.path
     end
 
+    should "validate trailing slashes" do
+      router = @router_class.new
+      router.get('/something',  'EmptyViewHandler')
+      router.get('/something/', 'EmptyViewHandler')
+      router.apply_definitions!
+
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+
+      router.allow_trailing_slashes
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+
+      router.require_trailing_slashes
+      err = assert_raises(TrailingSlashesError) do
+        router.validate_trailing_slashes!
+      end
+      exp = "all route paths must end with a \"/\", but these do not:\n/something"
+      assert_includes exp, err.message
+
+      router.require_no_trailing_slashes
+      err = assert_raises(TrailingSlashesError) do
+        router.validate_trailing_slashes!
+      end
+      exp = "all route paths must *not* end with a \"/\", but these do:\n/something/"
+      assert_includes exp, err.message
+
+      router = @router_class.new
+      router.get('/something/',      'EmptyViewHandler')
+      router.get('/something-else/', 'EmptyViewHandler')
+      router.apply_definitions!
+
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+
+      router.allow_trailing_slashes
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+
+      router.require_trailing_slashes
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+
+      router.require_no_trailing_slashes
+      err = assert_raises(TrailingSlashesError) do
+        router.validate_trailing_slashes!
+      end
+      exp = "all route paths must *not* end with a \"/\", but these do:\n"\
+            "/something/\n/something-else/"
+      assert_includes exp, err.message
+
+      router = @router_class.new
+      router.get('/something',      'EmptyViewHandler')
+      router.get('/something-else', 'EmptyViewHandler')
+      router.apply_definitions!
+
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+
+      router.allow_trailing_slashes
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+
+      router.require_trailing_slashes
+      err = assert_raises(TrailingSlashesError) do
+        router.validate_trailing_slashes!
+      end
+      exp = "all route paths must end with a \"/\", but these do not:\n"\
+            "/something\n/something-else"
+      assert_includes exp, err.message
+
+      router.require_no_trailing_slashes
+      assert_nothing_raised do
+        router.validate_trailing_slashes!
+      end
+    end
+
     should "apply definitions and validate each route when validating" do
       subject.get('/something', 'EmptyViewHandler')
       subject.apply_definitions!
+      subject.validate_trailing_slashes!
       route = subject.routes.last
       proxy = route.handler_proxies[subject.default_request_type_name]
 
       apply_def_called = false
       Assert.stub(subject, :apply_definitions!){ apply_def_called = true }
 
+      val_trailing_called = false
+      Assert.stub(subject, :validate_trailing_slashes!){ val_trailing_called = true }
+
       assert_false apply_def_called
+      assert_false val_trailing_called
       assert_nil proxy.handler_class
 
       subject.validate!
 
       assert_true apply_def_called
+      assert_true val_trailing_called
       assert_equal EmptyViewHandler, proxy.handler_class
     end
 


### PR DESCRIPTION
This adds 3 new router api methods: `require_trailing_slashes`,
`require_no_trailing_slashes`, and `allow_trailing_slashes`.
Calling any of these methods will set a "trailing slashes" config
setting value on the router that will direct it how to handle
trailing slashes in its routes.  The goal with this is to help
prevent unnecessary 404s b/c a user (or the browser) accidentally
adds/omits a trailing slash on a URL path.

First let's look at `require_trailing_slashes`.  This is intended
when you want all of your paths to end in a trailing slash.  The
router will ensure this and error if it finds routes not ending
in a slash when validating.  In a future effort, this directive
will also force-redirect any paths not ending in a slash to end
in a slash.

`require_no_trailing_slashes` does the opposite: the router will
complain if any of your defined routes have trailing slashes and
in a future effort the directive will force-redirect any paths
ending in a slash to not ending in a slash.

`allow_trailing_slashes` won't complain about the router's routes -
you can freely mix and match routes ending in slashes and not. In
a future effort, Deas will switch the slash on paths and retry
them if it sees any `Deas::NotFound` errors.  This will "allow"
specifying and using either trailing slashes or not.

Finally, if you don't use any of the directives, everything
behaves as normal.  You will get 404s for paths that don't
exactly match what is defined in the router.

As mentioned this is the first of a two-part effort.  This sets
up the directives and the router's API.  In the next effort,
I'll add a middleware that will handle enforcing any router
directive's behavior.

@jcredding ready for review.