### PR TITLE
jux "Route: ..." verbose logging after "Path: ..." logs

### DIFF
--- a/lib/deas/error_handler.rb
+++ b/lib/deas/error_handler.rb
@@ -35,18 +35,18 @@ module Deas
     class Context
 
       attr_reader :server_data
-      attr_reader :request, :response, :handler_class, :handler
-      attr_reader :params, :splat, :route_path
+      attr_reader :request, :response
+      attr_reader :route_path, :handler_class, :handler, :params, :splat
 
       def initialize(args)
         @server_data   = args.fetch(:server_data)
         @request       = args.fetch(:request)
         @response      = args.fetch(:response)
+        @route_path    = args.fetch(:route_path)
         @handler_class = args.fetch(:handler_class)
         @handler       = args.fetch(:handler)
         @params        = args.fetch(:params)
         @splat         = args.fetch(:splat)
-        @route_path    = args.fetch(:route_path)
       end
 
       def ==(other)
@@ -55,10 +55,10 @@ module Deas
           self.handler_class == other.handler_class &&
           self.request       == other.request       &&
           self.response      == other.response      &&
+          self.route_path    == other.route_path    &&
           self.handler       == other.handler       &&
           self.params        == other.params        &&
-          self.splat         == other.splat         &&
-          self.route_path    == other.route_path
+          self.splat         == other.splat
         else
           super
         end

--- a/lib/deas/handler_proxy.rb
+++ b/lib/deas/handler_proxy.rb
@@ -33,8 +33,8 @@ module Deas
         :router          => server_data.router,
         :template_source => server_data.template_source,
         :request         => request_data.request,
-        :params          => request_data.params,
-        :route_path      => request_data.route_path
+        :route_path      => request_data.route_path,
+        :params          => request_data.params
       })
 
       runner.request.env.tap do |env|
@@ -42,17 +42,17 @@ module Deas
         # this is specifically needed by the Logging middleware
         # this is also needed by the Sinatra error handlers so they can provide
         # error context.  This may change when we eventually remove Sinatra.
+        env['deas.route_path']    = runner.route_path
         env['deas.handler_class'] = self.handler_class
         env['deas.handler']       = runner.handler
         env['deas.params']        = runner.params
         env['deas.splat']         = runner.splat
-        env['deas.route_path']    = runner.route_path
 
         # this handles the verbose logging (it is a no-op if summary logging)
+        env['deas.logging'].call "  Route:   #{runner.route_path.inspect}"
         env['deas.logging'].call "  Handler: #{self.handler_class.name}"
         env['deas.logging'].call "  Params:  #{runner.params.inspect}"
         env['deas.logging'].call "  Splat:   #{runner.splat.inspect}" if !runner.splat.nil?
-        env['deas.logging'].call "  Route:   #{runner.route_path.inspect}"
       end
 
       runner.run

--- a/lib/deas/request_data.rb
+++ b/lib/deas/request_data.rb
@@ -8,21 +8,21 @@ module Deas
     # decouple the rack app from the handlers (we can use any rack app as long
     # as they provide this data).
 
-    attr_reader :request, :response, :params, :route_path
+    attr_reader :request, :response, :route_path, :params
 
     def initialize(args)
       @request    = args[:request]
       @response   = args[:response]
-      @params     = args[:params]
       @route_path = args[:route_path]
+      @params     = args[:params]
     end
 
     def ==(other_request_data)
       if other_request_data.kind_of?(RequestData)
         self.request    == other_request_data.request    &&
         self.response   == other_request_data.response   &&
-        self.params     == other_request_data.params     &&
-        self.route_path == other_request_data.route_path
+        self.route_path == other_request_data.route_path &&
+        self.params     == other_request_data.params
       else
         super
       end

--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -14,22 +14,22 @@ module Deas
     DEFAULT_BODY      = [].freeze
 
     attr_reader :handler_class, :handler
+    attr_reader :request, :route_path, :params
     attr_reader :logger, :router, :template_source
-    attr_reader :request, :params, :route_path
 
     def initialize(handler_class, args = nil)
       @status, @headers, @body = nil, Rack::Utils::HeaderHash.new, nil
 
+      @handler_class = handler_class
+      @handler = @handler_class.new(self)
+
       args ||= {}
+      @request         = args[:request]
+      @route_path      = args[:route_path].to_s
+      @params          = args[:params]          || {}
       @logger          = args[:logger]          || Deas::NullLogger.new
       @router          = args[:router]          || Deas::Router.new
       @template_source = args[:template_source] || Deas::NullTemplateSource.new
-      @request         = args[:request]
-      @params          = args[:params]          || {}
-      @route_path      = args[:route_path].to_s
-
-      @handler_class = handler_class
-      @handler = @handler_class.new(self)
     end
 
     def splat

--- a/lib/deas/sinatra_app.rb
+++ b/lib/deas/sinatra_app.rb
@@ -77,8 +77,8 @@ module Deas
                 RequestData.new({
                   :request    => request,
                   :response   => response,
-                  :params     => params,
-                  :route_path => route.path
+                  :route_path => route.path,
+                  :params     => params
                 })
               )
             rescue *STANDARD_ERROR_CLASSES => err
@@ -88,11 +88,11 @@ module Deas
                 :server_data   => server_data,
                 :request       => request,
                 :response      => response,
+                :route_path    => request.env['deas.route_path'],
                 :handler_class => request.env['deas.handler_class'],
                 :handler       => request.env['deas.handler'],
                 :params        => request.env['deas.params'],
-                :splat         => request.env['deas.splat'],
-                :route_path    => request.env['deas.route_path']
+                :splat         => request.env['deas.splat']
               })
             end
           end
@@ -112,11 +112,11 @@ module Deas
               :server_data   => server_data,
               :request       => request,
               :response      => response,
+              :route_path    => request.env['deas.route_path'],
               :handler_class => request.env['deas.handler_class'],
               :handler       => request.env['deas.handler'],
               :params        => request.env['deas.params'],
-              :splat         => request.env['deas.splat'],
-              :route_path    => request.env['deas.route_path']
+              :splat         => request.env['deas.splat']
             })
           end
         end

--- a/lib/deas/test_runner.rb
+++ b/lib/deas/test_runner.rb
@@ -27,8 +27,8 @@ module Deas
         :router          => a.delete(:router),
         :template_source => a.delete(:template_source),
         :request         => a.delete(:request),
-        :params          => NormalizedParams.new(a.delete(:params) || {}).value,
-        :route_path      => a.delete(:route_path)
+        :route_path      => a.delete(:route_path),
+        :params          => NormalizedParams.new(a.delete(:params) || {}).value
       })
       @splat = a.delete(:splat)
       a.each{|key, value| self.handler.send("#{key}=", value) }

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -41,8 +41,8 @@ module Factory
     Deas::RequestData.new({
       :request    => args[:request]    || Factory.request,
       :response   => args[:response]   || Factory.response,
-      :params     => args[:params]     || { Factory.string => Factory.string },
-      :route_path => args[:route_path] || Factory.string
+      :route_path => args[:route_path] || Factory.string,
+      :params     => args[:params]     || { Factory.string => Factory.string }
     })
   end
 

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -12,21 +12,21 @@ class Deas::ErrorHandler
       @server_data      = Factory.server_data(:error_procs => @error_proc_spies)
       @request          = Factory.string
       @response         = Factory.string
+      @route_path       = Factory.string
       @handler_class    = Factory.string
       @handler          = Factory.string
       @params           = Factory.string
       @splat            = Factory.string
-      @route_path       = Factory.string
 
       @context_hash = {
         :server_data   => @server_data,
         :request       => @request,
         :response      => @response,
+        :route_path    => @route_path,
         :handler_class => @handler_class,
         :handler       => @handler,
         :params        => @params,
-        :splat         => @splat,
-        :route_path    => @route_path
+        :splat         => @splat
       }
 
       @error_handler_class = Deas::ErrorHandler
@@ -117,18 +117,18 @@ class Deas::ErrorHandler
     subject{ @context }
 
     should have_readers :server_data
-    should have_readers :request, :response, :handler_class, :handler
-    should have_readers :params, :splat, :route_path
+    should have_readers :request, :response
+    should have_readers :route_path, :handler_class, :handler, :params, :splat
 
     should "know its attributes" do
       assert_equal @context_hash[:server_data],   subject.server_data
       assert_equal @context_hash[:request],       subject.request
       assert_equal @context_hash[:response],      subject.response
+      assert_equal @context_hash[:route_path],    subject.route_path
       assert_equal @context_hash[:handler_class], subject.handler_class
       assert_equal @context_hash[:handler],       subject.handler
       assert_equal @context_hash[:params],        subject.params
       assert_equal @context_hash[:splat],         subject.splat
-      assert_equal @context_hash[:route_path],    subject.route_path
     end
 
     should "know if it equals another context" do
@@ -139,11 +139,11 @@ class Deas::ErrorHandler
         :server_data   => Factory.server_data,
         :request       => Factory.string,
         :response      => Factory.string,
+        :route_path    => Factory.string,
         :handler_class => Factory.string,
         :handler       => Factory.string,
         :params        => Factory.string,
         :splat         => Factory.string,
-        :route_path    => Factory.string
       })
       assert_not_equal exp, subject
     end

--- a/test/unit/handler_proxy_tests.rb
+++ b/test/unit/handler_proxy_tests.rb
@@ -62,8 +62,8 @@ class Deas::HandlerProxy
         :router          => @server_data.router,
         :template_source => @server_data.template_source,
         :request         => @request_data.request,
-        :params          => @request_data.params,
-        :route_path      => @request_data.route_path
+        :route_path      => @request_data.route_path,
+        :params          => @request_data.params
       }
       assert_equal exp_args, @runner_spy.args
 
@@ -71,6 +71,9 @@ class Deas::HandlerProxy
     end
 
     should "add data to the request env to make it available to Rack" do
+      exp = @runner_spy.route_path
+      assert_equal exp, @request_data.request.env['deas.route_path']
+
       exp = subject.handler_class
       assert_equal exp, @request_data.request.env['deas.handler_class']
 
@@ -82,17 +85,14 @@ class Deas::HandlerProxy
 
       exp = @runner_spy.splat
       assert_equal exp, @request_data.request.env['deas.splat']
-
-      exp = @runner_spy.route_path
-      assert_equal exp, @request_data.request.env['deas.route_path']
     end
 
     should "log the handler class name and the params" do
       exp_msgs = [
+        "  Route:   #{@runner_spy.route_path.inspect}",
         "  Handler: #{subject.handler_class.name}",
         "  Params:  #{@runner_spy.params.inspect}",
-        "  Splat:   #{@runner_spy.splat.inspect}",
-        "  Route:   #{@runner_spy.route_path.inspect}"
+        "  Splat:   #{@runner_spy.splat.inspect}"
       ]
       assert_equal exp_msgs, @request_data.request.logging_msgs
     end

--- a/test/unit/request_data_tests.rb
+++ b/test/unit/request_data_tests.rb
@@ -8,25 +8,25 @@ class Deas::RequestData
     setup do
       @request    = Factory.string
       @response   = Factory.string
-      @params     = Factory.string
       @route_path = Factory.string
+      @params     = Factory.string
 
       @request_data = Deas::RequestData.new({
         :request    => @request,
         :response   => @response,
-        :params     => @params,
-        :route_path => @route_path
+        :route_path => @route_path,
+        :params     => @params
       })
     end
     subject{ @request_data }
 
-    should have_readers :request, :response, :params, :route_path
+    should have_readers :request, :response, :route_path, :params
 
     should "know its attributes" do
       assert_equal @request,    subject.request
       assert_equal @response,   subject.response
-      assert_equal @params,     subject.params
       assert_equal @route_path, subject.route_path
+      assert_equal @params,     subject.params
     end
 
     should "default its attributes when they aren't provided" do
@@ -34,16 +34,16 @@ class Deas::RequestData
 
       assert_nil request_data.request
       assert_nil request_data.response
-      assert_nil request_data.params
       assert_nil request_data.route_path
+      assert_nil request_data.params
     end
 
     should "know if it is equal to another request data" do
       request_data = Deas::RequestData.new({
         :request    => @request,
         :response   => @response,
-        :params     => @params,
-        :route_path => @route_path
+        :route_path => @route_path,
+        :params     => @params
       })
       assert_equal request_data, subject
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -44,9 +44,9 @@ class Deas::Runner
     subject{ @runner }
 
     should have_readers :handler_class, :handler
+    should have_readers :request, :params, :route_path
     should have_readers :logger, :router, :template_source
-    should have_readers :request, :params, :route_path, :splat
-    should have_imeths :run, :to_rack
+    should have_imeths :splat, :run, :to_rack
     should have_imeths :status, :headers, :body, :content_type
     should have_imeths :halt, :redirect, :send_file
     should have_imeths :render, :source_render, :partial, :source_partial
@@ -58,36 +58,37 @@ class Deas::Runner
 
     should "default its attrs" do
       runner = @runner_class.new(@handler_class)
-      assert_kind_of Deas::NullLogger,         runner.logger
-      assert_kind_of Deas::Router,             runner.router
-      assert_kind_of Deas::NullTemplateSource, runner.template_source
 
       assert_nil runner.request
 
-      assert_equal Hash.new, runner.params
       assert_equal '',       runner.route_path
+      assert_equal Hash.new, runner.params
+
+      assert_kind_of Deas::NullLogger,         runner.logger
+      assert_kind_of Deas::Router,             runner.router
+      assert_kind_of Deas::NullTemplateSource, runner.template_source
 
       assert_nil runner.splat
     end
 
     should "know its attrs" do
       args = {
+        :request         => Factory.request,
+        :route_path      => Factory.string,
+        :params          => { Factory.string => Factory.string },
         :logger          => Factory.string,
         :router          => Factory.string,
-        :template_source => Factory.string,
-        :request         => Factory.request,
-        :params          => { Factory.string => Factory.string },
-        :route_path      => Factory.string
+        :template_source => Factory.string
       }
 
       runner = @runner_class.new(@handler_class, args)
 
+      assert_equal args[:request],         runner.request
+      assert_equal args[:route_path],      runner.route_path
+      assert_equal args[:params],          runner.params
       assert_equal args[:logger],          runner.logger
       assert_equal args[:router],          runner.router
       assert_equal args[:template_source], runner.template_source
-      assert_equal args[:request],         runner.request
-      assert_equal args[:params],          runner.params
-      assert_equal args[:route_path],      runner.route_path
     end
 
     should "know its splat value" do
@@ -103,8 +104,8 @@ class Deas::Runner
 
       args = {
         :request    => Factory.request(:env => request_env),
-        :params     => params,
-        :route_path => route_path
+        :route_path => route_path,
+        :params     => params
       }
 
       runner = @runner_class.new(@handler_class, args)
@@ -119,8 +120,8 @@ class Deas::Runner
 
       args = {
         :request    => Factory.request(:env => request_env),
+        :route_path => route_path,
         :params     => params,
-        :route_path => route_path
       }
 
       runner = @runner_class.new(@handler_class, args)
@@ -136,8 +137,8 @@ class Deas::Runner
 
       args = {
         :request    => Factory.request(:env => request_env),
+        :route_path => route_path,
         :params     => params,
-        :route_path => route_path
       }
 
       runner = @runner_class.new(@handler_class, args)

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -33,8 +33,8 @@ class Deas::TestRunner
         :router          => Factory.string,
         :template_source => Factory.string,
         :request         => @request,
-        :params          => @params,
         :route_path      => Factory.string,
+        :params          => @params,
         :splat           => Factory.path,
         :custom_value    => Factory.integer
       }
@@ -62,8 +62,8 @@ class Deas::TestRunner
       assert_equal @args[:router],          subject.router
       assert_equal @args[:template_source], subject.template_source
       assert_equal @args[:request],         subject.request
-      assert_equal @args[:params],          subject.params
       assert_equal @args[:route_path],      subject.route_path
+      assert_equal @args[:params],          subject.params
     end
 
     should "know its splat value" do


### PR DESCRIPTION
This is a minor tweak I noticed while reviewing logs to make sure
the trailing slash redirects were working properly.  Jux'ing the
route log immediately after the path log makes it easier to see
how the path matches the route and produces param values for the
route placholder values.

In addition, I updated all places where the route path is used or
referenced to also order similar to how the logs read.  This works
out nice since the router path drives the handler class and params
so it (generally) should appear in the code before any handler or
params stuff.  This did add a bunch of diff noise to this effort
though.

Here is an example showing the before/after in the logs from an
app I'm working on (these logs also show the trailing slash
redirects in action):

Before:
```
[INFO ] : [Deas] ===== Received request =====
[INFO ] : [Deas]   Method:  "GET"
[INFO ] : [Deas]   Path:    "/people/"
[INFO ] : [Deas]   Redir:   /people
[INFO ] : [Deas] ===== Completed in 0.01ms (302, FOUND) =====
[INFO ] : [Deas] ===== Received request =====
[INFO ] : [Deas]   Method:  "GET"
[INFO ] : [Deas]   Path:    "/people"
[INFO ] : [Deas]   Handler: Deas::RedirectHandler
[INFO ] : [Deas]   Params:  {}
[INFO ] : [Deas]   Route:   "/people"
[INFO ] : [Deas]   Redir:   /people/user-browser?status=Active
[INFO ] : [Deas] ===== Completed in 3.52ms (302, FOUND) =====
```

After:
```
[INFO ] : [Deas] ===== Received request =====
[INFO ] : [Deas]   Method:  "GET"
[INFO ] : [Deas]   Path:    "/people/"
[INFO ] : [Deas]   Redir:   /people
[INFO ] : [Deas] ===== Completed in 0.04ms (302, FOUND) =====
[INFO ] : [Deas] ===== Received request =====
[INFO ] : [Deas]   Method:  "GET"
[INFO ] : [Deas]   Path:    "/people"
[INFO ] : [Deas]   Route:   "/people"
[INFO ] : [Deas]   Handler: Deas::RedirectHandler
[INFO ] : [Deas]   Params:  {}
[INFO ] : [Deas]   Redir:   /people/user-browser?status=Active
[INFO ] : [Deas] ===== Completed in 3.6ms (302, FOUND) =====
```

See #241 for reference on the trailing slashes feature.

@jcredding ready for review.