### PR TITLE
add view handler `set_cookie` private helper

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -68,6 +68,14 @@ module Deas
       self.headers['Content-Type'] = get_content_type(extname, params)
     end
 
+    def set_cookie(name, value, opts = nil)
+      Rack::Utils.set_cookie_header!(
+        self.headers,
+        name,
+        (opts || {}).merge(:value => value)
+      )
+    end
+
     def halt(*args)
       self.status(args.shift)  if args.first.instance_of?(::Fixnum)
       self.headers(args.shift) if args.first.kind_of?(::Hash)

--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -73,6 +73,7 @@ module Deas
       def headers(*args);      @deas_runner.headers(*args);      end
       def body(*args);         @deas_runner.body(*args);         end
       def content_type(*args); @deas_runner.content_type(*args); end
+      def set_cookie(*args);   @deas_runner.set_cookie(*args);   end
       def halt(*args);         @deas_runner.halt(*args);         end
       def redirect(*args);     @deas_runner.redirect(*args);     end
       def send_file(*args);    @deas_runner.send_file(*args);    end

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -278,6 +278,15 @@ module Deas::ViewHandler
       assert_nil @meth_block
     end
 
+    should "call to the runner for its set cookie helper" do
+      capture_runner_meth_args_for(:set_cookie)
+      exp_args = @args
+      subject.instance_eval{ set_cookie(*exp_args) }
+
+      assert_equal exp_args, @meth_args
+      assert_nil @meth_block
+    end
+
     should "call to the runner for its halt helper" do
       capture_runner_meth_args_for(:halt)
       exp_args = @args


### PR DESCRIPTION
This is a helper method for setting cookie headers.  It uses
`Rack::Utils.set_cookie_header!` under the covers but its api is
different.  It takes a cookie name, cookie value, and cookie
options.  It passes its own `self.headers` to the rack utils
method for making sure the headers are updated.

We chose this API as it is more defined and explicit compared to
the rack utils method (so it will be easier to support and
document).  It also makes more intuitive sense as a cookie has
a name and value.  The options allow you to pass the same options
you would to the rack utils method to control and secure the
cookies.  This just provides a defined api and abstraction for
the rack utils implementation so we can change it as needed with
minimal app impact.

@jcredding ready for review.