### PR TITLE
tweak the url path logic to squash dup '/' in the path only

### DIFF
--- a/lib/deas/url.rb
+++ b/lib/deas/url.rb
@@ -28,7 +28,7 @@ module Deas
 
       # ignore captures when setting params
       # remove duplicate forward slashes
-      set_anchor(set_extra(set_named(set_splat(@path, s), h), h), a).gsub(/\/\/+/, '/')
+      set_anchor(set_extra(set_named(set_splat(@path, s), h).gsub(/\/\/+/, '/'), h), a)
     end
 
     private

--- a/test/unit/url_tests.rb
+++ b/test/unit/url_tests.rb
@@ -183,12 +183,15 @@ class Deas::Url
       })
     end
 
-    should "'squash' duplicate forward-slashes" do
-      exp_path = '/a/goose/cooked'
+    should "'squash' duplicate forward-slashes in the path only" do
+      exp_path = '/a/goose/cooked?aye=a&bee=b&u=http://example.com'
       assert_equal exp_path, subject.path_for({
         'some'  => '/a',
         :thing  => '/goose',
-        'splat' => '///cooked'
+        'splat' => '///cooked',
+        'bee'   => 'b',
+        :aye    => 'a',
+        'u'     => 'http://example.com'
       })
     end
 


### PR DESCRIPTION
This fixes a weird edge case issue where you add a url value or
other value as a query string value and it gets its double forward
slashes squashed unintentionally.  The goal was to prevent
generating invalid urls but the multi forward slashes is only
nonsensical in the path info part of the url.  This switches the
logic to squash for the path info part but not for the query
string part.

@jcredding ready for review.