### PR TITLE
add predicate methods for testing trailing slash directives

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -36,8 +36,16 @@ module Deas
       @trailing_slashes = ALLOW_TRAILING_SLASHES
     end
 
+    def allow_trailing_slashes_set?
+      @trailing_slashes == ALLOW_TRAILING_SLASHES
+    end
+
     def remove_trailing_slashes
       @trailing_slashes = REMOVE_TRAILING_SLASHES
+    end
+
+    def remove_trailing_slashes_set?
+      @trailing_slashes == REMOVE_TRAILING_SLASHES
     end
 
     def trailing_slashes_set?

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -41,7 +41,9 @@ class Deas::Router
     should have_readers :trailing_slashes, :escape_query_value_proc
 
     should have_imeths :view_handler_ns
-    should have_imeths :allow_trailing_slashes, :remove_trailing_slashes
+    should have_imeths :allow_trailing_slashes, :allow_trailing_slashes_set?
+    should have_imeths :remove_trailing_slashes, :remove_trailing_slashes_set?
+    should have_imeths :trailing_slashes_set?
     should have_imeths :escape_query_value
     should have_imeths :base_url, :set_base_url, :prepend_base_url
     should have_imeths :url, :url_for
@@ -85,11 +87,23 @@ class Deas::Router
     end
 
     should "config trailing slash handling" do
+      assert_false subject.allow_trailing_slashes_set?
+      assert_false subject.remove_trailing_slashes_set?
+      assert_false subject.trailing_slashes_set?
+
       subject.allow_trailing_slashes
+
       assert_equal subject.class::ALLOW_TRAILING_SLASHES, subject.trailing_slashes
+      assert_true  subject.allow_trailing_slashes_set?
+      assert_false subject.remove_trailing_slashes_set?
+      assert_true  subject.trailing_slashes_set?
 
       subject.remove_trailing_slashes
+
       assert_equal subject.class::REMOVE_TRAILING_SLASHES, subject.trailing_slashes
+      assert_false subject.allow_trailing_slashes_set?
+      assert_true  subject.remove_trailing_slashes_set?
+      assert_true  subject.trailing_slashes_set?
     end
 
     should "allow configuring a custom escape query value proc" do


### PR DESCRIPTION
This adds `allow_trailing_slashes_set?` and
`remove_trailing_slashes_set?` predicate methods for helping test
whether your router has been configured properly.  This keeps you
from having to know the actual value the trailing slashes property
was set to (b/c it is unimportant) or the internal directive
constants (b/c they are just intended for internal use.

This also adds tests for the previously added
`trailing_slashes_set?` predicate method.  I originally missed
adding these in PR 239.

See #239 for reference.

@jcredding ready for review.