### PR TITLE
add a handler DSL api for setting default response values

### DIFF
--- a/lib/deas/view_handler.rb
+++ b/lib/deas/view_handler.rb
@@ -11,6 +11,10 @@ module Deas
       include InstanceMethods
     end
 
+    DEFAULT_STATUS  = 200.freeze
+    DEFAULT_HEADERS = {}.freeze
+    DEFAULT_BODY    = [''].freeze
+
     module InstanceMethods
 
       def initialize(runner)
@@ -87,6 +91,23 @@ module Deas
     end
 
     module ClassMethods
+
+      def default_status(value = nil)
+        @default_status = value if !value.nil?
+        @default_status || DEFAULT_STATUS
+      end
+
+      def default_headers(value = nil)
+        @default_headers = value if !value.nil? && value.kind_of?(::Hash)
+        @default_headers || DEFAULT_HEADERS
+      end
+
+      def default_body(value = nil)
+        if !value.nil?
+          @default_body = Deas::Runner.body_value(value)
+        end
+        @default_body || DEFAULT_BODY
+      end
 
       def layout(path = nil, &block)
         value = !path.nil? ? Proc.new{ path } : block

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -18,6 +18,7 @@ module Deas::ViewHandler
     end
     subject{ @handler_class }
 
+    should have_imeths :default_status, :default_headers, :default_body
     should have_imeths :layout, :layouts
     should have_imeths :before_callbacks, :after_callbacks
     should have_imeths :before_init_callbacks, :after_init_callbacks
@@ -31,6 +32,50 @@ module Deas::ViewHandler
 
     should "use much-plugin" do
       assert_includes MuchPlugin, Deas::ViewHandler
+    end
+
+    should "know its default status" do
+      assert_equal 200, subject::DEFAULT_STATUS
+    end
+
+    should "know its default headers" do
+      assert_equal({}, subject::DEFAULT_HEADERS)
+    end
+
+    should "know its default body" do
+      assert_equal [''], subject::DEFAULT_BODY
+    end
+
+    should "know and set its default status" do
+      assert_equal subject::DEFAULT_STATUS, subject.default_status
+
+      exp = Factory.integer
+      subject.default_status exp
+      assert_equal exp, subject.default_status
+    end
+
+    should "know and merge values on its response headers" do
+      assert_equal subject::DEFAULT_HEADERS, subject.default_headers
+
+      new_header_values = { Factory.string => Factory.string }
+      subject.default_headers(new_header_values)
+      assert_equal new_header_values, subject.default_headers
+
+      location = Factory.string
+      subject.default_headers['Location'] = location
+      exp = new_header_values.merge('Location' => location)
+      assert_equal exp, subject.default_headers
+    end
+
+    should "know and set its response body" do
+      assert_equal subject::DEFAULT_BODY, subject.default_body
+
+      subject.default_body [nil, ''].sample
+      assert_equal subject::DEFAULT_BODY, subject.default_body
+
+      value = [[Factory.string], Factory.string, Factory.integer].sample
+      exp   = Deas::Runner.body_value(value)
+      assert_equal exp, subject.default_body(value)
     end
 
     should "specify layouts" do


### PR DESCRIPTION
This allows individual handlers to override the default response
values for status, headers, and body in a reliable manner.
Specifically, this will be used in Deas-Json to override the
default body for its needs.

First this moves the status/headers/body defaults to the view
handler.  This also adds the DSL singleton methods for overriding
the defaults on a per handler basis.

Second, this reworks the runner logic to look to the given handler
class for the default values.

Note: to make this happen, I had to do two other things:

* I had to commonize the logic for setting body response values.
  This logic applies both for setting handler instance response
  bodies and handler-specific default response bodies.
* I had to rework some of the test contexts to work with the new
  singleton handler class settings.  This mostly meant reworking
  to not use a constant handler class and instead use an anonymous
  handler class so that any settings made in the tests are thrown
  away in subsequent tests.

@jcredding ready for review.