### PR TITLE
middleware for trailing slashes

### DIFF
--- a/lib/deas/trailing_slashes.rb
+++ b/lib/deas/trailing_slashes.rb
@@ -1,0 +1,110 @@
+require 'rack/utils'
+
+require 'deas/exceptions'
+require 'deas/router'
+
+module Deas
+
+  class TrailingSlashes
+
+    module RequireHandler;   end
+    module RequireNoHandler; end
+    module AllowHandler;     end
+
+    HANDLERS = {
+      Deas::Router::REQUIRE_TRAILING_SLASHES    => RequireHandler,
+      Deas::Router::REQUIRE_NO_TRAILING_SLASHES => RequireNoHandler,
+      Deas::Router::ALLOW_TRAILING_SLASHES      => AllowHandler
+    }
+
+    def initialize(app, router)
+      @app    = app
+      @router = router
+
+      if !@router.trailing_slashes_set?
+        val  = @router.trailing_slashes
+        desc = val.nil? ? 'no' : "an invalid (`#{val.inspect}`)"
+        raise ArgumentError, "TrailingSlashes middleware is in use but there is "\
+                             "#{desc} trailing slashes router directive set."
+      end
+    end
+
+    # The Rack call interface. The receiver acts as a prototype and runs
+    # each request in a clone object unless the +rack.run_once+ variable is
+    # set in the environment. Ripped from:
+    # http://github.com/rtomayko/rack-cache/blob/master/lib/rack/cache/context.rb
+    def call(env)
+      if env['rack.run_once']
+        call! env
+      else
+        clone.call! env
+      end
+    end
+
+    # The real Rack call interface.
+    def call!(env)
+      HANDLERS[@router.trailing_slashes].run(env){ @app.call(env) }
+    end
+
+    module Handler
+
+      def redirect(location)
+        [302, { 'Location' => location }, ['']]
+      end
+
+    end
+
+    module RequireHandler
+      extend Handler
+
+      def self.run(env)
+        if env['PATH_INFO'][-1..-1] != Deas::Router::SLASH
+          self.redirect(env['PATH_INFO']+Deas::Router::SLASH)
+        else
+          yield
+        end
+      end
+
+    end
+
+    module RequireNoHandler
+      extend Handler
+
+      def self.run(env)
+        if env['PATH_INFO'][-1..-1] == Deas::Router::SLASH
+          self.redirect(env['PATH_INFO'][0..-2])
+        else
+          yield
+        end
+      end
+
+    end
+
+    module AllowHandler
+      extend Handler
+
+      def self.run(env)
+        status, headers, body = yield
+        if env['deas.error'].kind_of?(Deas::NotFound)
+          # reset 'deas.error' state
+          env['deas.error'] = nil
+
+          # switching the trailing slash of the path info
+          env['PATH_INFO'] = if env['PATH_INFO'][-1..-1] == Deas::Router::SLASH
+            env['PATH_INFO'][0..-2]
+          else
+            env['PATH_INFO']+Deas::Router::SLASH
+          end
+
+          # retry
+          yield
+        else
+          [status, headers, body]
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -69,6 +69,56 @@ class DeasDevServer
 
 end
 
+class RequireTrailingSlashesServer
+  include Deas::Server
+
+  root            TEST_SUPPORT_ROOT
+  logger          TEST_LOGGER
+  verbose_logging true
+  show_exceptions true
+
+  router do
+    require_trailing_slashes
+
+    get '/show/', 'ShowHandler'
+  end
+
+end
+
+class RequireNoTrailingSlashesServer
+  include Deas::Server
+
+  root            TEST_SUPPORT_ROOT
+  logger          TEST_LOGGER
+  verbose_logging true
+  show_exceptions true
+
+  router do
+    require_no_trailing_slashes
+
+    get '/show', 'ShowHandler'
+  end
+
+end
+
+class AllowTrailingSlashesServer
+  include Deas::Server
+
+  root            TEST_SUPPORT_ROOT
+  logger          TEST_LOGGER
+  verbose_logging true
+  show_exceptions true
+
+  router do
+    allow_trailing_slashes
+
+    get '/show',       'ShowHandler'
+    get '/show-text/', 'ShowTextHandler'
+
+  end
+
+end
+
 class ShowHandler
   include Deas::ViewHandler
 

--- a/test/system/deas_tests.rb
+++ b/test/system/deas_tests.rb
@@ -165,4 +165,60 @@ module Deas
 
   end
 
+  class RequireTrailingSlashesTests < RackTestsContext
+    desc "a Deas server rack app with a router that requires trailing slashes"
+    setup do
+      @app = RequireTrailingSlashesServer.new
+    end
+
+    should "redirect any paths that don't end in a slash" do
+      get '/show'
+
+      assert_equal 302,      last_response.status
+      assert_equal '/show/', last_response.headers['Location']
+    end
+
+  end
+
+  class RequireNoTrailingSlashesTests < RackTestsContext
+    desc "a Deas server rack app with a router that requires no trailing slashes"
+    setup do
+      @app = RequireNoTrailingSlashesServer.new
+    end
+
+    should "redirect any paths that end in a slash" do
+      get '/show/'
+
+      assert_equal 302,      last_response.status
+      assert_equal '/show', last_response.headers['Location']
+    end
+
+  end
+
+  class AllowTrailingSlashesTests < RackTestsContext
+    desc "a Deas server rack app with a router that allows trailing slashes"
+    setup do
+      @app = AllowTrailingSlashesServer.new
+    end
+
+    should "serve any found paths regardless of whether they end with a slash" do
+      get '/show'
+      assert_equal 200, last_response.status
+      assert_equal 'text/html;charset=utf-8', last_response.headers['Content-Type']
+
+      get '/show/'
+      assert_equal 200, last_response.status
+      assert_equal 'text/html;charset=utf-8', last_response.headers['Content-Type']
+
+      get '/show-text'
+      assert_equal 200, last_response.status
+      assert_equal 'text/plain', last_response.headers['Content-Type']
+
+      get '/show-text/'
+      assert_equal 200, last_response.status
+      assert_equal 'text/plain', last_response.headers['Content-Type']
+    end
+
+  end
+
 end

--- a/test/unit/trailing_slashes_tests.rb
+++ b/test/unit/trailing_slashes_tests.rb
@@ -1,0 +1,178 @@
+require 'assert'
+require 'deas/trailing_slashes'
+
+require 'deas/exceptions'
+require 'deas/router'
+require 'rack/utils'
+
+class Deas::TrailingSlashes
+
+  class UnitTests < Assert::Context
+    desc "Deas::TrailingSlashes"
+    setup do
+      @env = {}
+
+      @middleware_class = Deas::TrailingSlashes
+    end
+    subject{ @middleware_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @value = Deas::Router::VALID_TRAILING_SLASHES_VALUES.sample
+
+      @handler_run_args = nil
+      @handler_run_proc = nil
+      Assert.stub(HANDLERS[@value], :run) do |*args, &block|
+        @handler_run_args = args
+        @handler_run_proc = block
+      end
+
+      @app, @router = build_value_app_router(@value)
+      @middleware   = @middleware_class.new(@app, @router)
+    end
+    subject{ @middleware }
+
+    should have_imeths :call, :call!
+
+    should "run a handler based on the router's trailing slashes value when called" do
+      subject.call(@env)
+
+      assert_equal [@env], @handler_run_args
+      assert_not_nil @handler_run_proc
+
+      status, headers, body = subject.instance_eval(&@handler_run_proc)
+      assert_equal @app.response.status,  status
+      assert_equal @app.response.headers, headers
+      assert_equal [@app.response.body],  body
+    end
+
+    should "complain if there is an invalid trailing slashes value set on the router" do
+      app, router = build_value_app_router(nil)
+
+      err = assert_raises(ArgumentError){ @middleware_class.new(app, router) }
+      exp = "TrailingSlashes middleware is in use but there is no "\
+            "trailing slashes router directive set."
+      assert_equal exp, err.message
+
+      invalid_val = ['', 1234, Class.new, Factory.string].sample
+      app, router = build_value_app_router(invalid_val)
+
+      err = assert_raises(ArgumentError){ @middleware_class.new(app, router) }
+      exp = "TrailingSlashes middleware is in use but there is an invalid "\
+            "(`#{invalid_val.inspect}`) trailing slashes router directive set."
+      assert_equal exp, err.message
+    end
+
+    private
+
+    def build_value_app_router(value)
+      router = Deas::Router.new
+      router.instance_eval{ @trailing_slashes = value }
+      [Factory.sinatra_call, router]
+    end
+
+  end
+
+  class HandlerSetupTests < UnitTests
+    setup do
+      @no_slash_path = Factory.url
+      @slash_path    = @no_slash_path+Deas::Router::SLASH
+
+      @app  = Factory.sinatra_call
+      @proc = proc{ @app.call(@env) }
+    end
+  end
+
+  class RequireHandlerTests < HandlerSetupTests
+    desc "RequireHandler"
+    subject{ RequireHandler }
+
+    should have_readers :run, :redirect
+
+    should "return the apps response if the path info ends in a slash" do
+      @env['PATH_INFO'] = @slash_path
+
+      status, headers, body = subject.run(@env, &@proc)
+      assert_equal @app.response.status,  status
+      assert_equal @app.response.headers, headers
+      assert_equal [@app.response.body],  body
+    end
+
+    should "redirect with a trailing slash if the path info does not end in a slash" do
+      @env['PATH_INFO'] = @no_slash_path
+
+      status, headers, body = subject.run(@env, &@proc)
+      exp = { 'Location' => @slash_path }
+      assert_equal exp,  headers
+      assert_equal 302,  status
+      assert_equal [''], body
+    end
+
+  end
+
+  class RequireNoHandlerTests < HandlerSetupTests
+    desc "RequireNoHandler"
+    subject{ RequireNoHandler }
+
+    should have_readers :run, :redirect
+
+    should "return the apps response if the path info does not end in a slash" do
+      @env['PATH_INFO'] = @no_slash_path
+
+      status, headers, body = subject.run(@env, &@proc)
+      assert_equal @app.response.status,  status
+      assert_equal @app.response.headers, headers
+      assert_equal [@app.response.body],  body
+    end
+
+    should "redirect without a trailing slash if the path info ends in a slash" do
+      @env['PATH_INFO'] = @slash_path
+
+      status, headers, body = subject.run(@env, &@proc)
+      exp = { 'Location' => @no_slash_path }
+      assert_equal exp,  headers
+      assert_equal 302,  status
+      assert_equal [''], body
+    end
+
+  end
+
+  class AllowHandlerTests < HandlerSetupTests
+    desc "AllowHandler"
+    subject{ AllowHandler }
+
+    should have_readers :run, :redirect
+
+    should "return the apps response if no Deas::NotFound error" do
+      paths = [@no_slash_path, @slash_path].shuffle
+      @env['PATH_INFO'] = paths.first
+
+      status, headers, body = subject.run(@env, &@proc)
+      assert_equal @app.response.status,  status
+      assert_equal @app.response.headers, headers
+      assert_equal [@app.response.body],  body
+
+      # path info not switched and retried b/c there was no Deas::NotFound
+      assert_equal paths.first, @env['PATH_INFO']
+    end
+
+    should "switch the trailing slash and return the apps response if Deas::NotFound error" do
+      paths = [@no_slash_path, @slash_path].shuffle
+      @env['PATH_INFO']  = paths.first
+      @env['deas.error'] = Deas::NotFound.new
+
+      status, headers, body = subject.run(@env, &@proc)
+      assert_equal @app.response.status,  status
+      assert_equal @app.response.headers, headers
+      assert_equal [@app.response.body],  body
+
+      # path info switched and retried b/c there was no Deas::NotFound
+      assert_equal paths.last, @env['PATH_INFO']
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a middleware that enforces any trailing slashes
directive in the Deas app's router.

This middleware takes a router as an arg and validates that it has
a trailing slashes directive set.  On call, the middleware looks
up a handler for the router directive and runs it.  I chose to
lookup the handlers from a hash to keep the logic at constant
time performance and to avoid a bunch of conditionals.  By org'ing
the logic in handlers, each directive's logic can be decoupled from
the other directives.

The require handler checks for a slash at the end of the path and
if there isn't one, redirects to the same path with a slash. The
require no handler does the opposite.  The allow handler tries the
path as is.  If it sees a `Deas::NotFound` (router not found)
response, it clears the error and retries the request with the
ending slash state switched.

I chose redirects for the require handlers to actually change the
url in the user's browser and to direct the browser to the desired
path representation.  I chose to retry (and to not redirect) in the
allow handler so that the url wouldn't change in the browser and
it would get the desired behavior as efficiently as possible.

Finally, this adds the middleware, if a router directive has been
set, to the server's middleware stack.  If no directive has been
set, no special handling is needed.  It is added last so that the
details of the allow retries as hidden from the logging middleware
and so that any errors will get the show exceptions logic.

This is part 2 of the main development effort for this new
"trailing slashes" feature.  I actually have one more thing to
handle after this though: I need to account for paths that end
in file extensions and not run any trailing slash behavior on them
as it is implies that they won't end in a slash no matter what
any directive says.  I'm doing that part next.

See #239 for part 1 of this effort.

@jcredding ready for review