### PR TITLE
improved default response body handling

### DIFF
--- a/lib/deas/runner.rb
+++ b/lib/deas/runner.rb
@@ -11,7 +11,7 @@ module Deas
     DEFAULT_MIME_TYPE = 'application/octet-stream'.freeze
     DEFAULT_CHARSET   = 'utf-8'.freeze
     DEFAULT_STATUS    = 200.freeze
-    DEFAULT_BODY      = [].freeze
+    DEFAULT_BODY      = [''].freeze
 
     attr_reader :handler_class, :handler
     attr_reader :request, :route_path, :params
@@ -55,7 +55,7 @@ module Deas
     end
 
     def body(value = nil)
-      if !value.nil?
+      if !value.to_s.empty?
         # http://www.rubydoc.info/github/rack/rack/master/file/SPEC#The_Body
         # "The Body must respond to each and must only yield String values"
         # String#each is a thing in 1.8.7, so account for it here
@@ -79,7 +79,7 @@ module Deas
     def halt(*args)
       self.status(args.shift)  if args.first.instance_of?(::Fixnum)
       self.headers(args.shift) if args.first.kind_of?(::Hash)
-      self.body(args.shift)
+      self.body(args.shift)    if !args.first.to_s.empty?
       throw :halt
     end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -30,7 +30,7 @@ class Deas::Runner
     end
 
     should "know its default body" do
-      assert_equal [], subject::DEFAULT_BODY
+      assert_equal [''], subject::DEFAULT_BODY
     end
 
   end
@@ -196,6 +196,9 @@ class Deas::Runner
     should "know and set its response body" do
       assert_nil subject.body
 
+      subject.body [nil, ''].sample
+      assert_nil subject.body
+
       exp = [Factory.string]
       subject.body exp
       assert_equal exp, subject.body
@@ -293,6 +296,11 @@ class Deas::Runner
       assert_equal @body, runner.body
 
       runner = runner_halted_with(@status, @headers)
+      assert_equal @status,  runner.status
+      assert_equal @headers, runner.headers
+      assert_nil runner.body
+
+      runner = runner_halted_with(@status, @headers, '')
       assert_equal @status,  runner.status
       assert_equal @headers, runner.headers
       assert_nil runner.body


### PR DESCRIPTION
This is a set of updates to how the response body is defaulted and
handled when called with "empty" values.  The goal of all of this
is that the default response body will be used unless a meaningful
alternative response body has been given.

First off, this updates the default body to, formally, be an array
with a single empty string as this more accurately conforms to
Rack's spec that body objects must yield string values.

Next, this updates the `body` helper to ignore `nil` and empty
string values as they have no value and are identical to the
default body in intent.

Finally, this updates the halt method to also ignore `nil` and
empty string values for similar reasons as above.

@jcredding ready for review.