### PR TITLE
trailing slashes: treat root index path `/` as a leading slash

### DIFF
--- a/lib/deas/router.rb
+++ b/lib/deas/router.rb
@@ -140,11 +140,12 @@ module Deas
     def validate_trailing_slashes!
       if self.trailing_slashes == REMOVE_TRAILING_SLASHES
         paths = []
-        all_missing = self.routes.inject(true) do |result, route|
-          paths << route.path if route.path[-1..-1] == SLASH
-          result && route.path[-1..-1] != SLASH
+        has_trailing = self.routes.inject(false) do |result, route|
+          route_has = route.path[-1,1] == SLASH && route.path != SLASH
+          paths << route.path if route_has
+          result || route_has
         end
-        if !all_missing
+        if has_trailing
           msg = "all route paths must *not* end with a \"/\", but these do:\n"\
                 "#{paths.join("\n")}"
           raise TrailingSlashesError, msg

--- a/test/support/routes.rb
+++ b/test/support/routes.rb
@@ -80,6 +80,7 @@ class RemoveTrailingSlashesServer
   router do
     remove_trailing_slashes
 
+    get '/',     'ShowHandler'
     get '/show', 'ShowHandler'
   end
 
@@ -96,6 +97,7 @@ class AllowTrailingSlashesServer
   router do
     allow_trailing_slashes
 
+    get '/',           'ShowHandler'
     get '/show',       'ShowHandler'
     get '/show-text/', 'ShowTextHandler'
 

--- a/test/system/deas_tests.rb
+++ b/test/system/deas_tests.rb
@@ -171,11 +171,21 @@ module Deas
       @app = RemoveTrailingSlashesServer.new
     end
 
-    should "redirect any paths that end in a slash" do
+    should "redirect any paths that end with a slash" do
       get '/show/'
 
-      assert_equal 302,      last_response.status
+      assert_equal 302,     last_response.status
       assert_equal '/show', last_response.headers['Location']
+    end
+
+    should "serve any found paths that do not end with a slash" do
+      get '/'
+      assert_equal 200, last_response.status
+      assert_equal 'text/html;charset=utf-8', last_response.headers['Content-Type']
+
+      get '/show'
+      assert_equal 200, last_response.status
+      assert_equal 'text/html;charset=utf-8', last_response.headers['Content-Type']
     end
 
   end
@@ -187,6 +197,10 @@ module Deas
     end
 
     should "serve any found paths regardless of whether they end with a slash" do
+      get '/'
+      assert_equal 200, last_response.status
+      assert_equal 'text/html;charset=utf-8', last_response.headers['Content-Type']
+
       get '/show'
       assert_equal 200, last_response.status
       assert_equal 'text/html;charset=utf-8', last_response.headers['Content-Type']

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -192,6 +192,7 @@ class Deas::Router
 
     should "validate trailing slashes" do
       router = @router_class.new
+      router.get('/',           'EmptyViewHandler')
       router.get('/something',  'EmptyViewHandler')
       router.get('/something/', 'EmptyViewHandler')
       router.apply_definitions!
@@ -213,6 +214,7 @@ class Deas::Router
       assert_includes exp, err.message
 
       router = @router_class.new
+      router.get('/',                'EmptyViewHandler')
       router.get('/something/',      'EmptyViewHandler')
       router.get('/something-else/', 'EmptyViewHandler')
       router.apply_definitions!
@@ -235,6 +237,7 @@ class Deas::Router
       assert_includes exp, err.message
 
       router = @router_class.new
+      router.get('/',               'EmptyViewHandler')
       router.get('/something',      'EmptyViewHandler')
       router.get('/something-else', 'EmptyViewHandler')
       router.apply_definitions!

--- a/test/unit/trailing_slashes_tests.rb
+++ b/test/unit/trailing_slashes_tests.rb
@@ -86,9 +86,9 @@ class Deas::TrailingSlashes
     end
   end
 
-  class RequireNoHandlerTests < HandlerSetupTests
-    desc "RequireNoHandler"
-    subject{ RequireNoHandler }
+  class RemoveHandlerTests < HandlerSetupTests
+    desc "RemoveHandler"
+    subject{ RemoveHandler }
 
     should have_readers :run
 


### PR DESCRIPTION
This is an edge case I forgot to account for when originally
implementing the trailing slashes handling logic feature (see
PRs 239, 240, and 241).  The root index path, `/` should be
considered a *leading* slash not a trailing slash.

This updates both the router validation logic and the middleware
handling logic to account for this special case.  I also expanded
the middleware system tests and the router unit tests to explicitly
test for this special case.

In addition, this does a few cleanups I noticed while implementing
this:

* I chose to rework the variable names and boolean handling in the
  router validation logic to be more "positive boolean" focused.
  I think this makes it easier to read and is a convention to use
  positive boolean logic whenever possible.
* I renamed the middleware's `RequireNoHandler` to `RemoveHandler`.
  This should have been done in d389f98 but was missed.

See #239, #240, and #241 for reference.

@jcredding ready for review.